### PR TITLE
chore: SSM 웹훅 등록 및 IAM 최소권한 적용과 terraform-mcp EC2 퍼블릭 서브넷 이전

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Kafka Consumer (10 파티션)
 
 ### Phase 1: Terraform (infra/ 전체 작성)
 
-#### ✅ 완료된 작업 (2026-03-31 기준, terraform plan → No changes 확인)
+#### ✅ 완료된 작업 (2026-04-13 기준, terraform apply 완료)
 
 | 파일 | 리소스 수 | 내용 |
 |------|-----------|------|
@@ -200,11 +200,12 @@ Kafka Consumer (10 파티션)
 | `variables.tf` | - | region, account_id, vpc_id, subnet_id, github_repo |
 | `vpc.tf` | 8개 | VPC(172.31.0.0/16), IGW, Route Table, 퍼블릭 서브넷 4개(2a~2d), private_app_2a |
 | `security_groups.tf` | 5개 | alb-public(80/443), app-sg(8080), rds-mysql(3306), Kafka-SG(9092/9094), elasticache-redis(6379) |
-| `ec2.tf` | 11개 | IAM Role×2, Instance Profile×2, Policy×1, Policy Attachment×6, EC2×3 (batch-kafka-app, kafka-1, terraform-mcp) |
+| `ec2.tf` | 11개 | IAM Role×2, Instance Profile×2, Policy×3, Policy Attachment×6, EC2×3 (batch-kafka-app, kafka-1, terraform-mcp) |
 | `rds.tf` | 1개 | batch-kafka-db (MySQL 8.0.44, db.t3.micro, SSM Parameter Store 비밀번호 연동) |
 | `dynamodb.tf` | 1개 | terraform-lock (PAY_PER_REQUEST, Terraform state lock용) |
 | `alb.tf` | 3개 | alb-batch-kafka-api, tg-api-8080, HTTP 리스너 — import 완료 |
-| `elasticache.tf` | 2개 | batch-kafka 서브넷 그룹 import 완료, Redis 7.1 클러스터 코드 작성 (apply 대기) |
+| `elasticache.tf` | 1개 | batch-kafka 서브넷 그룹 import 완료, Redis 클러스터 주석처리 (모니터링 후 활성화 예정) |
+| `iam.tf` | 2개 | GitHubActions S3/SSM 최소권한 커스텀 정책 추가 |
 
 **핵심 결정 사항:**
 - Route Table Association: 암시적 메인 라우팅 테이블 연결 유지 (명시적 association 코드 없음)
@@ -213,12 +214,15 @@ Kafka Consumer (10 파티션)
 - security_groups description: 실제 AWS 값 그대로 사용 (forces replacement 방지)
 - ALB Listener: `default_action` `ignore_changes` 추가 (stickiness 속성 Terraform provider 충돌 방지)
 - RDS engine_version: AWS 자동 업그레이드로 8.0.43 → 8.0.44 반영
+- GitHub Actions IAM: S3FullAccess → `campaign-deploy` 버킷 전용, SSMFullAccess → `/campaign/prod/*` 읽기 전용
+- terraform-mcp EC2: public_2a 서브넷, 퍼블릭 IP 활성화 (MCP 서버 Phase 3 대비), 현재 중지 상태
 
 #### 🔲 남은 작업
-- [ ] IAM 과잉권한 수정 (S3FullAccess, SSMFullAccess → 최소권한으로 교체) — `iam.tf`
-- [ ] terraform-mcp EC2 서브넷 검토 (현재 private_app_2a, public 서브넷 권장)
 - [ ] Kafka 3-broker EC2 추가 (v2 목표) — `ec2.tf`
-- [ ] ElastiCache Redis 클러스터 apply (현재 비용 절감으로 삭제 상태)
+- [ ] ElastiCache Redis 클러스터 apply (모니터링 구성 후) — `elasticache.tf`
+
+#### 📌 배포 전 AWS 작업 완료
+- [x] SSM `/batch-kafka/prod/SLACK_WEBHOOK_URL` 등록 완료
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -177,11 +177,11 @@ resource "aws_instance" "kafka_1" {
 resource "aws_instance" "terraform_mcp" {
   ami                    = "ami-0ecfdfd1c8ae01aec" # Amazon Linux 2023 ap-northeast-2 (2026-03-27)
   instance_type          = "t3.small"
-  subnet_id              = var.subnet_id
+  subnet_id              = aws_subnet.public_2a.id
   vpc_security_group_ids = [aws_security_group.terraform_mcp.id]
   iam_instance_profile   = aws_iam_instance_profile.terraform_mcp.name
 
-  associate_public_ip_address = false
+  associate_public_ip_address = true
 
   root_block_device {
     volume_type = "gp3"

--- a/infra/elasticache.tf
+++ b/infra/elasticache.tf
@@ -13,18 +13,18 @@ resource "aws_elasticache_subnet_group" "main" {
   tags = {}
 }
 
-# ElastiCache Redis 클러스터 (신규 생성)
-resource "aws_elasticache_cluster" "redis" {
-  cluster_id           = "batch-kafka-redis"
-  engine               = "redis"
-  engine_version       = "7.1"
-  node_type            = "cache.t3.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis7"
-  port                 = 6379
-
-  subnet_group_name  = aws_elasticache_subnet_group.main.name
-  security_group_ids = [aws_security_group.elasticache_redis.id]
-
-  tags = {}
-}
+# ElastiCache Redis 클러스터 (신규 생성) — 모니터링 구성 후 활성화 예정
+# resource "aws_elasticache_cluster" "redis" {
+#   cluster_id           = "batch-kafka-redis"
+#   engine               = "redis"
+#   engine_version       = "7.1"
+#   node_type            = "cache.t3.micro"
+#   num_cache_nodes      = 1
+#   parameter_group_name = "default.redis7"
+#   port                 = 6379
+#
+#   subnet_group_name  = aws_elasticache_subnet_group.main.name
+#   security_group_ids = [aws_security_group.elasticache_redis.id]
+#
+#   tags = {}
+# }

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -41,9 +41,32 @@ resource "aws_iam_role_policy_attachment" "github_actions_ecr" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
 }
 
+resource "aws_iam_policy" "github_actions_s3_minimal" {
+  name = "GitHubActions-S3-Deploy-campaign"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::campaign-deploy-${var.account_id}",
+          "arn:aws:s3:::campaign-deploy-${var.account_id}/*"
+        ]
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "github_actions_s3" {
   role       = aws_iam_role.github_actions.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  policy_arn = aws_iam_policy.github_actions_s3_minimal.arn
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_codedeploy" {
@@ -51,7 +74,26 @@ resource "aws_iam_role_policy_attachment" "github_actions_codedeploy" {
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
 }
 
+resource "aws_iam_policy" "github_actions_ssm_minimal" {
+  name = "GitHubActions-SSM-Read-campaign"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ]
+        Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/campaign/prod/*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "github_actions_ssm" {
   role       = aws_iam_role.github_actions.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+  policy_arn = aws_iam_policy.github_actions_ssm_minimal.arn
 }


### PR DESCRIPTION

## 개요

GitHub Actions IAM 과잉권한을 최소권한으로 교체하고, terraform-mcp EC2를 퍼블릭 서브넷으로 이전

---

## 변경 사항

### SSM parameter store dlq 알림용 webhook 추가
<img width="814" height="43" alt="image" src="https://github.com/user-attachments/assets/0968a1d7-1270-4e35-9311-dcd20dbfecb4" />


### IAM 정책 최소 권한화 (`iam.tf`)

* `AmazonS3FullAccess` → **campaign-deploy 버킷 전용 커스텀 정책**으로 교체
* `AmazonSSMFullAccess` → **/campaign/prod/* 읽기 전용 커스텀 정책**으로 교체

### EC2 네트워크 변경 (`ec2.tf`)

* `terraform-mcp` 서브넷 변경

  * `private_app_2a` → `public_2a`
* 퍼블릭 IP 활성화

### Redis 설정 (`elasticache.tf`)

* Redis 클러스터 **주석 처리**
* 추후 **모니터링 구성 후 활성화 예정**

---

## 변경 유형

* infra — Terraform / AWS 인프라

---

## 관련 이슈

* closes #19

---

## 체크리스트

* [x] 로컬에서 정상 동작 확인 (`terraform apply 완료`)
* [x] 기존 기능 영향 범위 파악
* [x] Phase 1 변경 사항 여부 확인

---

