### PR TITLE
feat: GitHub Actions OIDC 신규 레포 연동 및 terraform-mcp EC2 생성 — Terraform으로 인프라 형상관리 시작

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@
 
 # k6 binary
 stress-test/k6.exe
+
+# Terraform
+infra/.terraform/
+infra/terraform.tfstate
+infra/terraform.tfstate.backup
+infra/*.tfvars
+
+# 환경변수 (민감정보)
+.env
+app/campaign-core/.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ v2(`1milion-campaign-orchestration-system`, 100만 트래픽 + AI 자율 운영)
 
 ```
 app/campaign-core/     ← Spring Boot 앱 (v1 코드 마이그레이션 완료)
-infra/                 ← Terraform (현재 비어있음, Phase 1 작업 대상)
+infra/                 ← Terraform (Phase 1 진행 중 — OIDC, EC2 완료)
 mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase 3, 미작성)
 stress-test/           ← k6 부하 테스트 스크립트
 .github/workflows/     ← deploy.yml (루트에 있어야 GitHub Actions 인식)
@@ -124,9 +124,12 @@ Kafka Consumer (10 파티션)
 - [ ] `application-prod.yml` Kafka 3-broker, partitions=10, replication-factor=3
 
 ### Phase 1: Terraform (infra/ 전체 작성)
-- [ ] vpc.tf, ec2.tf (App + Kafka 3-broker EC2)
-- [ ] rds.tf, elasticache.tf (Redis Cluster 3샤드)
-- [ ] alb.tf, iam.tf (OIDC role), ssm.tf, variables.tf
+- [x] `main.tf` — provider, S3 backend (campaign-terraform-state-631124976154)
+- [x] `iam.tf` — GitHub Actions OIDC 신규 레포 연동, IAM Role 생성
+- [x] `ec2.tf` — terraform-mcp EC2 생성 (i-00ec03ad5c52e0a3a, AL2023, t3.small)
+- [x] `variables.tf`, `outputs.tf`, `terraform.tfvars.example`
+- [ ] 기존 리소스 import — 앱 EC2, RDS, ElastiCache (내일 예정)
+- [ ] vpc.tf, rds.tf, elasticache.tf (Kafka 3-broker, Redis Cluster 3샤드)
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버
@@ -156,15 +159,17 @@ Kafka Consumer (10 파티션)
 | Account ID | 631124976154 |
 | Region | ap-northeast-2 |
 | ECR | campaign-core |
-| S3 | campaign-deploy-631124976154 |
+| S3 (배포) | campaign-deploy-631124976154 |
+| S3 (tfstate) | campaign-terraform-state-631124976154 |
 | CodeDeploy App | campaign-core-app |
 | Deployment Group | campaign-prod-dg |
-| IAM Role | github-actions-campaign-deploy-role |
+| IAM Role (CI/CD) | github-actions-campaign-deploy-role ✅ 신규 레포 연동 완료 |
+| IAM Role (MCP EC2) | terraform-mcp-role |
+| EC2 (MCP) | terraform-mcp (i-00ec03ad5c52e0a3a, 3.35.175.15) |
 | SSM prefix | /campaign/prod/ |
 
-### OIDC Trust Policy 수정 필요
-IAM → github-actions-campaign-deploy-role → Trust relationships에서
-`repo:hskhsmm/1milion-campaign-orchestration-system:*` 로 업데이트 (레포 이동됨)
+### OIDC 상태
+Terraform으로 완료 — `repo:hskhsmm/1milion-campaign-orchestration-system:*` 적용됨
 
 ---
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,79 @@
+# terraform-mcp EC2 IAM Role (SSM 접속용)
+resource "aws_iam_role" "terraform_mcp" {
+  name = "terraform-mcp-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "terraform_mcp" {
+  name = "terraform-mcp-profile"
+  role = aws_iam_role.terraform_mcp.name
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_mcp_ssm" {
+  role       = aws_iam_role.terraform_mcp.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# terraform-mcp 보안 그룹
+resource "aws_security_group" "terraform_mcp" {
+  name        = "terraform-mcp-sg"
+  description = "Security group for terraform-mcp server"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "FastAPI MCP server"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "terraform-mcp-sg"
+  }
+}
+
+# terraform-mcp EC2 인스턴스
+resource "aws_instance" "terraform_mcp" {
+  ami                    = "ami-0ecfdfd1c8ae01aec" # Amazon Linux 2023 ap-northeast-2 (2026-03-27)
+  instance_type          = "t3.small"
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [aws_security_group.terraform_mcp.id]
+  iam_instance_profile   = aws_iam_instance_profile.terraform_mcp.name
+
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = true
+  }
+
+  metadata_options {
+    http_tokens                 = "required" # IMDSv2 강제
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+  }
+
+  user_data = filebase64("${path.module}/user-data.sh")
+
+  tags = {
+    Name    = "terraform-mcp"
+    Purpose = "MCP-Server"
+  }
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,57 @@
+# GitHub Actions OIDC Provider
+# 이미 존재할 경우: terraform import aws_iam_openid_connect_provider.github_actions arn:aws:iam::631124976154:oidc-provider/token.actions.githubusercontent.com
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# GitHub Actions 배포 역할 (기존 역할 Trust Policy 업데이트)
+# 이미 존재할 경우: terraform import aws_iam_role.github_actions github-actions-campaign-deploy-role
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-campaign-deploy-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# 기존 정책 연결 유지
+resource "aws_iam_role_policy_attachment" "github_actions_ecr" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_s3" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_codedeploy" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_ssm" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "campaign-terraform-state-631124976154"
+    key    = "infrastructure/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,11 @@
+output "terraform_mcp_instance_id" {
+  value = aws_instance.terraform_mcp.id
+}
+
+output "terraform_mcp_private_ip" {
+  value = aws_instance.terraform_mcp.private_ip
+}
+
+output "terraform_mcp_public_ip" {
+  value = aws_instance.terraform_mcp.public_ip
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# 이 파일을 복사해서 terraform.tfvars로 만들고 값을 채워주세요.
+# cp terraform.tfvars.example terraform.tfvars
+
+account_id = "YOUR_AWS_ACCOUNT_ID"
+vpc_id     = "YOUR_VPC_ID"
+subnet_id  = "YOUR_SUBNET_ID"

--- a/infra/user-data.sh
+++ b/infra/user-data.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# 패키지 업데이트
+yum update -y
+
+# Python 3.11 + pip 설치
+yum install -y python3.11 python3.11-pip
+
+# FastAPI + Uvicorn 설치
+python3.11 -m pip install fastapi uvicorn
+
+# 앱 디렉토리 생성
+mkdir -p /app/mcp-server
+
+# systemd 서비스 등록 (재부팅 시 자동 시작)
+cat <<EOF > /etc/systemd/system/mcp-server.service
+[Unit]
+Description=MCP FastAPI Server
+After=network.target
+
+[Service]
+WorkingDirectory=/app/mcp-server
+ExecStart=/usr/local/bin/uvicorn main:app --host 0.0.0.0 --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable mcp-server

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,26 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "account_id" {
+  description = "AWS Account ID"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for terraform-mcp EC2"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository (owner/repo)"
+  type        = string
+  default     = "hskhsmm/1milion-campaign-orchestration-system"
+}


### PR DESCRIPTION
## 개요

GitHub Actions OIDC 신규 레포 연동 및 terraform-mcp EC2 생성 — Terraform으로 인프라 형상관리 시작

---

## 변경 사항

### 완료된 것

- `infra/main.tf`  
  - Terraform provider 설정 및 S3 backend 연결 (campaign-terraform-state-631124976154)

- `infra/iam.tf`  
  - GitHub Actions OIDC Trust Policy를 신규 레포(hskhsmm/1milion-campaign-orchestration-system)로 업데이트  
  - CI/CD용 IAM Role(github-actions-campaign-deploy-role) 신규 생성  

- `infra/ec2.tf`  
  - MCP 서버용 EC2(terraform-mcp) 생성 (AL2023, t3.small, 20GB gp3, IMDSv2 강제, SSM 접속)
  - 
<img width="850" height="141" alt="image" src="https://github.com/user-attachments/assets/289409ba-4139-4b58-b7af-0f8b64245526" />


- `infra/variables.tf`  
  - 민감정보 변수화 (account_id, vpc_id, subnet_id)

- `infra/terraform.tfvars.example`  
  - 팀원 온보딩용 변수 템플릿

- `infra/outputs.tf`  
  - instance_id, private_ip, public_ip 출력

- `infra/user-data.sh`  
  - EC2 부팅 시 FastAPI 설치 스크립트

- `.gitignore`  
  - Terraform 바이너리, tfstate, tfvars, .env 제외

- `CLAUDE.md`  
  - 현재 인프라 현황 최신화



---

### 이후 PR에서 할 것 (관련 이슈 참고)

- 기존 AWS 리소스 terraform import  
  - ECR, S3, CodeDeploy, ALB, RDS, ElastiCache, 앱 EC2

- Kafka 3-broker EC2 추가  
- Redis Cluster 3샤드 추가  

---

## 변경 유형

- feat — 새 기능  
- infra — Terraform / AWS 인프라  

---

## 관련 이슈

#6

---

## 체크리스트

- terraform plan 으로 변경사항 사전 확인 완료  
- terraform apply 로 실제 리소스 생성 확인 (EC2 i-00ec03ad5c52e0a3a)  
- 민감정보 gitignore 처리 확인 (tfvars, .env, .terraform/)  
- Phase 1 범위 내 변경 확인  