### PR TITLE
 chore : 의존성 정리 및 Micrometer/Prometheus 모니터링 설정 추가 

### DIFF
--- a/app/campaign-core/build.gradle
+++ b/app/campaign-core/build.gradle
@@ -24,27 +24,49 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
-	implementation 'org.springframework.boot:spring-boot-starter-batch'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// HTTP API 서버 — REST 엔드포인트 제공
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// 재고 차감(Lua DECR), Rate Limiter(SET NX EX), Queue(LPUSH/RPOP), 결과 캐시
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-kafka'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	// PENDING → SUCCESS 확정, 캠페인/참여이력 영속
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Bridge → Kafka 배치 발행, Consumer PENDING 확정 처리
+	implementation 'org.springframework.kafka:spring-kafka'
+
+	// DB 스키마 버전 관리 — V002__add_pending_and_constraints.sql 등 마이그레이션
+	implementation 'org.flywaydb:flyway-mysql'
+
+	// PendingRetryScheduler(@Scheduled), RedisSyncScheduler(@Scheduled) — @EnableScheduling 활성화
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+	// AOP 기반 트랜잭션/로깅 처리 (Spring Boot 4.0 신규 스타터)
+	implementation 'org.springframework.boot:spring-boot-starter-aspectj'
+
+	// /actuator/prometheus 엔드포인트 — Micrometer → Prometheus 스크래핑
+	// 모니터링 문서 2장: Spring Boot(Micrometer) → Prometheus → Grafana 파이프라인 필수
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// /actuator/health, /actuator/metrics — 헬스체크 및 커스텀 메트릭(TPS, p99, DLQ 등) 노출
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// @RequestBody 유효성 검증 (@Valid, @NotNull 등)
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+
+	// TODO: 현재 설계 문서(DESIGN_GUIDE_V2.md)에 템플릿 엔진 사용 계획 없음
+	// REST API + 폴링 구조로 서버사이드 렌더링 불필요해 보이나,
+	// 관리자 페이지 또는 이벤트 결과 페이지 계획이 있다면 유지 필요 — 확인 요청
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-batch-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-thymeleaf-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/app/campaign-core/src/main/resources/application-local.yml
+++ b/app/campaign-core/src/main/resources/application-local.yml
@@ -1,3 +1,18 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics  # 로컬은 모두 노출
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      cloudwatch:
+        enabled: false                        # 로컬에서 CloudWatch 비활성화
+      prometheus:
+        enabled: true
+
 spring:
   datasource:
     # Docker Compose로 띄운 MySQL에 접속 (localhost)

--- a/app/campaign-core/src/main/resources/application-prod.yml
+++ b/app/campaign-core/src/main/resources/application-prod.yml
@@ -2,13 +2,23 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus        # Prometheus scrape 엔드포인트 노출
   endpoint:
     health:
-      show-details: never
+      show-details: when-authorized        # 인증된 요청만 상세 노출
+    prometheus:
+      enabled: true
   health:
     kafka:
-      enabled: false   #  Actuator Kafka Health 완전 제거
+      enabled: false                       # Actuator Kafka Health 완전 제거
+  metrics:
+    export:
+      cloudwatch:
+        enabled: true
+        namespace: CampaignSystem/V2       # CloudWatch 콘솔 네임스페이스
+        step: 1m                           # 이벤트 중 실시간 감지 (PDF 목적 1번)
+      prometheus:
+        enabled: true
 
 spring:
   datasource:

--- a/app/campaign-core/src/main/resources/application.yml
+++ b/app/campaign-core/src/main/resources/application.yml
@@ -35,6 +35,23 @@ spring:
       enabled: true
       force: true
 
+# 모니터링 공통 설정
+management:
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      env: ${spring.profiles.active:local}
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true        # p95/p99 히스토그램 활성화
+      percentiles:
+        "[http.server.requests]": 0.95, 0.99  # PDF 3-1: API 응답시간 p95/p99
+      slo:
+        "[http.server.requests]": 1s, 3s      # PDF 알람 임계값: WARNING 1초 / CRITICAL 3초
+    export:
+      prometheus:
+        enabled: true
+
 # 배치 작업 설정
 batch:
   aggregation:


### PR DESCRIPTION

  ## 개요

  잘못된 의존성 수정 및 모니터링  Micrometer → Prometheus 설정 추가

  ## 변경 사항

  **build.gradle**
  - 잘못된 artifact ID 수정
    - `spring-boot-starter-webmvc` → `spring-boot-starter-web`
    - `spring-boot-starter-kafka` → `spring-kafka`
    - `spring-boot-starter-aop` → `spring-aspectj`
  - 존재하지 않는 test 스타터 전부 제거 → `spring-boot-starter-test` + `spring-kafka-test` 로 통합
  - 의존성 추가
    - `flyway-mysql` — DB 스키마 버전 관리 (V002__add_pending_and_constraints.sql 대응)
    - `micrometer-registry-prometheus` — /actuator/prometheus 엔드포인트 활성화
  - 각 의존성에 역할 주석 추가
  - `spring-boot-starter-thymeleaf` — 설계 문서에 사용 계획 없음, TODO 주석으로 리뷰어 확인 요청

  **application.yml (공통)**
  - `http.server.requests` p95/p99 히스토그램 수집 설정
  - SLO 임계값 1s/3s 등록 (모니터링 PDF 5장 기준 — WARNING 1초 / CRITICAL 3초)
  - 모든 메트릭에 `application`, `env` 태그 자동 부착
  - YAML 점(.) 키 파싱 오류 수정 → `"[http.server.requests]"` 대괄호 표기 적용

  **application-local.yml**
  - `health`, `prometheus`, `metrics` 엔드포인트 로컬 전체 노출
  - CloudWatch export 비활성화 (로컬에서 AWS 연결 차단)
  - Prometheus export 활성화

  **application-prod.yml**
  - actuator 노출에 `prometheus` 추가 (Prometheus scrape 대응)
  - health 상세 노출 `never` → `when-authorized` (보안 강화)
  - CloudWatch export 활성화 (`namespace: CampaignSystem/V2`, `step: 1m`)
  - Prometheus export 활성화

  ## 변경 유형

  - [x] `chore` — 빌드, 설정, 의존성 등 기타

  ## 관련 이슈

  closes #

  ## 체크리스트

  - [ ] 로컬에서 정상 동작 확인
  - [ ] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함
  - [ ] Phase에 맞는 변경인지 확인 (Phase 2 — Spring Boot 코드 고도화)

  ## 리뷰어 확인 요청

  - `spring-boot-starter-thymeleaf` 유지 여부 — REST API 구조상 불필요해 보이나 관리자 페이지 계획이 있다면 유지

