### PR TITLE
feat: 모니터링 대시보드 확장 및 HikariCP/CPU 관측 지표 추가 

### DIFF
--- a/app/campaign-core/build.gradle
+++ b/app/campaign-core/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	// /actuator/prometheus 엔드포인트 — Micrometer → Prometheus 스크래핑
 	// 모니터링 문서 2장: Spring Boot(Micrometer) → Prometheus → Grafana 파이프라인 필수
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'io.micrometer:micrometer-registry-cloudwatch2'  // application-prod.yml cloudwatch.enabled: true
 
 	// /actuator/health, /actuator/metrics — 헬스체크 및 커스텀 메트릭(TPS, p99, DLQ 등) 노출
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/app/campaign-core/monitoring/grafana/dashboards/campaign.json
+++ b/app/campaign-core/monitoring/grafana/dashboards/campaign.json
@@ -2,21 +2,34 @@
   "uid": "campaign-v2-monitoring",
   "title": "Campaign Orchestration System",
   "description": "v2 파이프라인 모니터링 — API / Bridge / Queue / Consumer / Kafka / Redis",
-  "tags": ["campaign", "v2"],
+  "tags": [
+    "campaign",
+    "v2"
+  ],
   "timezone": "Asia/Seoul",
   "refresh": "5s",
-  "time": { "from": "now-15m", "to": "now" },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "schemaVersion": 38,
   "panels": [
-
     {
       "id": 1,
       "title": "API TPS (건/초)",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/campaigns.*/participation\"}[1m]))",
           "legendFormat": "TPS"
         }
@@ -24,21 +37,37 @@
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 2,
       "title": "API p95 응답시간",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{uri=~\"/api/campaigns.*/participation\"}[1m])) by (le))",
           "legendFormat": "p95"
         }
@@ -46,28 +75,50 @@
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 3,
       "title": "API p99 응답시간",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{uri=~\"/api/campaigns.*/participation\"}[1m])) by (le))",
           "legendFormat": "p99"
         }
@@ -75,29 +126,54 @@
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 3 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
             ]
           }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 4,
       "title": "API 에러율 (5xx, 건/초)",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/campaigns.*/participation\", status=~\"5..\"}[1m]))",
           "legendFormat": "5xx 에러율"
         }
@@ -105,21 +181,38 @@
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": { "mode": "fixed", "fixedColor": "red" },
-          "custom": { "lineWidth": 2, "fillOpacity": 20 }
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20
+          }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 5,
       "title": "Bridge 드레인 속도 (건/초)",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(bridge_messages_published_total[1m])) by (campaignId)",
           "legendFormat": "캠페인 {{campaignId}}"
         }
@@ -127,21 +220,37 @@
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
     },
-
     {
       "id": 6,
       "title": "Bridge 드레인 사이클 소요시간 (평균)",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "rate(bridge_drain_duration_seconds_sum[1m]) / rate(bridge_drain_duration_seconds_count[1m])",
           "legendFormat": "평균 소요시간"
         }
@@ -149,21 +258,37 @@
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 7,
       "title": "Redis Queue 캠페인별 적재량",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "redis_queue_size",
           "legendFormat": "캠페인 {{campaignId}}"
         }
@@ -171,31 +296,54 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 15 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 50000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50000
+              }
             ]
           }
         }
       },
       "options": {
-        "tooltip": { "mode": "multi" },
-        "legend": { "displayMode": "table", "placement": "bottom" }
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
       }
     },
-
     {
       "id": 8,
       "title": "Consumer PENDING→SUCCESS 평균 지연",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "rate(consumer_pending_to_success_latency_seconds_sum[1m]) / rate(consumer_pending_to_success_latency_seconds_count[1m])",
           "legendFormat": "PENDING→SUCCESS 지연"
         }
@@ -203,48 +351,83 @@
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "single" } }
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 9,
       "title": "Kafka Consumer Group Lag",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(kafka_consumergroup_lag{consumergroup=\"campaign-group\"}) by (topic, partition)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(kafka_consumergroup_lag{consumergroup=\"campaign-participation-group\"}) by (topic, partition)",
           "legendFormat": "{{topic}} p{{partition}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
     },
-
     {
       "id": 10,
       "title": "Redis 메모리 사용량",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 8 },
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 8
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "redis_memory_used_bytes",
           "legendFormat": "used"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "redis_memory_max_bytes",
           "legendFormat": "max"
         }
@@ -252,12 +435,221 @@
       "fieldConfig": {
         "defaults": {
           "unit": "bytes",
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
         }
       },
-      "options": { "tooltip": { "mode": "multi" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "HikariCP 커넥션 풀 (pending/active/idle/max)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 48,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "pending (대기)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active (사용중)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hikaricp_connections_idle",
+          "legendFormat": "idle (유휴)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hikaricp_connections_max",
+          "legendFormat": "max (최대)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pending (대기)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "HikariCP 활성율 (active/max) — 0.95+ 병목",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 56,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hikaricp_connections_active / hikaricp_connections_max",
+          "legendFormat": "활성율"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.95
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "CPU 사용률 — 0.85+ 앱 병목",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 56,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_cpu_usage",
+          "legendFormat": "CPU"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     }
-
   ]
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
@@ -59,10 +59,19 @@ public class ParticipationService {
         long sequence = total - remaining;
         // JPA 프록시 — INSERT 시 FK(campaign_id)만 필요, DB 조회 없음
         Campaign campaign = campaignRepository.getReferenceById(campaignId);
+
+        long t0 = System.currentTimeMillis();
         Long historyId = insertPendingWithRetry(campaign, userId, sequence, campaignId);
+        long dbInsertMs = System.currentTimeMillis() - t0;
 
         String message = buildMessage(campaignId, userId, historyId);
+        long t1 = System.currentTimeMillis();
         boolean pushed = redisQueueService.push(campaignId, message);
+        long redisPushMs = System.currentTimeMillis() - t1;
+
+        log.info("[TIMING] campaignId={} userId={} DB_INSERT={}ms REDIS_PUSH={}ms TOTAL={}ms",
+                campaignId, userId, dbInsertMs, redisPushMs, dbInsertMs + redisPushMs);
+
         if (!pushed) {
             log.warn("Redis Queue 적재 실패 (Spring Batch 안전망). campaignId={}, userId={}, historyId={}",
                     campaignId, userId, historyId);

--- a/app/campaign-core/src/main/resources/application-local.yml
+++ b/app/campaign-core/src/main/resources/application-local.yml
@@ -53,7 +53,6 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
-      group-id: campaign-group
       auto-offset-reset: earliest
 
 kafka:

--- a/app/campaign-core/src/main/resources/application-prod.yml
+++ b/app/campaign-core/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, prometheus        # Prometheus scrape 엔드포인트 노출
+        include: health, prometheus, metrics   # Prometheus scrape + metrics 디버깅용
   endpoint:
     health:
       show-details: when-authorized        # 인증된 요청만 상세 노출
@@ -56,6 +56,11 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true    # flyway_schema_history 없을 때 자동 baseline 생성
     baseline-version: 0
+
+  task:
+    scheduling:
+      pool:
+        size: 2
 
   batch:
     job:


### PR DESCRIPTION
                                                                                                                                                                                 
  ## 개요                                                                                                                                                                         
                                                                                                                                                                                  
  모니터링 관측 지표를 확장하고, 운영 환경 메트릭 수집 설정을 보강했습니다.                                                                                                       
  주요 목적은 부하 테스트/운영 중 병목 구간(DB 커넥션 풀, CPU, 브릿지 드레인, 큐 적체)을 빠르게 식별할 수 있도록 대시보드와 설정을 정리하는 것입니다.                             
                                                                                                                                                                                  
  ## 변경사항                                                                                                                                                                     
                                                                                                                                                                                  
  - Grafana 대시보드(`campaign.json`) 확장                                                                                                                                        
  - HikariCP 관련 지표 패널 추가                                                                                                                                                  
    - `hikaricp_connections_pending`                                                                                                                                              
    - `hikaricp_connections_active`                                                                                                                                               
    - `hikaricp_connections_idle`                                                                                                                                                 
    - `hikaricp_connections_max`                                                                                                                                                  
    - `hikaricp_connections_active / hikaricp_connections_max`                                                                                                                    
  - CPU 지표 패널 추가                                                                                                                                                            
    - `process_cpu_usage`                                                                                                                                                         
  - 브릿지/큐 관측 지표 보강                                                                                                                                                      
    - `bridge_messages_published_total`                                                                                                                                           
    - `bridge_drain_duration_seconds_*`                                                                                                                                           
    - `redis_queue_size`                                                                                                                                                          
  - 참여 요청 경로 타이밍 로그 추가                                                                                                                                               
    - DB insert / Redis push / total 소요시간 로그 출력                                                                                                                           
  - 운영 설정 보강                                                                                                                                                                
    - `management.endpoints.web.exposure.include`: `health, prometheus, metrics`                                                                                                  
    - `spring.task.scheduling.pool.size: 2`                                                                                                                                       
    - CloudWatch 메트릭 레지스트리 의존성 추가                                                                                                                                    
  - 로컬 설정 정리                                                                                                                                                                
    - `application-local.yml`의 kafka consumer `group-id` 제거                                                                                                                    
                                                                                                                                                                                  
  ## 변경 유형                                                                                                                                                                    
                                                                                                                                                                                  
  - [x] `feat` 새로운 기능                                                                                                                                                        
  - [ ] `fix` 버그 수정                                                                                                                                                           
  - [ ] `refactor` 기능 변경 없는 코드 개선                                                                                                                                       
  - [x] `chore` 빌드, 설정, 의존성 등 기타                                                                                                                                        
  - [ ] `docs` 문서                                                                                                                                                               
  - [ ] `test` 테스트                                                                                                                                                             
  - [ ] `infra` Terraform / AWS 인프라                                                                                                                                            
                                                                                                                                                                                  
  ## 관련 이슈                                                                                                                                                                    
                                                                                                                                                                                  
  closes #                                                                                                                                                                        
                                                                                                                                                                                  
  ## 체크리스트                                                                                                                                                                   
                                                                                                                                                                                  
  - [ ] 로컬에서  정상 동작 확인    
<img width="1507" height="787" alt="local test3" src="https://github.com/user-attachments/assets/3fb53866-c0e5-4cd8-8212-8786218deb51" />
<img width="1526" height="760" alt="lcoal test" src="https://github.com/user-attachments/assets/2c281713-23f0-4098-a13f-6961281eae5e" />

                                                                                                                                               
  - [x] 기존 기능 영향 범위 파악                                                                                                                                                  
  - [x] Phase에 맞는 변경인지 확인 (Phase 3: 모니터링/관측 강화)     