### PR TITLE
 feat: 로컬 모니터링 인프라 및 커스텀 비즈니스 메트릭 추가 (#22, #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,9 +186,23 @@ Kafka Consumer (10 파티션)
 - [ ] ItemProcessor: Redis Queue 재발행 가능 여부 판단
 - [ ] ItemWriter: 재발행 성공 → 유지, 실패 → FAIL UPDATE
 
-### 모니터링 (A/B 코드 완성 후)
-- [ ] Prometheus + Grafana 구성
-- [ ] 메트릭 포인트 확정 (Bridge 드레인 속도, PENDING→SUCCESS 지연시간, Queue 적재량)
+### #22 로컬 모니터링 인프라 ✅ 완료 (2026-04-15, feature/monitoring 브랜치)
+- [x] `docker-compose.yml` — kafka-exporter(:9308), redis-exporter(:9121), Prometheus(:9090), Grafana(:3000) 추가
+- [x] `monitoring/prometheus.yml` — spring-boot(app:8080/actuator/prometheus), kafka, redis 스크레이프 타겟 3개
+- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — Grafana 기동 시 Prometheus 데이터소스 자동 프로비저닝
+- [x] `.env` — 모니터링 포트 환경변수 추가
+- 로컬 검증 완료: Prometheus 타겟 3개 UP, Grafana :3000 접속 확인
+
+### #23 커스텀 비즈니스 메트릭 ✅ 완료 (2026-04-15, feature/monitoring 브랜치)
+- [x] `ParticipationBridge.java` — `bridge.drain.duration` (Timer), `bridge.messages.published` (Counter, campaignId 태그)
+- [x] `ParticipationEventConsumer.java` — `consumer.pending_to_success.latency` (Timer)
+- [x] `QueueMetricsScheduler.java` 신규 — `redis.queue.size` (Gauge, campaignId 태그, 10초 주기 LLEN 수집)
+- 로컬 검증 완료: /actuator/prometheus에서 4개 메트릭 전부 수집 확인
+  - `bridge_drain_duration_seconds` — count=5062, sum=18.77s
+  - `bridge_messages_published_total{campaignId="1"}` — 1.0
+  - `consumer_pending_to_success_latency_seconds` — count=1, sum=2.683s
+  - `redis_queue_size{campaignId="1"}` — 0.0 (큐 소진 정상)
+
 
 ### Phase 1: Terraform (infra/ 전체 작성)
 
@@ -223,6 +237,9 @@ Kafka Consumer (10 파티션)
 
 #### 📌 배포 전 AWS 작업 완료
 - [x] SSM `/batch-kafka/prod/SLACK_WEBHOOK_URL` 등록 완료
+
+#### 🔲 남은 작업 (모니터링 관련)
+- [ ] Grafana 대시보드 구성 (Bridge 드레인 속도, PENDING→SUCCESS 지연시간, Queue 적재량 패널)
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버

--- a/app/campaign-core/docker-compose.yml
+++ b/app/campaign-core/docker-compose.yml
@@ -118,6 +118,71 @@ services:
       redis:
         condition: service_healthy
 
+  # ===== 모니터링 스택 =====
+
+  kafka-exporter:
+    image: danielqsj/kafka-exporter:latest
+    container_name: kafka-exporter
+    ports:
+      - "${KAFKA_EXPORTER_PORT:-9308}:9308"
+    command:
+      - --kafka.server=kafka:29092
+    networks:
+      - campaign-net
+    depends_on:
+      kafka:
+        condition: service_healthy
+
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    container_name: redis-exporter
+    ports:
+      - "${REDIS_EXPORTER_PORT:-9121}:9121"
+    environment:
+      REDIS_ADDR: redis:6379
+    networks:
+      - campaign-net
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+    networks:
+      - campaign-net
+    depends_on:
+      - app
+      - kafka-exporter
+      - redis-exporter
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    networks:
+      - campaign-net
+    depends_on:
+      - prometheus
+
 networks:
   campaign-net:
     driver: bridge
@@ -126,3 +191,5 @@ volumes:
   mysql_data:
   kafka_data:
   redis_data:
+  prometheus_data:
+  grafana_data:

--- a/app/campaign-core/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/app/campaign-core/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/app/campaign-core/monitoring/prometheus.yml
+++ b/app/campaign-core/monitoring/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s      # 15초마다 메트릭 수집
+  evaluation_interval: 15s  # 15초마다 룰 평가
+
+scrape_configs:
+  # Spring Boot 앱 — /actuator/prometheus
+  - job_name: 'spring-boot'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080']
+        labels:
+          app: 'campaign-core'
+
+  # Kafka 브로커 메트릭 (kafka-exporter)
+  - job_name: 'kafka'
+    static_configs:
+      - targets: ['kafka-exporter:9308']
+        labels:
+          app: 'kafka'
+
+  # Redis 메트릭 (redis-exporter)
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis-exporter:9121']
+        labels:
+          app: 'redis'

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -2,7 +2,9 @@ package io.eventdriven.campaign.application.bridge;
 
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.config.KafkaConfig;
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,7 +12,9 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Redis Queue → Kafka 유량 조절 브릿지 (v2)
@@ -25,20 +29,45 @@ import java.util.Set;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
+// @RequiredArgsConstructor 미사용 이유:
+// Timer는 Spring Bean이 아닌 직접 생성 객체(Timer.builder().register())이므로
+// Lombok이 생성자 파라미터로 주입할 수 없음.
+// MeterRegistry(Bean)를 먼저 주입받은 뒤 생성자 안에서 Timer를 직접 만들어야 하므로
+// 생성자를 수동으로 작성함.
 public class ParticipationBridge {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final SlackNotificationService slackNotificationService;
+    private final MeterRegistry meterRegistry;  // Spring Bean → 생성자 주입
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
     private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
     private static final int MAX_RETRY = 3;
 
+    // campaignId별 Counter 캐시
+    // campaignId는 런타임에 결정되므로 생성자에서 미리 만들 수 없음 , 첫 발행 시 lazily 생성 후 재사용
+    private final Map<Long, Counter> publishedCounters = new ConcurrentHashMap<>();
+
+    // Timer는 Bean이 아닌 직접 생성 객체, 생성자에서 MeterRegistry를 받아 초기화
+    private final Timer drainTimer;
+
     @Value("${bridge.batch-size:500}")
     private int batchSize;
+
+    public ParticipationBridge(RedisTemplate<String, String> redisTemplate,
+                               KafkaTemplate<String, String> kafkaTemplate,
+                               SlackNotificationService slackNotificationService,
+                               MeterRegistry meterRegistry) {
+        this.redisTemplate = redisTemplate;
+        this.kafkaTemplate = kafkaTemplate;
+        this.slackNotificationService = slackNotificationService;
+        this.meterRegistry = meterRegistry;  // 1. Bean 주입 완료
+        this.drainTimer = Timer.builder("bridge.drain.duration")
+                .description("drainQueues() 실행 소요시간")
+                .register(meterRegistry);    // 2. 주입된 MeterRegistry로 Timer 등록
+    }
 
     /**
      * 100ms마다 실행 (fixedDelay: 이전 실행 완료 후 100ms 대기)
@@ -46,18 +75,20 @@ public class ParticipationBridge {
      */
     @Scheduled(fixedDelay = 100)
     public void drainQueues() {
-        Set<String> campaignIds = redisTemplate.opsForSet().members(ACTIVE_CAMPAIGNS_KEY);
-        if (campaignIds == null || campaignIds.isEmpty()) {
-            return;
-        }
-
-        for (String campaignIdStr : campaignIds) {
-            try {
-                drainCampaignQueue(Long.parseLong(campaignIdStr));
-            } catch (Exception e) {
-                log.error("캠페인 큐 드레인 중 예외 발생. campaignId={}", campaignIdStr, e);
+        drainTimer.record(() -> {
+            Set<String> campaignIds = redisTemplate.opsForSet().members(ACTIVE_CAMPAIGNS_KEY);
+            if (campaignIds == null || campaignIds.isEmpty()) {
+                return;
             }
-        }
+
+            for (String campaignIdStr : campaignIds) {
+                try {
+                    drainCampaignQueue(Long.parseLong(campaignIdStr));
+                } catch (Exception e) {
+                    log.error("캠페인 큐 드레인 중 예외 발생. campaignId={}", campaignIdStr, e);
+                }
+            }
+        });
     }
 
     /**
@@ -85,6 +116,13 @@ public class ParticipationBridge {
         for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
             try {
                 kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(campaignId), message);
+                // Kafka 발행 성공 카운터 — campaignId 태그로 캠페인별 구분
+                publishedCounters.computeIfAbsent(campaignId, id ->
+                        Counter.builder("bridge.messages.published")
+                                .description("Kafka 발행 성공 건수")
+                                .tag("campaignId", String.valueOf(id))
+                                .register(meterRegistry)
+                ).increment();
                 return; // 성공
             } catch (Exception e) {
                 log.warn("Kafka 발행 실패 (시도 {}/{}). campaignId={}", attempt, MAX_RETRY, campaignId, e);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -5,6 +5,8 @@ import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.domain.entity.ParticipationHistory;
 import io.eventdriven.campaign.domain.entity.ParticipationStatus;
 import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -23,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +49,7 @@ public class ParticipationEventConsumer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final RedisTemplate<String, String> redisTemplate;
     private final SlackNotificationService slackNotificationService;
+    private final MeterRegistry meterRegistry; // Timer는 record() 호출 시 즉석 생성 → 필드 Timer 불필요
 
     private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
     private static final String RESULT_CACHE_PREFIX = "participation:result:";
@@ -109,8 +113,23 @@ public class ParticipationEventConsumer {
                     .map(ParticipationEvent::getHistoryId)
                     .collect(Collectors.toList());
             try {
+                // PENDING → SUCCESS 지연시간 측정
+                // 기준: PENDING INSERT 시점(createdAt) ~ bulkUpdateSuccess 완료 시점
+                // 배치 내 가장 오래된 createdAt을 기준으로 측정 (배치 전체 지연의 최대값)
+                LocalDateTime batchStartTime = validEvents.stream()
+                        .map(e -> historyMap.get(e.getHistoryId()).getCreatedAt())
+                        .min(LocalDateTime::compareTo)
+                        .orElse(LocalDateTime.now());
+
                 int updated = participationHistoryRepository.bulkUpdateSuccess(validHistoryIds);
-                log.info("SUCCESS 업데이트 완료. {}건", updated);
+
+                long latencyMs = Duration.between(batchStartTime, LocalDateTime.now()).toMillis();
+                Timer.builder("consumer.pending_to_success.latency")
+                        .description("PENDING INSERT ~ SUCCESS UPDATE 지연시간")
+                        .register(meterRegistry)
+                        .record(latencyMs, TimeUnit.MILLISECONDS);
+
+                log.info("SUCCESS 업데이트 완료. {}건, 지연시간={}ms", updated, latencyMs);
                 writeResultCache(validEvents);
             } catch (Exception e) {
                 log.error("배치 UPDATE 실패. 개별 처리로 전환. {}건", validEvents.size(), e);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/scheduler/QueueMetricsScheduler.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/scheduler/QueueMetricsScheduler.java
@@ -1,0 +1,84 @@
+package io.eventdriven.campaign.application.scheduler;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Redis Queue 적재량 메트릭 수집 스케줄러 (이슈 #23)
+ *
+ * 10초 주기로 active:campaigns를 순회하며 각 캠페인 Queue의 LLEN을 Gauge로 기록.
+ * Gauge는 현재 시점의 값을 반환하는 메트릭 → Queue 적재량 모니터링에 적합.
+ *
+ * Prometheus 메트릭명: redis_queue_size{campaignId="1"}
+ *
+ * Gauge 사용 이유:
+ * - Counter: 누적값만 증가 (Queue 크기 표현 불가)
+ * - Timer: 실행 시간 측정용
+ * - Gauge: 현재 값을 조회해서 반환 → LLEN 같은 현재 상태 측정에 적합
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueMetricsScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MeterRegistry meterRegistry;
+
+    private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
+
+    // campaignId별 현재 Queue 크기 저장소
+    // Gauge는 이 Map의 값을 주기적으로 읽어서 Prometheus에 노출
+    private final Map<Long, Long> queueSizes = new ConcurrentHashMap<>();
+
+    /**
+     * 10초마다 실행 — active:campaigns 순회 → LLEN 조회 → Gauge 갱신
+     *
+     * Gauge 등록 방식:
+     * - 최초 campaignId 등장 시 Gauge 등록 (queueSizes Map의 값을 참조)
+     * - 이후 매 10초마다 queueSizes 값만 갱신 → Gauge가 자동으로 최신값 반환
+     */
+    @Scheduled(fixedDelay = 10_000)
+    public void collectQueueSizes() {
+        Set<String> campaignIds = redisTemplate.opsForSet().members(ACTIVE_CAMPAIGNS_KEY);
+        if (campaignIds == null || campaignIds.isEmpty()) {
+            return;
+        }
+
+        for (String campaignIdStr : campaignIds) {
+            try {
+                Long campaignId = Long.parseLong(campaignIdStr);
+                String queueKey = QUEUE_KEY_PREFIX + campaignId;
+
+                Long size = redisTemplate.opsForList().size(queueKey);
+                long queueSize = size != null ? size : 0L;
+
+                // 첫 등장 시 Gauge 등록
+                // Gauge는 람다로 queueSizes.get(campaignId)를 참조 → 값이 바뀌면 자동 반영
+                queueSizes.computeIfAbsent(campaignId, id -> {
+                    Gauge.builder("redis.queue.size", queueSizes, m -> m.getOrDefault(id, 0L).doubleValue())
+                            .description("Redis Queue 현재 적재량")
+                            .tag("campaignId", String.valueOf(id))
+                            .register(meterRegistry);
+                    return 0L;
+                });
+
+                // 현재 LLEN 값으로 갱신 → Gauge가 다음 스크래핑 시 이 값을 반환
+                queueSizes.put(campaignId, queueSize);
+
+                log.debug("Queue 적재량 수집. campaignId={}, size={}", campaignId, queueSize);
+            } catch (Exception e) {
+                log.error("Queue 메트릭 수집 실패. campaignId={}", campaignIdStr, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

  docker-compose 모니터링 스택 구성(#22)과 Micrometer 커스텀 비즈니스 메트릭 추가(#23)를 완료하고 로컬 환경에서 전체 파이프라인 동작을 검증한 PR.

  ## 변경 사항

  ### Issue #22 — 로컬 모니터링 인프라

  **`docker-compose.yml`**
  - kafka-exporter, redis-exporter, Prometheus, Grafana 4개 서비스 추가
  - 포트는 `.env` 변수로 분리해 하드코딩 없이 오버라이드 가능하게 구성
  - kafka-exporter: `danielqsj/kafka-exporter` 이미지, kafka:29092 (내부 리스너) 연결
    - 외부 리스너(9092) 아닌 내부 리스너(29092) 사용 이유: docker 네트워크 내부 통신이므로 컨테이너 이름으로 직접 접근 가능
  - redis-exporter: `oliver006/redis_exporter` 이미지, REDIS_ADDR 환경변수로 주소 주입
  - Prometheus: `./monitoring/prometheus.yml`을 read-only 마운트 → 컨테이너 재기동 없이 설정 파일만 교체 가능
  - Grafana: `./monitoring/grafana/provisioning`을 read-only 마운트 → 기동 시 데이터소스 자동 등록 (수동 UI 설정 불필요)
  - prometheus_data, grafana_data volume 추가 → 컨테이너 재기동 시 수집 데이터/대시보드 유지

  **`monitoring/prometheus.yml`**
  - scrape_interval 기본값 15s 적용
  - 스크레이프 타겟 3개 구성:
    - `spring-boot`: `app:8080/actuator/prometheus` → Micrometer 메트릭 수집
    - `kafka`: `kafka-exporter:9308` → 브로커 lag, 파티션 오프셋 등 Kafka 내부 메트릭 수집
    - `redis`: `redis-exporter:9121` → connected_clients, used_memory 등 Redis 상태 수집

  **`monitoring/grafana/provisioning/datasources/prometheus.yml`**
  - Grafana provisioning 기능 활용 → 컨테이너 기동 시 Prometheus 데이터소스 자동 등록
  - `isDefault: true` → 새 패널 추가 시 데이터소스 선택 없이 바로 쿼리 가능
  - `editable: false` → UI에서 실수로 데이터소스 설정이 변경되는 것 방지

  **`.env`**
  - 모니터링 포트 환경변수 추가: KAFKA_EXPORTER_PORT(9308), REDIS_EXPORTER_PORT(9121), PROMETHEUS_PORT(9090), GRAFANA_PORT(3000)
  - GRAFANA_USER, GRAFANA_PASSWORD 추가 (기본값 admin/admin, 로컬 전용)
  - `.env`는 이미 `.gitignore`에 포함 → 운영 비밀번호 노출 위험 없음

  ---

  ### Issue #23 — 커스텀 비즈니스 메트릭

  **`ParticipationBridge.java`**

  메트릭 2개 추가:

  1. `bridge.drain.duration` (Timer)
     - `drainQueues()` 전체 실행 소요시간 측정
     - Timer 선택 이유: 100ms마다 반복 실행되는 드레인의 실행 시간 추이를 보면 Redis 큐 적재량 증가나 Kafka 발행 지연을 간접 탐지 가능
     - Timer 생성을 생성자에서 처리: `Timer`는 Spring Bean이 아닌 직접 생성 객체이므로 Lombok `@RequiredArgsConstructor`로 주입 불가. `MeterRegistry`(Bean)를 먼저 주입받은 뒤    
  그것을 사용해 Timer를 초기화하는 방식으로 생성자를 수동 작성

  2. `bridge.messages.published` (Counter, campaignId 태그)
     - Kafka 발행 성공 시마다 increment
     - campaignId 태그를 붙인 이유: 캠페인별 발행 속도를 개별 추적해 특정 캠페인에 트래픽이 몰리는지 확인 가능
     - Counter 선택 이유: 발행 건수는 감소하지 않는 누적값 → Prometheus `rate()`로 초당 발행 속도 계산 가능

  **`ParticipationEventConsumer.java`**

  메트릭 1개 추가:

  `consumer.pending_to_success.latency` (Timer)
  - PENDING INSERT 시점(historyMap의 createdAt) ~ bulkUpdateSuccess 완료 시점까지 지연시간 측정
  - 배치 내 가장 오래된 createdAt 기준 → 배치 전체의 최대 지연을 대표값으로 사용
  - 이 지연이 길어지면 Redis Queue → Kafka → Consumer DB 반영까지 전체 파이프라인이 느려지고 있다는 신호

  **`QueueMetricsScheduler.java` (신규)**

  메트릭 1개 추가:

  `redis.queue.size` (Gauge, campaignId 태그)
  - 10초마다 `active:campaigns` 순회 → 캠페인별 `LLEN` 조회 → Gauge 갱신
  - Gauge 선택 이유: Queue 적재량은 증가/감소 모두 가능한 현재 상태값 → Counter(누적 증가만)나 Timer(실행 시간 측정)로는 표현 불가
  - Gauge 등록 방식: `ConcurrentHashMap<Long, Long> queueSizes`에 캠페인별 LLEN 저장, 최초 등장 시 `computeIfAbsent`로 Gauge 등록 후 이후 매 10초마다 Map 값만 갱신 → Prometheus  
  스크레이핑 시 자동으로 최신값 반환
  - `ConcurrentHashMap` 사용 이유: `@Scheduled`는 별도 스레드에서 실행, `computeIfAbsent`와 `put`이 동시 호출될 수 있으므로 thread-safe한 Map 필요

  ---

  ## 로컬 검증 결과

  ### docker compose 전체 컨테이너 Up 확인
<img width="380" height="653" alt="image" src="https://github.com/user-attachments/assets/cec20d30-afed-4731-ae3f-d72b7d2f3053" />


  Prometheus 타겟 3개(spring-boot, kafka, redis) 모두 UP 상태 확인.
<img width="1851" height="716" alt="image" src="https://github.com/user-attachments/assets/60caf948-fa78-4b13-830e-51b8b803fc11" />


  ### `/actuator/prometheus` 커스텀 메트릭 수집 확인

  HELP bridge_drain_duration_seconds drainQueues() 실행 소요시간

  TYPE bridge_drain_duration_seconds summary

  bridge_drain_duration_seconds_count{...} 5062
<img width="1527" height="805" alt="image" src="https://github.com/user-attachments/assets/077defdf-90ed-4c3e-b3af-88449802884f" />

  bridge_drain_duration_seconds_sum{...} 18.774248264
<img width="1510" height="842" alt="image" src="https://github.com/user-attachments/assets/9066b909-69b0-4f41-8920-7a0a2fe0531f" />



  HELP bridge_messages_published_total Kafka 발행 성공 건수

  TYPE bridge_messages_published_total counter

  bridge_messages_published_total{campaignId="1",...} 1.0

  HELP consumer_pending_to_success_latency_seconds PENDING INSERT ~ SUCCESS UPDATE 지연시간

  TYPE consumer_pending_to_success_latency_seconds summary

  consumer_pending_to_success_latency_seconds_count{...} 1
  consumer_pending_to_success_latency_seconds_sum{...} 2.683

  HELP redis_queue_size Redis Queue 현재 적재량

  TYPE redis_queue_size gauge

  redis_queue_size{campaignId="1",...} 0.0

  ## 변경 유형

  - [x] `feat` — 새 기능
  - [x] `chore` — 빌드, 설정, 의존성 등 기타

  ## 관련 이슈

  closes #22
  closes #23

  ## 체크리스트

  - [x] 로컬에서 정상 동작 확인 (docker compose 전체 Up, Prometheus 타겟 3개 UP, 커스텀 메트릭 4개 수집 확인)
  - [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함 (ParticipationBridge 생성자 수동 작성으로 교체, 기존 동작 동일)
  - [x] Phase에 맞는 변경인지 확인 (Phase 2 모니터링 선행 작업)

