### PR TITLE
feat: ALB, ElastiCache 서브넷 그룹 Terraform import 완료 및 Redis 클러스터 코드 작성 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Kafka Consumer (10 파티션)
 
 ### Phase 1: Terraform (infra/ 전체 작성)
 
-#### ✅ 완료된 작업 (2026-03-27 기준, terraform plan → No changes 확인)
+#### ✅ 완료된 작업 (2026-03-31 기준, terraform plan → No changes 확인)
 
 | 파일 | 리소스 수 | 내용 |
 |------|-----------|------|
@@ -143,21 +143,24 @@ Kafka Consumer (10 파티션)
 | `vpc.tf` | 8개 | VPC(172.31.0.0/16), IGW, Route Table, 퍼블릭 서브넷 4개(2a~2d), private_app_2a |
 | `security_groups.tf` | 5개 | alb-public(80/443), app-sg(8080), rds-mysql(3306), Kafka-SG(9092/9094), elasticache-redis(6379) |
 | `ec2.tf` | 11개 | IAM Role×2, Instance Profile×2, Policy×1, Policy Attachment×6, EC2×3 (batch-kafka-app, kafka-1, terraform-mcp) |
-| `rds.tf` | 1개 | batch-kafka-db (MySQL 8.0.43, db.t3.micro, SSM Parameter Store 비밀번호 연동) |
+| `rds.tf` | 1개 | batch-kafka-db (MySQL 8.0.44, db.t3.micro, SSM Parameter Store 비밀번호 연동) |
 | `dynamodb.tf` | 1개 | terraform-lock (PAY_PER_REQUEST, Terraform state lock용) |
+| `alb.tf` | 3개 | alb-batch-kafka-api, tg-api-8080, HTTP 리스너 — import 완료 |
+| `elasticache.tf` | 2개 | batch-kafka 서브넷 그룹 import 완료, Redis 7.1 클러스터 코드 작성 (apply 대기) |
 
 **핵심 결정 사항:**
 - Route Table Association: 암시적 메인 라우팅 테이블 연결 유지 (명시적 association 코드 없음)
 - RDS 비밀번호: SSM `/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD` 에서 가져옴 + `lifecycle { ignore_changes = [password] }`
 - kafka-1 EC2: `associate_public_ip_address = false` (public 서브넷이지만 IGW로 외부 통신, 퍼블릭 IP 불필요)
 - security_groups description: 실제 AWS 값 그대로 사용 (forces replacement 방지)
+- ALB Listener: `default_action` `ignore_changes` 추가 (stickiness 속성 Terraform provider 충돌 방지)
+- RDS engine_version: AWS 자동 업그레이드로 8.0.43 → 8.0.44 반영
 
 #### 🔲 남은 작업
-- [ ] `alb.tf` — alb-batch-kafka-api import
-- [ ] `elasticache.tf` — Redis ElastiCache import
-- [ ] IAM 과잉권한 수정 (S3FullAccess, SSMFullAccess → 최소권한으로 교체)
-- [ ] terraform-mcp EC2 서브넷 검토 (현재 var.subnet_id, public 서브넷 권장)
-- [ ] Kafka 3-broker EC2 추가 (v2 목표)
+- [ ] IAM 과잉권한 수정 (S3FullAccess, SSMFullAccess → 최소권한으로 교체) — `iam.tf`
+- [ ] terraform-mcp EC2 서브넷 검토 (현재 private_app_2a, public 서브넷 권장)
+- [ ] Kafka 3-broker EC2 추가 (v2 목표) — `ec2.tf`
+- [ ] ElastiCache Redis 클러스터 apply (현재 비용 절감으로 삭제 상태)
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버
@@ -199,7 +202,9 @@ Kafka Consumer (10 파티션)
 | EC2 (앱) | batch-kafka-app (t3.small, private-app-subnet-1) |
 | EC2 (Kafka) | kafka-1 (t3.small, public-2a) |
 | EC2 (MCP) | terraform-mcp (t3.small, AL2023) |
-| RDS | batch-kafka-db (MySQL 8.0.43, db.t3.micro, ap-northeast-2b) |
+| RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro, ap-northeast-2b) |
+| ALB | alb-batch-kafka-api (internet-facing, 2a/2b, HTTP 80 → tg-api-8080) |
+| ElastiCache | 서브넷 그룹 batch-kafka (존재), 클러스터 삭제 상태 (비용 절감) |
 | SSM (앱) | /batch-kafka/prod/* |
 | SSM (CI/CD) | /campaign/prod/ |
 

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -5,8 +5,8 @@ resource "aws_lb" "main" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb_public.id]
   subnets            = [
-    "subnet-01b092eda6da614fc",  # public-2a
-    "subnet-095abce6c4befae62",  # public-2b
+    aws_subnet.public_2a.id,
+    aws_subnet.public_2b.id,
   ]
 
   ip_address_type = "ipv4"

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,54 @@
+# ALB
+resource "aws_lb" "main" {
+  name               = "alb-batch-kafka-api"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb_public.id]
+  subnets            = [
+    "subnet-01b092eda6da614fc",  # public-2a
+    "subnet-095abce6c4befae62",  # public-2b
+  ]
+
+  ip_address_type = "ipv4"
+
+  tags = {}
+}
+
+# Target Group
+resource "aws_lb_target_group" "api_8080" {
+  name        = "tg-api-8080"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    path                = "/actuator/health"
+    protocol            = "HTTP"
+    port                = "traffic-port"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+
+  tags = {}
+}
+
+# Listener (HTTP:80 → tg-api-8080)
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api_8080.arn
+  }
+
+  lifecycle {
+    ignore_changes = [default_action]
+  }
+}

--- a/infra/elasticache.tf
+++ b/infra/elasticache.tf
@@ -1,0 +1,30 @@
+# ElastiCache 서브넷 그룹 (기존 리소스 import)
+resource "aws_elasticache_subnet_group" "main" {
+  name        = "batch-kafka"
+  description = " "
+  subnet_ids  = [
+    "subnet-03e64a5c78e57a505",  # private_app_2a
+    "subnet-01b092eda6da614fc",  # public_2a
+    "subnet-028c65ac17ecc8447",  # public_2c
+    "subnet-0e4e9986cda504b3e",  # public_2d
+    "subnet-095abce6c4befae62",  # public_2b
+  ]
+
+  tags = {}
+}
+
+# ElastiCache Redis 클러스터 (신규 생성)
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "batch-kafka-redis"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [aws_security_group.elasticache_redis.id]
+
+  tags = {}
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -8,7 +8,7 @@ data "aws_ssm_parameter" "db_password" {
 resource "aws_db_instance" "batch_kafka_db" {
   identifier        = "batch-kafka-db"
   engine            = "mysql"
-  engine_version    = "8.0.43"
+  engine_version    = "8.0.44"
   instance_class    = "db.t3.micro"
   username          = "batchuser"
   password          = data.aws_ssm_parameter.db_password.value


### PR DESCRIPTION
## 개요

ALB, ElastiCache 서브넷 그룹 Terraform import 완료 및 Redis 클러스터 코드 작성 — Phase 1 Terraform IaC 형상관리 완성

---

## 변경 사항

- infra/alb.tf 신규 작성 — alb-batch-kafka-api, tg-api-8080, HTTP 리스너 3개 리소스 import 완료  
  - default_action ignore_changes 추가 (stickiness 속성 충돌 방지)

- infra/elasticache.tf 신규 작성  
  - aws_elasticache_subnet_group.main — batch-kafka import 완료  
  - aws_elasticache_cluster.redis — cache.t3.micro, Redis 7.1 신규 생성 코드 작성 (현재 비용 절감으로 삭제 상태, apply 시 재생성)

- infra/rds.tf 수정 — engine_version 8.0.43 → 8.0.44 (AWS 자동 마이너 업그레이드 반영)

---

## 변경 유형

- infra — Terraform / AWS 인프라  
- fix — rds.tf engine_version 실제 상태 반영  

---

## 관련 이슈

closes #6

---

## 체크리스트

- [x] 로컬에서 정상 동작 확인 (terraform plan → 서브넷그룹 No changes, 클러스터 1 to add 확인)  
- [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함 (import만 수행, 실제 인프라 변경 없음)  
- [x] Phase에 맞는 변경인지 확인 (Phase 1 — Terraform IaC 형상관리 완성)