### PR TITLE
v1 인프라 - VPC, 보안그룹, EC2, RDS, DynamoDB(terraform-lock)를 Terraform으로 코드화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ v2(`1milion-campaign-orchestration-system`, 100만 트래픽 + AI 자율 운영)
 ## 레포 구조
 
 ```
-app/campaign-core/     ← Spring Boot 앱 (v1 코드 마이그레이션 완료)
-infra/                 ← Terraform (Phase 1 진행 중 — OIDC, EC2 완료)
+app/campaign-core/     ← Spring Boot 앱 (v1 코드 + Kafka 수동 관리 전환 완료)
+infra/                 ← Terraform (Phase 1 진행 중 — v1 기존 리소스 import 완료)
 mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase 3, 미작성)
 stress-test/           ← k6 부하 테스트 스크립트
 .github/workflows/     ← deploy.yml (루트에 있어야 GitHub Actions 인식)
@@ -38,6 +38,15 @@ stress-test/           ← k6 부하 테스트 스크립트
 - Spring Batch 새벽 2시 통계 집계 (participation_history → campaign_stats)
 - GitHub Actions → ECR → S3 → CodeDeploy Blue-Green CI/CD
 - SSH 차단 + SSM Session Manager + Parameter Store
+
+### 최근 변경 (2026-03-27)
+- **Kafka 수동 파티션 관리 전환**: `KafkaTopicService` 삭제, `KafkaAdmin` Bean 제거
+  - 이유: 서버 기동 시 Kafka 브로커 연결 필수 → 로컬/테스트 환경 불편
+  - 토픽 생성은 Kafka CLI로 수동 관리 (`kafka-topics.sh --create`)
+  - `KafkaConfig.java`에서 `KafkaAdmin`, `NewTopic` 빈 제거
+  - `LoadTestService`에서 `KafkaTopicService` 의존성 제거
+- **모니터링 추가**: `micrometer-registry-prometheus` 의존성 추가 (build.gradle)
+  - `/actuator/prometheus` 엔드포인트 노출 → Prometheus 수집 예정
 
 ### 실험 결과 (핵심)
 | 파티션 | DB TPS | switch_ratio | violation_count |
@@ -124,12 +133,31 @@ Kafka Consumer (10 파티션)
 - [ ] `application-prod.yml` Kafka 3-broker, partitions=10, replication-factor=3
 
 ### Phase 1: Terraform (infra/ 전체 작성)
-- [x] `main.tf` — provider, S3 backend (campaign-terraform-state-631124976154)
-- [x] `iam.tf` — GitHub Actions OIDC 신규 레포 연동, IAM Role 생성
-- [x] `ec2.tf` — terraform-mcp EC2 생성 (i-00ec03ad5c52e0a3a, AL2023, t3.small)
-- [x] `variables.tf`, `outputs.tf`, `terraform.tfvars.example`
-- [ ] 기존 리소스 import — 앱 EC2, RDS, ElastiCache (내일 예정)
-- [ ] vpc.tf, rds.tf, elasticache.tf (Kafka 3-broker, Redis Cluster 3샤드)
+
+#### ✅ 완료된 작업 (2026-03-27 기준, terraform plan → No changes 확인)
+
+| 파일 | 리소스 수 | 내용 |
+|------|-----------|------|
+| `main.tf` | - | provider, S3 backend + **DynamoDB lock** (terraform-lock) |
+| `variables.tf` | - | region, account_id, vpc_id, subnet_id, github_repo |
+| `vpc.tf` | 8개 | VPC(172.31.0.0/16), IGW, Route Table, 퍼블릭 서브넷 4개(2a~2d), private_app_2a |
+| `security_groups.tf` | 5개 | alb-public(80/443), app-sg(8080), rds-mysql(3306), Kafka-SG(9092/9094), elasticache-redis(6379) |
+| `ec2.tf` | 11개 | IAM Role×2, Instance Profile×2, Policy×1, Policy Attachment×6, EC2×3 (batch-kafka-app, kafka-1, terraform-mcp) |
+| `rds.tf` | 1개 | batch-kafka-db (MySQL 8.0.43, db.t3.micro, SSM Parameter Store 비밀번호 연동) |
+| `dynamodb.tf` | 1개 | terraform-lock (PAY_PER_REQUEST, Terraform state lock용) |
+
+**핵심 결정 사항:**
+- Route Table Association: 암시적 메인 라우팅 테이블 연결 유지 (명시적 association 코드 없음)
+- RDS 비밀번호: SSM `/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD` 에서 가져옴 + `lifecycle { ignore_changes = [password] }`
+- kafka-1 EC2: `associate_public_ip_address = false` (public 서브넷이지만 IGW로 외부 통신, 퍼블릭 IP 불필요)
+- security_groups description: 실제 AWS 값 그대로 사용 (forces replacement 방지)
+
+#### 🔲 남은 작업
+- [ ] `alb.tf` — alb-batch-kafka-api import
+- [ ] `elasticache.tf` — Redis ElastiCache import
+- [ ] IAM 과잉권한 수정 (S3FullAccess, SSMFullAccess → 최소권한으로 교체)
+- [ ] terraform-mcp EC2 서브넷 검토 (현재 var.subnet_id, public 서브넷 권장)
+- [ ] Kafka 3-broker EC2 추가 (v2 목표)
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버
@@ -158,15 +186,22 @@ Kafka Consumer (10 파티션)
 |--------|---------|
 | Account ID | 631124976154 |
 | Region | ap-northeast-2 |
+| VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
 | ECR | campaign-core |
 | S3 (배포) | campaign-deploy-631124976154 |
 | S3 (tfstate) | campaign-terraform-state-631124976154 |
+| DynamoDB (lock) | terraform-lock |
 | CodeDeploy App | campaign-core-app |
 | Deployment Group | campaign-prod-dg |
 | IAM Role (CI/CD) | github-actions-campaign-deploy-role ✅ 신규 레포 연동 완료 |
+| IAM Role (앱 EC2) | ec2-batchkafka-role |
 | IAM Role (MCP EC2) | terraform-mcp-role |
-| EC2 (MCP) | terraform-mcp (i-00ec03ad5c52e0a3a, 3.35.175.15) |
-| SSM prefix | /campaign/prod/ |
+| EC2 (앱) | batch-kafka-app (t3.small, private-app-subnet-1) |
+| EC2 (Kafka) | kafka-1 (t3.small, public-2a) |
+| EC2 (MCP) | terraform-mcp (t3.small, AL2023) |
+| RDS | batch-kafka-db (MySQL 8.0.43, db.t3.micro, ap-northeast-2b) |
+| SSM (앱) | /batch-kafka/prod/* |
+| SSM (CI/CD) | /campaign/prod/ |
 
 ### OIDC 상태
 Terraform으로 완료 — `repo:hskhsmm/1milion-campaign-orchestration-system:*` 적용됨

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -1,0 +1,13 @@
+# Terraform State Lock용 DynamoDB 테이블
+resource "aws_dynamodb_table" "terraform_lock" {
+  name         = "terraform-lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {}
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -48,6 +48,131 @@ resource "aws_security_group" "terraform_mcp" {
   }
 }
 
+# ──────────────────────────────────────────
+# batch-kafka-app / kafka-1 공통 IAM Role
+# ──────────────────────────────────────────
+
+resource "aws_iam_role" "batch_kafka_app" {
+  name        = "ec2-batchkafka-role"
+  description = "Allows EC2 instances to call AWS services on your behalf."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "batch_kafka_app" {
+  name = "ec2-batchkafka-role"
+  role = aws_iam_role.batch_kafka_app.name
+}
+
+# 커스텀 정책 - SSM Parameter Store 읽기
+resource "aws_iam_policy" "ssm_parameter_read" {
+  name = "SSMParameterRead-batch-kafka-prod"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ]
+        Resource = "arn:aws:ssm:*:*:parameter/batch-kafka/prod/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# AWS 관리형 정책 연결
+resource "aws_iam_role_policy_attachment" "batch_kafka_cloudwatch" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_kafka_ssm" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_kafka_codedeploy_ec2" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_kafka_ecr_read" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_kafka_codedeploy_role" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_kafka_ssm_parameter_read" {
+  role       = aws_iam_role.batch_kafka_app.name
+  policy_arn = aws_iam_policy.ssm_parameter_read.arn
+}
+
+# ──────────────────────────────────────────
+# batch-kafka-app EC2
+# ──────────────────────────────────────────
+
+resource "aws_instance" "batch_kafka_app" {
+  ami                         = "ami-0b818a04bc9c2133c"
+  instance_type               = "t3.small"
+  subnet_id                   = aws_subnet.private_app_2a.id
+  vpc_security_group_ids      = [aws_security_group.app.id]
+  iam_instance_profile        = aws_iam_instance_profile.batch_kafka_app.name
+  associate_public_ip_address = false
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 8
+    encrypted   = false
+  }
+
+  tags = {
+    Name = "batch-kafka-app"
+  }
+}
+
+# ──────────────────────────────────────────
+# kafka-1 EC2
+# ──────────────────────────────────────────
+
+resource "aws_instance" "kafka_1" {
+  ami                         = "ami-0b818a04bc9c2133c"
+  instance_type               = "t3.small"
+  subnet_id                   = aws_subnet.public_2a.id
+  vpc_security_group_ids      = [aws_security_group.kafka.id]
+  iam_instance_profile        = aws_iam_instance_profile.batch_kafka_app.name
+  associate_public_ip_address = false
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 8
+    encrypted   = false
+  }
+
+  tags = {
+    Name = "kafka-1"
+  }
+}
+
 # terraform-mcp EC2 인스턴스
 resource "aws_instance" "terraform_mcp" {
   ami                    = "ami-0ecfdfd1c8ae01aec" # Amazon Linux 2023 ap-northeast-2 (2026-03-27)

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "terraform_mcp" {
   vpc_security_group_ids = [aws_security_group.terraform_mcp.id]
   iam_instance_profile   = aws_iam_instance_profile.terraform_mcp.name
 
-  associate_public_ip_address = true
+  associate_public_ip_address = false
 
   root_block_device {
     volume_type = "gp3"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -7,9 +7,10 @@ terraform {
   }
 
   backend "s3" {
-    bucket = "campaign-terraform-state-631124976154"
-    key    = "infrastructure/terraform.tfstate"
-    region = "ap-northeast-2"
+    bucket         = "campaign-terraform-state-631124976154"
+    key            = "infrastructure/terraform.tfstate"
+    region         = "ap-northeast-2"
+    dynamodb_table = "terraform-lock"
   }
 }
 

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,45 @@
+# SSM Parameter Store에서 DB 비밀번호 가져오기
+data "aws_ssm_parameter" "db_password" {
+  name            = "/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD"
+  with_decryption = true
+}
+
+# RDS MySQL 인스턴스
+resource "aws_db_instance" "batch_kafka_db" {
+  identifier        = "batch-kafka-db"
+  engine            = "mysql"
+  engine_version    = "8.0.43"
+  instance_class    = "db.t3.micro"
+  username          = "batchuser"
+  password          = data.aws_ssm_parameter.db_password.value
+
+  # 스토리지
+  allocated_storage     = 20
+  max_allocated_storage = 1000
+  storage_type          = "gp2"
+  storage_encrypted     = true
+  kms_key_id            = "arn:aws:kms:ap-northeast-2:631124976154:key/8ad3a522-6d4f-4891-8c39-9f9d33cb9e38"
+
+  # 네트워크
+  db_subnet_group_name   = "default-vpc-02bacd8c658dc632e"
+  vpc_security_group_ids = [aws_security_group.rds_mysql.id]
+  availability_zone      = "ap-northeast-2b"
+  publicly_accessible    = false
+  multi_az               = false
+
+  # 백업 및 유지보수
+  backup_retention_period = 1
+  copy_tags_to_snapshot   = true
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+
+  # 파라미터/옵션 그룹
+  parameter_group_name = "default.mysql8.0"
+  option_group_name    = "default:mysql-8-0"
+
+  tags = {}
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1,0 +1,121 @@
+# ALB 보안그룹 - 인터넷에서 80, 443 허용
+resource "aws_security_group" "alb_public" {
+  name        = "alb-public"
+  description = "alb sg"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {}
+}
+
+# 앱 보안그룹 - ALB에서 8080 허용
+resource "aws_security_group" "app" {
+  name        = "app-sg"
+  description = "Application EC2 security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_public.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {}
+}
+
+# RDS 보안그룹 - app-sg에서 3306 허용
+resource "aws_security_group" "rds_mysql" {
+  name        = "rds-mysql"
+  description = "RDS MySQL for batch-kafka"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {}
+}
+
+# Kafka 보안그룹 - app-sg에서 9092, 9094 허용
+resource "aws_security_group" "kafka" {
+  name        = "Kafka-SG"
+  description = "launch-wizard-1 created 2025-12-27T06:24:22.804Z"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 9092
+    to_port         = 9092
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  ingress {
+    from_port       = 9094
+    to_port         = 9094
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {}
+}
+
+# ElastiCache 보안그룹 - app-sg에서 6379 허용, 아웃바운드 없음
+resource "aws_security_group" "elasticache_redis" {
+  name        = "elasticache-redis"
+  description = "el"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  tags = {}
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,80 @@
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = "172.31.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {}
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {}
+}
+
+# Route Table (Main)
+resource "aws_route_table" "main" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {}
+}
+
+# 퍼블릭 서브넷 2a
+resource "aws_subnet" "public_2a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.0.0/20"
+  availability_zone       = "ap-northeast-2a"
+  map_public_ip_on_launch = true
+
+  tags = {}
+}
+
+# 퍼블릭 서브넷 2b
+resource "aws_subnet" "public_2b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.16.0/20"
+  availability_zone       = "ap-northeast-2b"
+  map_public_ip_on_launch = true
+
+  tags = {}
+}
+
+# 퍼블릭 서브넷 2c
+resource "aws_subnet" "public_2c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.32.0/20"
+  availability_zone       = "ap-northeast-2c"
+  map_public_ip_on_launch = true
+
+  tags = {}
+}
+
+# 퍼블릭 서브넷 2d
+resource "aws_subnet" "public_2d" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.48.0/20"
+  availability_zone       = "ap-northeast-2d"
+  map_public_ip_on_launch = true
+
+  tags = {}
+}
+
+# 앱 서브넷 (이름만 Private, 실제론 IGW 연결된 Public)
+# v2에서 NAT Gateway 추가 후 진짜 Private으로 전환 예정
+resource "aws_subnet" "private_app_2a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.100.0/24"
+  availability_zone       = "ap-northeast-2a"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "private-app-subnet-1"
+  }
+}


### PR DESCRIPTION
 ## 개요                                                                                                                                                                         
                                                                                                                                                                                  
  v1 인프라(VPC, 보안그룹, EC2, RDS, DynamoDB)를 Terraform으로 코드화.                                                                                                            
  기존 AWS 콘솔에서 수동 관리하던 리소스들을 `terraform import`로 가져와 형상관리 시작.                                                                                             실제 인프라 변경 없이 현재 상태를 코드로 표현하는 것이 목표.                                                                                                                    
                                                                                                                                                                                    ---                                                                                                                                                                                                                                                                                                                                                               
  ## 변경 사항                                                                                                                                                                    
                                                                                                                                                                                
  ### main.tf — DynamoDB Lock 추가
  - S3 backend에 `dynamodb_table = "terraform-lock"` 추가
  - 팀원과 동시에 `terraform apply` 실행 시 state 파일 충돌 방지
  - AWS 콘솔에서 DynamoDB 테이블(`terraform-lock`, Partition key: `LockID`) 수동 생성 후 연결

  ### vpc.tf — 신규 작성 (8개 리소스 import)
  - `aws_vpc.main` — 172.31.0.0/16, DNS 활성화
  - `aws_internet_gateway.main` — VPC에 연결
  - `aws_route_table.main` — 0.0.0.0/0 → IGW 라우팅
  - `aws_subnet.public_2a~2d` — 퍼블릭 서브넷 4개 (map_public_ip_on_launch = true)
  - `aws_subnet.private_app_2a` — 앱 서브넷 (이름만 Private, 실제론 IGW 연결)
  - `aws_route_table_association` 미작성 — 모든 서브넷이 암시적 연결 상태이므로 명시적 association 추가 시 실제 인프라 변경 발생

  ### security_groups.tf — 신규 작성 (5개 리소스 import)

  트래픽 흐름:
  Internet → ALB(80,443) → App(8080) → RDS(3306)
                                      → Kafka(9092, 9094)
                                      → ElastiCache(6379)

  - `aws_security_group.alb_public` — 인터넷 → 80, 443 허용
  - `aws_security_group.app` — alb-public → 8080 허용
  - `aws_security_group.rds_mysql` — app-sg → 3306 허용
  - `aws_security_group.kafka` — app-sg → 9092, 9094 허용
  - `aws_security_group.elasticache_redis` — app-sg → 6379 허용, 아웃바운드 없음
  - description을 실제 AWS 값으로 정확히 맞춤 (forces replacement 속성이라 다르면 삭제 후 재생성 발생)

  ### ec2.tf — 업데이트 (11개 리소스 import)

  **IAM Role (`ec2-batchkafka-role`)**
  - batch-kafka-app, kafka-1 두 EC2가 공통으로 사용하는 역할
  - AWS 관리형 정책 5개 연결
    - `CloudWatchAgentServerPolicy` — CloudWatch 메트릭/로그 수집
    - `AmazonSSMManagedInstanceCore` — SSM Session Manager 접속 (SSH 키 없이 접속)
    - `AmazonEC2RoleforAWSCodeDeploy` (service-role/) — CodeDeploy 배포 에이전트
    - `AmazonEC2ContainerRegistryReadOnly` — ECR 이미지 pull
    - `AWSCodeDeployRole` (service-role/) — CodeDeploy 배포 실행
  - 커스텀 정책 1개 (`SSMParameterRead-batch-kafka-prod`)
    - `/batch-kafka/prod/*` 경로 SSM Parameter Store 읽기 전용

  **EC2 인스턴스**

  | 항목 | batch-kafka-app | kafka-1 |
  |------|----------------|---------|
  | AMI | ami-0b818a04bc9c2133c | ami-0b818a04bc9c2133c |
  | 타입 | t3.small | t3.small |
  | 서브넷 | private_app_2a | public_2a |
  | 보안그룹 | app-sg | Kafka-SG |
  | 퍼블릭 IP | false | false |
  | 키페어 | 없음 (SSM 접속) | 없음 (SSM 접속) |
  | 볼륨 | 8GB, gp3, 암호화 없음 | 8GB, gp3, 암호화 없음 |

  **`associate_public_ip_address = false` 수정**
  - 코드에 `true`로 작성돼있었으나 실제 AWS는 `false`
  - 서브넷의 `map_public_ip_on_launch = false` 설정이 우선 적용되어 `false`로 생성됨
  - 코드를 실제 상태에 맞게 수정 (다르면 EC2 삭제 후 재생성 발생)

  ### rds.tf — 신규 작성 (1개 리소스 import)
  - MySQL 8.0.43, db.t3.micro, 20GB gp2, 암호화 활성화
  - 서브넷 그룹: `default-vpc-02bacd8c658dc632e`
  - 보안그룹: rds-mysql
  - AZ: ap-northeast-2b (고정, 다르면 교체 발생)
  - 스토리지 자동 확장: 최대 1000GB

  **비밀번호 처리**
  - SSM Parameter Store(`/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD`)에서 가져옴
  - `lifecycle { ignore_changes = [password] }` 추가
    - import 시 Terraform이 비밀번호를 state에 저장하지 않아 매번 diff 발생하는 문제 해결
    - 비밀번호 변경은 Terraform이 아닌 SSM에서 직접 관리

  ### dynamodb.tf — 신규 작성 (1개 리소스 import)
  - `terraform-lock` 테이블 코드화
  - Partition key: `LockID` (String)
  - billing_mode: `PAY_PER_REQUEST`
  - Terraform state lock 전용 테이블

  ---

  ## 변경 유형

  - [x] `infra` — Terraform / AWS 인프라
  - [x] `fix` — Terraform (ec2.tf)

  ## 관련 이슈

  #6 

  ## 체크리스트

  - [x] 로컬에서 정상 동작 확인 (`terraform plan` → 모든 리소스 `No changes` 확인)
  - [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함 (import만 수행, 실제 인프라 변경 없음)
  - [x] Phase에 맞는 변경인지 확인 (Phase 1 — Terraform IaC 형상관리 시작)

  ---

  ## 추가 작업 (다음 PR)

  ### Terraform import 미완료 리소스
  - [ ] `alb.tf` — ALB import (alb-batch-kafka-api)
  - [ ] `elasticache.tf` — ElastiCache 서브넷 그룹 import (batch-kafka)

  ### 보안 개선
  - [ ] `iam.tf` — GitHub Actions IAM Role 과잉권한 수정
    - `AmazonS3FullAccess` → 특정 버킷 ARN으로 제한
    - `AmazonSSMFullAccess` → `/campaign/prod/*` 경로만 허용

  ### 인프라 개선 (v2)
  - [ ] terraform-mcp EC2 서브넷 재검토 (현재 private_app_2a, MCP 용도에 맞게 변경 필요)

