### PR TITLE
fix: PendingRecovery 재발행 경로 Redis Queue → Kafka 직접 발행으로 전환

### DIFF
--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
@@ -1,6 +1,6 @@
 package io.eventdriven.campaign.batch;
 
-import io.eventdriven.campaign.application.service.RedisQueueService;
+import io.eventdriven.campaign.config.KafkaConfig;
 import io.eventdriven.campaign.domain.entity.ParticipationHistory;
 import io.eventdriven.campaign.domain.entity.ParticipationStatus;
 import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
@@ -15,6 +15,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -32,7 +33,7 @@ public class PendingRecoveryJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
     private final ParticipationHistoryRepository participationHistoryRepository;
-    private final RedisQueueService redisQueueService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
     private final JsonMapper jsonMapper;
 
     @Bean
@@ -64,13 +65,22 @@ public class PendingRecoveryJobConfig {
             List<Long> failIds = new ArrayList<>();
             for (ParticipationHistory history : pendingList) {
                 String message = buildMessage(history);
-                boolean pushed = redisQueueService.push(history.getCampaign().getId(), message);
-                if (!pushed) {
+                try {
+                    // Redis Queue 대신 Kafka 직접 발행
+                    // 이유: 재고 소진 시 active:campaigns에서 SREM → Bridge가 큐를 드레인하지 않음
+                    //       Batch 복구 대상은 소량이므로 Bridge 우회해도 부하 없음
+                    kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(history.getCampaign().getId()), message)
+                            .whenComplete((result, ex) -> {
+                                if (ex != null) {
+                                    log.error("PENDING 재발행 실패 → FAIL 처리 예정. historyId={}", history.getId(), ex);
+                                } else {
+                                    log.info("PENDING 재발행 성공. historyId={}", history.getId());
+                                }
+                            });
+                } catch (Exception e) {
                     failIds.add(history.getId());
                     log.warn("PENDING 재발행 실패 → FAIL 처리. historyId={}, campaignId={}",
-                            history.getId(), history.getCampaign().getId());
-                } else {
-                    log.info("PENDING 재발행 성공. historyId={}", history.getId());
+                            history.getId(), history.getCampaign().getId(), e);
                 }
             }
 


### PR DESCRIPTION

## Summary

- **버그**: 재고 소진 후 PENDING 상태가 영원히 처리되지 않는 문제 수정
- **원인 분석**: Lua 스크립트에서 `remaining == 0` 시 `SREM active:campaigns` 원자 실행 → Bridge가 해당 캠페인 큐를 순회 대상에서 제외 → 재고 소진 타이밍에 끼인 메시지가 큐에 잔류
- **기존 안전망의 한계**: 5분 후 `PendingRecoveryJob`이 실행되어 `redisQueueService.push()`로 큐에 재적재하지만, 캠페인이 여전히 `active:campaigns`에 없으므로 Bridge가 또 드레인하지 않음 → PENDING 상태 영구 유지
- **해결**: Batch 재처리 경로를 `Redis Queue → Bridge → Kafka` 에서 `Kafka 직접 발행`으로 전환

## 문제 흐름 (Before)


재고 100번째 요청
  → remaining = 0 → Lua SREM active:campaigns
  → Bridge: active:campaigns에 없음 → 큐 드레인 안 함
  → 5분 후 PendingRecoveryJob 실행
  → redisQueueService.push() → 큐 재적재
  → Bridge: 여전히 active:campaigns에 없음 → 또 드레인 안 함
  → PENDING 영구 유지 ❌


## 해결 흐름 (After)


5분 후 PendingRecoveryJob 실행
  → kafkaTemplate.send() → Kafka 직접 발행
  → active:campaigns 유무 무관
  → Consumer가 historyId PK 조회 → PENDING → SUCCESS UPDATE ✅


## 변경 사항

- `PendingRecoveryJobConfig`: `RedisQueueService` 의존성 제거, `KafkaTemplate` 주입으로 교체
- 재발행 방식: `redisQueueService.push()` → `kafkaTemplate.send()` (Bridge 우회)
- 비동기 결과 처리: `.whenComplete()`로 발행 성공/실패 로그 추가

## 이렇게 해도 되는 이유

Bridge의 역할은 API 고트래픽 유량 조절 (`queue:campaign:{id}` 버퍼링)이지만,
Batch 복구 대상은 재고 소진 타이밍에 끼인 **소수 건(수십 건 이하)** 이므로
유량 조절 없이 Kafka에 직접 발행해도 Consumer나 Kafka에 부하 없음.

## 예상 결과

- 재고 소진 후 잔류 PENDING 건이 5분 이내 SUCCESS로 정상 처리
- `active:campaigns` 재등록 불필요 → Redis stock 값 오염(음수 누적) 없음
- Spring Batch 안전망이 설계 의도대로 완전히 동작

## Test Plan

- [ ] totalStock=100 캠페인 생성 후 200건 요청 → 100건 SUCCESS, 나머지 400 확인
- [ ] PENDING 상태 레코드 5분 대기 후 PendingRecoveryJob 실행 확인
- [ ] 잔류 PENDING 건이 SUCCESS로 전환되는지 DB 확인
- [ ] Grafana `consumer.pending_to_success.latency` 메트릭으로 처리 확인
