### PR TITLE
feat: Grafana 대시보드 구성 및 k6 기반 v2 파이프라인 전 구간 검증 (#24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,22 +186,62 @@ Kafka Consumer (10 파티션)
 - [ ] ItemProcessor: Redis Queue 재발행 가능 여부 판단
 - [ ] ItemWriter: 재발행 성공 → 유지, 실패 → FAIL UPDATE
 
-### #22 로컬 모니터링 인프라 ✅ 완료 (2026-04-15, feature/monitoring 브랜치)
-- [x] `docker-compose.yml` — kafka-exporter(:9308), redis-exporter(:9121), Prometheus(:9090), Grafana(:3000) 추가
-- [x] `monitoring/prometheus.yml` — spring-boot(app:8080/actuator/prometheus), kafka, redis 스크레이프 타겟 3개
-- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — Grafana 기동 시 Prometheus 데이터소스 자동 프로비저닝
-- [x] `.env` — 모니터링 포트 환경변수 추가
-- 로컬 검증 완료: Prometheus 타겟 3개 UP, Grafana :3000 접속 확인
+### 모니터링 — #22~#25 (진행 중)
 
-### #23 커스텀 비즈니스 메트릭 ✅ 완료 (2026-04-15, feature/monitoring 브랜치)
-- [x] `ParticipationBridge.java` — `bridge.drain.duration` (Timer), `bridge.messages.published` (Counter, campaignId 태그)
-- [x] `ParticipationEventConsumer.java` — `consumer.pending_to_success.latency` (Timer)
-- [x] `QueueMetricsScheduler.java` 신규 — `redis.queue.size` (Gauge, campaignId 태그, 10초 주기 LLEN 수집)
-- 로컬 검증 완료: /actuator/prometheus에서 4개 메트릭 전부 수집 확인
+> 진행 순서: 로컬 인프라 구성 → 커스텀 메트릭 코드 → Grafana 대시보드 + k6 검증 → AWS 반영
+> 작업 브랜치: `feature/monitoring`
+
+#### #22 로컬 모니터링 인프라 ✅ 완료 (2026-04-15, leepg)
+- [x] `docker-compose.yml` — kafka-exporter(:9308), redis-exporter(:9121), Prometheus(:9090), Grafana(:3000) 추가
+  - kafka-exporter: 내부 리스너 `kafka:29092` 사용 (컨테이너 내부 통신이므로 외부 9092 아님)
+  - 포트는 `.env` 변수로 분리, 모든 모니터링 서비스 `campaign-net` 네트워크 포함
+- [x] `monitoring/prometheus.yml` — spring-boot(app:8080), kafka-exporter(9308), redis-exporter(9121) 3개 타겟
+- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — 기동 시 자동 프로비저닝, `editable: false`
+- [x] `.env` — KAFKA_EXPORTER_PORT, REDIS_EXPORTER_PORT, PROMETHEUS_PORT, GRAFANA_PORT, GRAFANA_USER, GRAFANA_PASSWORD 추가
+- 로컬 검증 완료: `localhost:9090/targets` 3개 모두 UP
+
+#### #23 커스텀 비즈니스 메트릭 ✅ 완료 (2026-04-15, leepg)
+- [x] `ParticipationBridge.java` — `bridge.drain.duration` (Timer, drainQueues() 전체 소요시간), `bridge.messages.published` (Counter, campaignId 태그)
+  - Timer는 Spring Bean 아니므로 생성자 수동 작성 (`MeterRegistry` 주입 후 Timer 초기화)
+- [x] `ParticipationEventConsumer.java` — `consumer.pending_to_success.latency` (Timer, 배치 내 가장 오래된 createdAt 기준)
+- [x] `QueueMetricsScheduler.java` 신규 — `redis.queue.size` (Gauge, campaignId 태그, 10초 주기)
+  - `ConcurrentHashMap<Long, Long>` + `computeIfAbsent`로 신규 캠페인 최초 발견 시에만 Gauge 등록, 이후 Map 값만 갱신
+- 로컬 검증 완료: `/actuator/prometheus` 커스텀 메트릭 4종 수집 확인
   - `bridge_drain_duration_seconds` — count=5062, sum=18.77s
   - `bridge_messages_published_total{campaignId="1"}` — 1.0
   - `consumer_pending_to_success_latency_seconds` — count=1, sum=2.683s
   - `redis_queue_size{campaignId="1"}` — 0.0 (큐 소진 정상)
+
+#### 📌 #22/#23 코드리뷰에서 발견된 알려진 이슈 → 모두 수정 완료 (2026-04-17)
+- **[완료]** `spring.task.scheduling.pool.size: 2` — `application-local.yml` 추가
+- **[완료]** `.env` `KAFKA_BOOTSTRAP_SERVERS=kafka:29092` — 이미 올바른 값으로 존재 확인
+- **[잔존]** `consumer.pending_to_success.latency` Timer 배치 대표값 1회 기록 → 추후 개선 권장
+
+#### #24 Grafana 대시보드 구성 + k6 부하 검증 ✅ 완료 (2026-04-17, hskhsmm)
+- [x] 알려진 이슈 수정: 스케줄러 스레드 풀 설정 (`application-local.yml`)
+- [x] `monitoring/grafana/dashboards/campaign.json` — 10개 패널 구성
+- [x] `monitoring/grafana/provisioning/dashboards/dashboard.yml` — 자동 프로비저닝 설정
+- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — `uid: prometheus` 고정 (dashboard.json UID 매칭)
+- [x] `docker-compose.yml` — JVM `MaxMetaspaceSize` 128m → 256m 상향 (OOM 방지)
+- [x] `stress-test/k6-load-test.js` — `__ITER` → `exec.scenario.iterationInTest` 교체 (VU 간 userId 중복 방지)
+- [x] k6 로컬 검증 완료 (VU=10, 300 요청, 100% 202 성공)
+- [x] Grafana 실시간 수집 확인
+  - API TPS, p95/p99 응답시간(85~130ms), 에러율 0 ✅
+  - Bridge 드레인 속도, 사이클 소요시간(2~10ms) ✅
+  - `redis_queue_size` 0 수렴 ✅ ← 핵심 완료 기준
+- 트러블슈팅 기록:
+  - Grafana datasource UID 불일치 → provisioning yml에 `uid: prometheus` 고정으로 해결
+  - k6 `__ITER` per-VU 문제 → 전역 iterationInTest 사용으로 해결
+  - JVM Metaspace OOM (좀비 현상) → MaxMetaspaceSize 256m으로 해결
+
+#### #25 AWS 모니터링 인프라 반영 — terraform (hskhsmm 담당) 🔲 진행 예정 (내일)
+- [ ] `security_groups.tf` — terraform-mcp-sg에 9090(Prometheus)/3000(Grafana) ingress 추가
+- [ ] `security_groups.tf` — app-sg에 8080/9121(redis-exporter) from terraform-mcp-sg ingress 추가
+- [ ] `security_groups.tf` — kafka-sg에 9092 from terraform-mcp-sg ingress 추가
+- [ ] terraform-mcp EC2에 Prometheus + Grafana + kafka-exporter 배포 (SSM으로 설치 스크립트 실행)
+- [ ] batch-kafka-app EC2에 redis-exporter 배포 (SSM)
+- [ ] 완료 기준: `terraform-mcp:9090/targets` 3개 UP, Grafana 대시보드 데이터 표시
+- 선행 조건: EC2 인스턴스(terraform-mcp, batch-kafka-app) 시작 필요 (비용 고려)
 
 
 ### Phase 1: Terraform (infra/ 전체 작성)
@@ -237,9 +277,6 @@ Kafka Consumer (10 파티션)
 
 #### 📌 배포 전 AWS 작업 완료
 - [x] SSM `/batch-kafka/prod/SLACK_WEBHOOK_URL` 등록 완료
-
-#### 🔲 남은 작업 (모니터링 관련)
-- [ ] Grafana 대시보드 구성 (Bridge 드레인 속도, PENDING→SUCCESS 지연시간, Queue 적재량 패널)
 
 ### Phase 3: MCP 서버 (mcp-server/)
 - [ ] Python/FastAPI MCP 서버

--- a/app/campaign-core/docker-compose.yml
+++ b/app/campaign-core/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       TZ: Asia/Seoul
-      JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -XX:MaxMetaspaceSize=128m -XX:MaxDirectMemorySize=128m -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8
+      JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:MaxDirectMemorySize=128m -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8
     ports:
       - "8080:8080"
     networks:

--- a/app/campaign-core/docker-compose.yml
+++ b/app/campaign-core/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       GF_USERS_ALLOW_SIGN_UP: 'false'
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana_data:/var/lib/grafana
     networks:
       - campaign-net

--- a/app/campaign-core/monitoring/grafana/dashboards/campaign.json
+++ b/app/campaign-core/monitoring/grafana/dashboards/campaign.json
@@ -1,0 +1,263 @@
+{
+  "uid": "campaign-v2-monitoring",
+  "title": "Campaign Orchestration System",
+  "description": "v2 파이프라인 모니터링 — API / Bridge / Queue / Consumer / Kafka / Redis",
+  "tags": ["campaign", "v2"],
+  "timezone": "Asia/Seoul",
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "schemaVersion": 38,
+  "panels": [
+
+    {
+      "id": 1,
+      "title": "API TPS (건/초)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/campaigns.*/participation\"}[1m]))",
+          "legendFormat": "TPS"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 2,
+      "title": "API p95 응답시간",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{uri=~\"/api/campaigns.*/participation\"}[1m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 3,
+      "title": "API p99 응답시간",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{uri=~\"/api/campaigns.*/participation\"}[1m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 4,
+      "title": "API 에러율 (5xx, 건/초)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/campaigns.*/participation\", status=~\"5..\"}[1m]))",
+          "legendFormat": "5xx 에러율"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": { "lineWidth": 2, "fillOpacity": 20 }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 5,
+      "title": "Bridge 드레인 속도 (건/초)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(bridge_messages_published_total[1m])) by (campaignId)",
+          "legendFormat": "캠페인 {{campaignId}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+
+    {
+      "id": 6,
+      "title": "Bridge 드레인 사이클 소요시간 (평균)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(bridge_drain_duration_seconds_sum[1m]) / rate(bridge_drain_duration_seconds_count[1m])",
+          "legendFormat": "평균 소요시간"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 7,
+      "title": "Redis Queue 캠페인별 적재량",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "redis_queue_size",
+          "legendFormat": "캠페인 {{campaignId}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 15 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      }
+    },
+
+    {
+      "id": 8,
+      "title": "Consumer PENDING→SUCCESS 평균 지연",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(consumer_pending_to_success_latency_seconds_sum[1m]) / rate(consumer_pending_to_success_latency_seconds_count[1m])",
+          "legendFormat": "PENDING→SUCCESS 지연"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 9,
+      "title": "Kafka Consumer Group Lag",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(kafka_consumergroup_lag{consumergroup=\"campaign-group\"}) by (topic, partition)",
+          "legendFormat": "{{topic}} p{{partition}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+
+    {
+      "id": 10,
+      "title": "Redis 메모리 사용량",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "redis_memory_used_bytes",
+          "legendFormat": "used"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "redis_memory_max_bytes",
+          "legendFormat": "max"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    }
+
+  ]
+}

--- a/app/campaign-core/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/app/campaign-core/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: campaign
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/app/campaign-core/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/app/campaign-core/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/app/campaign-core/src/main/resources/application-local.yml
+++ b/app/campaign-core/src/main/resources/application-local.yml
@@ -41,6 +41,11 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: 100  # N+1 문제 방지: IN 절로 한 번에 조회
 
+  task:
+    scheduling:
+      pool:
+        size: 2  # ParticipationBridge(100ms) + QueueMetricsScheduler(10s) 동시 실행 보장
+
   kafka:
     bootstrap-servers: localhost:9092
     consumer:

--- a/stress-test/k6-load-test.js
+++ b/stress-test/k6-load-test.js
@@ -62,21 +62,13 @@ export default function () {
     params
   );
 
-  // 응답 검증
+  // 응답 검증 (v2: 202 Accepted 반환)
   const isSuccess = check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response has success field': (r) => {
-      try {
-        const body = JSON.parse(r.body);
-        return body.hasOwnProperty('success');
-      } catch (e) {
-        return false;
-      }
-    },
+    'status is 202': (r) => r.status === 202,
   });
 
-  // 성공/실패 카운트 (참고: Kafka 비동기 처리라 즉시 결과는 모름)
-  if (response.status === 200) {
+  // 성공/실패 카운트
+  if (response.status === 202) {
     successCount.add(1);
   } else {
     failCount.add(1);

--- a/stress-test/k6-load-test.js
+++ b/stress-test/k6-load-test.js
@@ -2,6 +2,7 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { Counter } from 'k6/metrics';
 import { SharedArray } from 'k6/data';
+import exec from 'k6/execution';
 
 // 커스텀 메트릭
 const successCount = new Counter('participation_success');
@@ -41,8 +42,8 @@ const BASE_URL = 'http://localhost:8080';
 const CAMPAIGN_ID = __ENV.CAMPAIGN_ID || 1; // 환경변수로 캠페인 ID 전달 가능
 
 export default function () {
-  // 현재 iteration 번호를 userId로 사용 (1부터 TOTAL_REQUESTS까지 유니크)
-  const userId = userIds[__ITER];
+  // 전역 iteration 인덱스로 userId 결정 (VU 간 중복 없이 유니크)
+  const userId = userIds[exec.scenario.iterationInTest];
 
   const payload = JSON.stringify({
     userId: userId,
@@ -75,8 +76,8 @@ export default function () {
   }
 
   // 응답 로그 (샘플링 - 100번째마다)
-  if (__ITER % 100 === 0) {
-    console.log(`[Iteration ${__ITER}] UserID: ${userId}, Status: ${response.status}`);
+  if (exec.scenario.iterationInTest % 100 === 0) {
+    console.log(`[Iteration ${exec.scenario.iterationInTest}] UserID: ${userId}, Status: ${response.status}`);
   }
 }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>개요</h2>
<p>Grafana 대시보드 10개 패널 구성(#24)을 완료하고, k6 부하 테스트로 v2 파이프라인 전 구간 메트릭 실시간 수집을 로컬에서 검증한 PR. 작업 과정에서 발견한 버그 3개(datasource UID 불일치, k6 userId 중복, JVM OOM)도 함께 수정.</p>
<hr>
<h2>변경 사항</h2>
<h3>Issue #24 — Grafana 대시보드 구성 + k6 부하 검증</h3>
<p><strong><code>monitoring/grafana/provisioning/dashboards/dashboard.yml</code> (신규)</strong></p>
<ul>
<li>Grafana provisioning 기능으로 대시보드 JSON 파일 자동 로드 설정</li>
<li><code>options.path: /var/lib/grafana/dashboards</code> → docker-compose에서 마운트한 경로와 일치</li>
<li><code>allowUiUpdates: true</code> → Grafana UI에서 패널 수정 후 저장 가능 (로컬 개발 편의)</li>
<li><code>updateIntervalSeconds: 30</code> → JSON 파일 변경 시 30초 이내 자동 반영</li>
</ul>
<p><strong><code>monitoring/grafana/dashboards/campaign.json</code> (신규)</strong></p>
<p>10개 패널 구성:</p>

패널 | 타입 | PromQL | 의도
-- | -- | -- | --
API TPS | timeseries | rate(http_server_requests_seconds_count{uri=~".*/participation"}[1m]) | 참여 API 초당 처리량
API p95 응답시간 | timeseries | histogram_quantile(0.95, ...) | 상위 5% 응답 지연 추이
API p99 응답시간 | timeseries | histogram_quantile(0.99, ...) | 상위 1% 응답 지연 — 임계값 1s/3s 경보선
API 에러율 (5xx) | timeseries | rate(...{status=~"5.."}[1m]) | 서버 장애 감지
Bridge 드레인 속도 | timeseries | rate(bridge_messages_published_total[1m]) | Redis→Kafka 처리 속도 (캠페인별)
Bridge 사이클 소요시간 | timeseries | rate(drain_sum[1m]) / rate(drain_count[1m]) | Bridge 1사이클 평균 소요 시간
Redis Queue 적재량 | timeseries | redis_queue_size | 큐 적재량 현황 — 50,000 WARNING 기준선
Consumer 지연 | timeseries | rate(latency_sum[1m]) / rate(latency_count[1m]) | PENDING→SUCCESS 평균 지연
Kafka Consumer Lag | timeseries | kafka_consumergroup_lag{consumergroup="campaign-group"} | Consumer 미처리 메시지 수
Redis 메모리 | timeseries | redis_memory_used_bytes / redis_memory_max_bytes | 메모리 사용량 및 한계 비교


<ul>
<li><code>refresh: 5s</code> → 5초마다 자동 갱신</li>
<li><code>time.from: now-15m</code> → 기본 조회 범위 최근 15분</li>
</ul>
<p><strong><code>monitoring/grafana/provisioning/datasources/prometheus.yml</code> (수정)</strong></p>
<ul>
<li><code>uid: prometheus</code> 추가</li>
<li>수정 이유: dashboard.json의 각 패널이 <code>"datasource": {"uid": "prometheus"}</code>로 하드코딩되어 있는데, Grafana가 프로비저닝 시 UID를 자동 생성하면 패널이 데이터소스를 찾지 못해 전체 No data 발생. UID를 명시적으로 고정해 JSON과 일치시킴</li>
</ul>
<p><strong><code>docker-compose.yml</code> (수정)</strong></p>
<ul>
<li>Grafana 볼륨에 <code>./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro</code> 마운트 추가 → 기동 시 campaign.json 자동 로드</li>
<li>JVM <code>MaxMetaspaceSize</code> 128m → 256m 상향
<ul>
<li>변경 이유: 로컬 부하 테스트 중 <code>OutOfMemoryError: Metaspace</code> 발생. Metaspace는 JVM이 로드한 클래스 메타데이터를 저장하는 영역으로, 128m은 Spring Boot + 모니터링 의존성 전체를 감당하기 부족. OOM 발생 시 Tomcat 스레드가 요청 처리를 못하면서 Health Check는 UP이지만 실제 요청은 전부 EOF로 실패하는 좀비 현상 발생 → 256m으로 상향해 해결</li>
</ul>
</li>
</ul>
<p><strong><code>application-local.yml</code> (수정)</strong></p>
<ul>
<li><code>spring.task.scheduling.pool.size: 2</code> 추가
<ul>
<li>변경 이유: Spring의 <code>@Scheduled</code> 기본 스레드 풀 크기는 1개. <code>ParticipationBridge</code>(100ms 주기)와 <code>QueueMetricsScheduler</code>(10s 주기)가 동일 풀을 공유하므로 한 스케줄러가 실행 중이면 나머지가 블로킹되는 현상 방지</li>
</ul>
</li>
</ul>
<p><strong><code>stress-test/k6-load-test.js</code> (수정)</strong></p>
<ul>
<li><code>import exec from 'k6/execution'</code> 추가</li>
<li><code>userIds[__ITER]</code> → <code>userIds[exec.scenario.iterationInTest]</code> 교체
<ul>
<li>변경 이유: <code>__ITER</code>은 VU(가상 사용자)별 카운터로 모든 VU의 첫 번째 실행 시 0. 200 VU 동시 시작 시 전부 <code>userId=1</code>로 요청 → <code>RateLimitService</code>(SET NX EX 10)가 첫 1건 외 전부 차단해 429 폭탄 발생. <code>exec.scenario.iterationInTest</code>는 시나리오 전체 기준 전역 카운터로 VU별로 고유한 인덱스 할당 → userId 중복 없이 각 VU가 다른 userId로 요청</li>
</ul>
</li>
</ul>
<hr>
<h2>로컬 검증 결과</h2>
<p><strong>Prometheus 타겟 3개 UP 확인</strong></p>
<img width="1854" height="522" alt="image" src="https://github.com/user-attachments/assets/1ab11d64-cc30-466a-a282-ed42743fdae9" />
<p><strong>k6 부하 테스트 결과 (VU=10, 300 요청)</strong></p>
<pre><code>✓ status is 202

checks            : 100.00% ✓ 300 / ✗ 0
http_req_duration : avg=84.91ms  p(90)=114.32ms  p(95)=125.46ms
http_reqs         : 300 (113/s)
participation_success: 300
</code></pre>
<p><strong>Grafana — API 패널 (TPS / p95 / p99 / 에러율)</strong></p>
<img width="1398" height="614" alt="image" src="https://github.com/user-attachments/assets/7e14caf2-ded1-4df1-8e93-cf6b2a0bb31a" />

<p><strong>Grafana — Bridge / Queue 패널</strong></p>
<img width="1536" height="295" alt="image" src="https://github.com/user-attachments/assets/9e5f730a-7b57-463b-84ba-4319167863ed" />
<hr>
<h2>변경 유형</h2>
<ul>
<li><code>feat</code> — 새 기능</li>
<li><code>fix</code> — 버그 수정</li>
<li><code>chore</code> — 빌드, 설정, 의존성 등 기타</li>
</ul>
<hr>
<h2>관련 이슈</h2>
<p>closes #24</p>
<hr>
<h2>체크리스트</h2>
<ul>
<li>[x] 로컬에서 정상 동작 확인 (k6 300건 100% 202, Grafana 10개 패널 데이터 수집, redis_queue_size 0 수렴)</li>
<li>[x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함 (<code>application-local.yml</code> 스케줄러 풀 추가 — 기존 스케줄링 동작에 영향 없음)</li>
<li>[x] Phase에 맞는 변경인지 확인 (Phase 2 모니터링)</li>
</ul></body></html><!--EndFragment-->
</body>
</html>