### PR TITLE
Feature/phase2 prereq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Kafka Consumer (10 파티션)
 - [ ] `KafkaConfig` 수정 (파티션 키 null → campaignId % partitionCount)
 - [ ] `application-prod.yml` 수정 (partitions=10, replication-factor=3)
 - [ ] Bridge 예외처리 + DLQ 신규 로직 (Kafka produce 실패 시 재시도 / DLQ 적재)
+- [ ] DLQ 메시지 적재 시 Slack 알림 (Consumer에서 감지 → SlackNotificationService)
 
 ### #5 Redis 클러스터링 — ElastiCache Cluster 모드 전환 (hskhsmm 담당, A/B 완성 후)
 - [ ] `elasticache.tf` 수정 (단일 노드 → Cluster 모드 3샤드)

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/ParticipationEvent.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/ParticipationEvent.java
@@ -3,6 +3,7 @@ package io.eventdriven.campaign.application.event;
 public class ParticipationEvent {
     private Long campaignId;
     private Long userId;
+    private Long historyId; // v2 — PENDING 선점 후 획득한 PK
 
     // Kafka 메타데이터 (Consumer에서 설정)
     private Long kafkaOffset;
@@ -16,6 +17,20 @@ public class ParticipationEvent {
     public ParticipationEvent(Long campaignId, Long userId) {
         this.campaignId = campaignId;
         this.userId = userId;
+    }
+
+    public ParticipationEvent(Long campaignId, Long userId, Long historyId) {
+        this.campaignId = campaignId;
+        this.userId = userId;
+        this.historyId = historyId;
+    }
+
+    public Long getHistoryId() {
+        return historyId;
+    }
+
+    public void setHistoryId(Long historyId) {
+        this.historyId = historyId;
     }
 
     public Long getCampaignId() {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ParticipationHistory.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ParticipationHistory.java
@@ -44,6 +44,17 @@ public class ParticipationHistory extends BaseTimeEntity {
     @Column(name = "processing_sequence")
     private Long processingSequence;
 
+    // 선착순 번호 (Redis DECR 반환값 기반, v2)
+    @Column(name = "sequence")
+    private Long sequence;
+
+    // PENDING 선점용 생성자 (v2 — A파트에서 사용)
+    public ParticipationHistory(Campaign campaign, Long userId) {
+        this.campaign = campaign;
+        this.userId = userId;
+        this.status = ParticipationStatus.PENDING;
+    }
+
     // 기존 생성자 (하위 호환성)
     public ParticipationHistory(Campaign campaign, Long userId, ParticipationStatus status) {
         this.campaign = campaign;

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ParticipationStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ParticipationStatus.java
@@ -1,6 +1,7 @@
 package io.eventdriven.campaign.domain.entity;
 
 public enum ParticipationStatus {
+    PENDING,
     SUCCESS,
     FAIL
 }

--- a/app/campaign-core/src/main/resources/application-prod.yml
+++ b/app/campaign-core/src/main/resources/application-prod.yml
@@ -50,6 +50,10 @@ spring:
     admin:
       auto-create: true         # (있어도 되고 없어도 됨)
 
+  flyway:
+    baseline-on-migrate: true    # 기존 DB를 V1 베이스라인으로 인식, V2부터 적용
+    baseline-version: 1
+
   batch:
     job:
       enabled: false             #  Batch 자동 실행 차단

--- a/app/campaign-core/src/main/resources/db/migration/V2__add_sequence_to_participation_history.sql
+++ b/app/campaign-core/src/main/resources/db/migration/V2__add_sequence_to_participation_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE participation_history
+    ADD COLUMN sequence BIGINT NULL;


### PR DESCRIPTION
## 개요

  v2 A/B파트 브랜치 분기 전 공통 인터페이스 확정 (PENDING 상태, sequence 필드, historyId, Flyway 설정)

  ## 변경 사항

  - `ParticipationStatus` — PENDING 상태 추가 (v2 선점 구조 대응)
  - `ParticipationHistory` — sequence 필드 및 PENDING 선점 생성자 추가
  - `ParticipationEvent` — historyId 필드 추가 (Consumer PK 조회용)
  - `V2__add_sequence_to_participation_history.sql` — sequence 컬럼 마이그레이션
  - `application-prod.yml` — Flyway baseline 설정 추가 (기존 DB V1 인식)
  - 상세 코드는 변경 사항에서 확인 바랍니다.

  ## 변경 유형

  - [x] `feat` — 새 기능

  ## 관련 이슈

 - closes #11

  ## 체크리스트

  - [ ] 로컬에서 정상 동작 확인
  - [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함
  - [x] Phase에 맞는 변경인지 확인 (Phase 2)

