### PR TITLE
chore(config): p3/p5 yml v3 기준 업데이트 — concurrency 제거, HikariCP pool 최적화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,6 +616,16 @@ Aurora는 Consumer DB INSERT가 병목으로 확인될 때 결정.
   - terraform-mcp에서: `CAMPAIGN_ID=<id> TOTAL_REQUESTS=15000 MAX_VUS=1000 DURATION=60 bash stress-test/run-test.sh prod`
   - 파라미터 오버라이드: `CAMPAIGN_ID=2 TOTAL_REQUESTS=30000 ./run-test.sh prod`
 
+#### 테스트 전 캠페인 생성 (매번 필요)
+- 캠페인 생성 엔드포인트: **`POST /api/admin/campaigns`** (`/api/campaigns` 아님)
+- terraform-mcp에서 실행:
+  ```bash
+  curl -X POST $BASE_URL/api/admin/campaigns \
+    -H "Content-Type: application/json" \
+    -d '{"name":"load-test","totalStock":10000,"startDate":"2026-04-22","endDate":"2026-04-30"}'
+  ```
+- BASE_URL은 `~/.bashrc`에 영구 저장됨 (`http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com`)
+
 #### 파티션별 yml (단일 브로커 한계 테스트용)
 - `application-p2.yml`, `application-p3.yml`, `application-p5.yml`, `application-p10.yml`
 - Consumer concurrency는 KafkaConfig가 Kafka 토픽 파티션 수 자동 감지 (yml 변경 불필요)

--- a/app/campaign-core/src/main/resources/application-p3.yml
+++ b/app/campaign-core/src/main/resources/application-p3.yml
@@ -2,14 +2,11 @@
 # 사용법: SPRING_PROFILES_ACTIVE=prod,p3
 
 spring:
-  kafka:
-    listener:
-      concurrency: 3  # Consumer 스레드 3개 (파티션 수와 동일)
-
+  # concurrency는 KafkaConfig가 토픽 파티션 수 자동 감지 → 여기서 설정 불필요
   datasource:
     hikari:
-      maximum-pool-size: 30     # 25 → 30 (Consumer 스레드 3개 + 여유)
-      minimum-idle: 15
+      maximum-pool-size: 15     # v3 Redis-first: Consumer INSERT 전용, Consumer 3개 × 여유
+      minimum-idle: 8
       connection-timeout: 20000
       idle-timeout: 300000
       max-lifetime: 1800000
@@ -29,9 +26,7 @@ kafka:
     session-timeout-ms: 45000    # 45초 (유지)
 
 # 실험 메모
-# 파티션: 3개
-# Consumer 스레드: 3개 (자동)
-# 예상 TPS: 2,000 ~ 2,500
-# 예상 CPU: 60~65%
-# 순서 보장: 파티션별로만 보장
-# 파티션 편향 가능성 있음 (해시 함수 의존)
+# 파티션: 3개 (kafka-topics.sh --alter --partitions 3 후 앱 재시작)
+# Consumer 스레드: 3개 (KafkaConfig 자동 감지)
+# HikariCP: API DB 제거(v3)로 Consumer INSERT 전용 → pool 15로 충분
+# 순서 보장: 파티션별로만 보장 (파티션 편향 가능성 있음)

--- a/app/campaign-core/src/main/resources/application-p5.yml
+++ b/app/campaign-core/src/main/resources/application-p5.yml
@@ -2,10 +2,11 @@
 # 사용법: SPRING_PROFILES_ACTIVE=local,p5 ./gradlew bootRun
 
 spring:
+  # concurrency는 KafkaConfig가 토픽 파티션 수 자동 감지 → 여기서 설정 불필요
   datasource:
     hikari:
-      maximum-pool-size: 40     # 30 → 40 (Consumer 스레드 5개 + 여유)
-      minimum-idle: 20
+      maximum-pool-size: 20     # v3 Redis-first: Consumer INSERT 전용, Consumer 5개 × 여유
+      minimum-idle: 10
       connection-timeout: 20000
       idle-timeout: 300000
       max-lifetime: 1800000
@@ -25,10 +26,8 @@ kafka:
     session-timeout-ms: 45000    # 45초 (유지)
 
 # 실험 메모
-# 파티션: 5개
-# Consumer 스레드: 5개 (자동)
-# 예상 TPS: 3,000 ~ 4,000
-# 예상 CPU: 70~80%
+# 파티션: 5개 (kafka-topics.sh --alter --partitions 5 후 앱 재시작)
+# Consumer 스레드: 5개 (KafkaConfig 자동 감지)
+# HikariCP: API DB 제거(v3)로 Consumer INSERT 전용 → pool 20으로 충분
 # 순서 보장: 파티션별로만 보장
-# ⚠️ DB 병목 시작 가능성 (커넥션 경합)
-# ⚠️ 인프라: 최소 4코어, 4GB 권장
+# ⚠️ Consumer 5개 동시 INSERT → RDS CPU/DiskQueueDepth 주시

--- a/stress-test/k6-load-test.js
+++ b/stress-test/k6-load-test.js
@@ -15,7 +15,7 @@ const MAX_VUS = parseInt(__ENV.MAX_VUS) || 5000;     // 최대 가상 사용자 
 const TOTAL_REQUESTS = parseInt(__ENV.TOTAL_REQUESTS) || 30000; // 총 요청 수
 const PARTITIONS = parseInt(__ENV.PARTITIONS) || 3;  // Kafka 파티션 수
 
-console.log(`🚀 Kafka 부하 테스트 설정: 정확히 ${TOTAL_REQUESTS}개 요청, 목표 ${RATE}/s, ${DURATION}s, ${PARTITIONS} 파티션`);
+console.log(`[k6] total=${TOTAL_REQUESTS}, rate=${RATE}/s, duration=${DURATION}s, partitions=${PARTITIONS}`);
 
 // 사전 생성된 userId 배열 (정확히 TOTAL_REQUESTS개)
 const userIds = new SharedArray('userIds', function () {

--- a/stress-test/run-test.sh
+++ b/stress-test/run-test.sh
@@ -27,7 +27,7 @@ MAX_VUS=${MAX_VUS:-1000}
 DURATION=${DURATION:-60}
 
 echo "=============================="
-echo " k6 부하 테스트 시작"
+echo " k6 load test start"
 echo " ENV           : $ENV"
 echo " BASE_URL      : $BASE_URL"
 echo " CAMPAIGN_ID   : $CAMPAIGN_ID"


### PR DESCRIPTION
 ## Summary
  - p3/p5 실험용 yml v3 Redis-first 기준 업데이트 (concurrency 제거, HikariCP pool 최적화)
  - k6 스크립트 한글 제거 (EC2 터미널 깨짐 방지)
  - CLAUDE.md 캠페인 생성 엔드포인트 및 테스트 절차 보완

  ## Test plan
  - [ ] p3 프로필 배포 후 KafkaConfig 로그에서 concurrency=3 자동 감지 확인
  - [ ] k6 출력 한글 깨짐 없는지 확인
