### PR TITLE
fix: run-test alb 주소 placeholder -> 실제 주소 변환

### DIFF
--- a/stress-test/run-test.sh
+++ b/stress-test/run-test.sh
@@ -15,7 +15,7 @@ ENV=${1:-"local"}
 
 # 환경별 BASE_URL
 if [ "$ENV" = "prod" ]; then
-  BASE_URL="http://alb-batch-kafka-api-xxx.ap-northeast-2.elb.amazonaws.com"
+  BASE_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com"
 else
   BASE_URL="http://localhost:8080"
 fi


### PR DESCRIPTION
## Summary

- `PendingRecoveryJobConfig`: Batch 재처리 발행 경로를 Redis Queue → Kafka 직접 발행으로 전환
- `ParticipationEvent`: 오타 제거 (팡)

## 변경 상세

### PendingRecoveryJobConfig

기존에는 5분 초과 PENDING 재처리 시 `redisQueueService.push()`로 Redis Queue에 재적재했으나,
재고 소진 시점에 Lua에서 `SREM active:campaigns`가 실행되어 Bridge가 해당 캠페인 큐를 드레인하지 않는 문제 존재.

Batch 복구 대상은 소량(재고 소진 타이밍에 끼인 수십 건)이므로 Bridge 우회 후 Kafka 직접 발행으로 전환.

- `RedisQueueService` 의존성 제거 → `KafkaTemplate` 주입
- `redisQueueService.push()` → `kafkaTemplate.send()` (Bridge 우회)
- `.whenComplete()`로 비동기 발행 성공/실패 로그 처리

## Test Plan

- [ ] 캠페인 생성 후 k6 부하 테스트
- [ ] 재고 소진 후 잔류 PENDING 건이 5분 내 SUCCESS 전환 확인