### PR TITLE
chore: v1 잔재 제거 및 v2 명명 규칙 적용

### DIFF
--- a/app/campaign-core/docker-compose.yml
+++ b/app/campaign-core/docker-compose.yml
@@ -1,0 +1,128 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    ports:
+      - "${MYSQL_PORT}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul # 타임존 설정 (선택하자)
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - campaign-net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    ports:
+      - "${KAFKA_PORT}:9092"
+    environment:
+      # --- KRaft 설정 (Confluent 이미지 전용 변수명) ---
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+
+      # --- 리스너 설정 (중요) ---
+      # CONTROLLER: 컨트롤러 간 통신 (29093)
+      # INTERNAL: 도커 내부 통신 (kafka-ui, app 컨테이너용, 29092)
+      # EXTERNAL: 호스트 외부 통신 (로컬 개발용, 9092)
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,EXTERNAL://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,EXTERNAL://localhost:${KAFKA_PORT}
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    networks:
+      - campaign-net
+    healthcheck:
+      # Confluent 이미지는 kafka-topics 명령어를 바로 쓸 수 있습니다.
+      test: [ "CMD", "kafka-topics", "--bootstrap-server", "kafka:29092", "--list" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    networks:
+      - campaign-net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "${KAFKA_UI_PORT}:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      DYNAMIC_CONFIG_ENABLED: 'true'
+    networks:
+      - campaign-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+  app:
+    build: .
+    container_name: campaign-core-app
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      TZ: Asia/Seoul
+      JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -XX:MaxMetaspaceSize=128m -XX:MaxDirectMemorySize=128m -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8
+    ports:
+      - "8080:8080"
+    networks:
+      - campaign-net
+    depends_on:
+      mysql:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+networks:
+  campaign-net:
+    driver: bridge
+
+volumes:
+  mysql_data:
+  kafka_data:
+  redis_data:

--- a/app/campaign-core/dockerfile
+++ b/app/campaign-core/dockerfile
@@ -1,0 +1,26 @@
+# 1. Build stage
+FROM eclipse-temurin:25-jdk AS build
+WORKDIR /app
+
+# gradle wrapper
+COPY gradlew .
+COPY gradle gradle
+RUN chmod +x gradlew
+
+# gradle 설정 (캐시)
+COPY build.gradle* settings.gradle* ./
+RUN ./gradlew dependencies --no-daemon || true
+
+# 소스 코드만 복사
+COPY src src
+
+RUN ./gradlew clean bootJar --no-daemon
+
+# 2. Run stage
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+
+# JAR 파일 복사
+COPY --from=build /app/build/libs/campaign-core-*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 개요                                                                                                                                              
                                                                                                                                                       
  v1 레포 잔재 명칭을 v2 기준으로 정리합니다.                            
                                                                                 
  ## 변경 사항                                                                                                                                         
  - `dockerfile` k6 설치 및 스크립트 COPY 제거 (stress-test/ 디렉토리로 분리됨)
  - `dockerfile` JAR명 수정: `batch-kafka-system-*.jar` → `campaign-core-*.jar`
  - `docker-compose.yml` 컨테이너명 수정: `batch-kafka-app` → `campaign-core-app`                                                                      
  - `docker-compose.yml` 네트워크명 수정: `batch-kafka-net` → `campaign-net` (전체 5개소)                                                              

## 변경 유형                                                                                                                                         
                                                                                                                                                       
  - [x] `chore` — 빌드, 설정, 의존성 등 기타                

  ## 관련 이슈                                                                                                                                            
  없음                                                                                                                                                 
                                                            
  ## 체크리스트
  - [x] 로컬에서 정상 동작 확인
  - [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함
  - [x] Phase에 맞는 변경인지 확인 (Phase 1 / 2 / 3)  