### PR TITLE
fix : Kafka 파티션 키 campaignId -> userId

### DIFF
--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -1,5 +1,6 @@
 package io.eventdriven.campaign.application.bridge;
 
+import io.eventdriven.campaign.application.event.ParticipationEvent;
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.config.KafkaConfig;
 import io.micrometer.core.instrument.Counter;
@@ -10,12 +11,11 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Redis Queue → Kafka 유량 조절 브릿지 (v2)
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  * - active:campaigns Set 순회 → 캠페인별 큐 드레인
  * - MAX_RETRY 3회 + exponential backoff 후 실패 시 DLQ + Slack 알림
  * - RPOP 실패 시 LPUSH 재적재 금지 (Queue 순서 뒤섞임 방지)
- * - 파티션 키: campaignId (동일 캠페인 메시지는 같은 파티션으로 라우팅)
+ * - 파티션 키: userId (파티션 균등 분산, v3에서 선착순은 Redis DECR 시점에 이미 확정)
  *
  * 주의: @EnableScheduling이 CampaignCoreApplication에 있어야 동작.
  */
@@ -41,12 +41,12 @@ public class ParticipationBridge {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final SlackNotificationService slackNotificationService;
     private final MeterRegistry meterRegistry;  // Spring Bean → 생성자 주입
+    private final JsonMapper jsonMapper;
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
     private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
     private static final int MAX_RETRY = 3;
-    private static final Pattern USER_ID_PATTERN = Pattern.compile("\"userId\"\\s*:\\s*(\\d+)");
 
     // campaignId별 Counter 캐시
     // campaignId는 런타임에 결정되므로 생성자에서 미리 만들 수 없음 , 첫 발행 시 lazily 생성 후 재사용
@@ -58,11 +58,13 @@ public class ParticipationBridge {
     public ParticipationBridge(RedisTemplate<String, String> redisTemplate,
                                KafkaTemplate<String, String> kafkaTemplate,
                                SlackNotificationService slackNotificationService,
-                               MeterRegistry meterRegistry) {
+                               MeterRegistry meterRegistry,
+                               JsonMapper jsonMapper) {
         this.redisTemplate = redisTemplate;
         this.kafkaTemplate = kafkaTemplate;
         this.slackNotificationService = slackNotificationService;
         this.meterRegistry = meterRegistry;  // 1. Bean 주입 완료
+        this.jsonMapper = jsonMapper;
         this.drainTimer = Timer.builder("bridge.drain.duration")
                 .description("drainQueues() 실행 소요시간")
                 .register(meterRegistry);    // 2. 주입된 MeterRegistry로 Timer 등록
@@ -159,13 +161,13 @@ public class ParticipationBridge {
     }
 
     private String extractUserIdKey(String message, Long campaignId) {
-        Matcher matcher = USER_ID_PATTERN.matcher(message);
-        if (matcher.find()) {
-            return matcher.group(1);
+        try {
+            ParticipationEvent event = jsonMapper.readValue(message, ParticipationEvent.class);
+            return String.valueOf(event.getUserId());
+        } catch (Exception e) {
+            log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
+            return String.valueOf(campaignId);
         }
-
-        log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
-        return String.valueOf(campaignId);
     }
 
     /**

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Redis Queue → Kafka 유량 조절 브릿지 (v2)
@@ -44,6 +46,7 @@ public class ParticipationBridge {
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
     private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
     private static final int MAX_RETRY = 3;
+    private static final Pattern USER_ID_PATTERN = Pattern.compile("\"userId\"\\s*:\\s*(\\d+)");
 
     // campaignId별 Counter 캐시
     // campaignId는 런타임에 결정되므로 생성자에서 미리 만들 수 없음 , 첫 발행 시 lazily 생성 후 재사용
@@ -121,9 +124,10 @@ public class ParticipationBridge {
      * 실패 메시지를 Redis Queue에 재적재하지 않음 (순서 보장 우선).
      */
     private void publishWithRetry(Long campaignId, String message) {
+        String partitionKey = extractUserIdKey(message, campaignId);
         for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
             try {
-                kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(campaignId), message);
+                kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
                 // Kafka 발행 성공 카운터 — campaignId 태그로 캠페인별 구분
                 publishedCounters.computeIfAbsent(campaignId, id ->
                         Counter.builder("bridge.messages.published")
@@ -152,6 +156,16 @@ public class ParticipationBridge {
         // MAX_RETRY 모두 소진
         log.error("Bridge MAX_RETRY({}) 초과. DLQ 전송. campaignId={}", MAX_RETRY, campaignId);
         sendToDlqWithSlack(campaignId, message, "MAX_RETRY_EXCEEDED");
+    }
+
+    private String extractUserIdKey(String message, Long campaignId) {
+        Matcher matcher = USER_ID_PATTERN.matcher(message);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
+        return String.valueOf(campaignId);
     }
 
     /**


### PR DESCRIPTION

## 개요
ParticipationBridge의 Kafka 파티션 키를 `campaignId`에서 `userId`로 변경했습니다. 단일 캠페인 트래픽 집중 시 특정 파티션으로 트래픽이 쏠리는 문제를 완화하기 위한 조치입니다.

## 변경 사항
* **수정 파일:**
    * `app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java`

* **핵심 코드 변경 1: Kafka key 변경 (`campaignId` → `userId`)**
    ```java
    // before
    kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(campaignId), message);

    // after
    String partitionKey = extractUserIdKey(message, campaignId);
    kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
    ```

* **핵심 코드 변경 2: `userId` 추출 로직 (`regex` → `JsonMapper`) 전환**
    기존 regex 방식은 `ParticipationEvent` 필드명 변경 시 에러를 탐지하지 못하고 조용히 fallback으로 빠지는 문제가 있어, 안정성을 위해 `JsonMapper` 역직렬화 방식으로 전환했습니다.

    ```java
    // before (regex)
    private static final Pattern USER_ID_PATTERN = Pattern.compile("\"userId\"\\s*:\\s*(\\d+)");
    private String extractUserIdKey(String message, Long campaignId) {
        Matcher matcher = USER_ID_PATTERN.matcher(message);
        if (matcher.find()) {
            return matcher.group(1);
        }
        log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
        return String.valueOf(campaignId);
    }

    // after (JsonMapper)
    private String extractUserIdKey(String message, Long campaignId) {
        try {
            ParticipationEvent event = jsonMapper.readValue(message, ParticipationEvent.class);
            return String.valueOf(event.getUserId());
        } catch (Exception e) {
            log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
            return String.valueOf(campaignId);
        }
    }
    ```

* **동작 영향**
    * 정상 메시지(userId 포함): `userId` 기준으로 파티션 분산
    * 비정상 메시지(userId 누락): 기존과 동일하게 `campaignId` key 사용
    * DLQ 전송 key는 기존 유지(`campaignId`)

## 변경 유형
- [ ] feat 새로운 기능
- [ ] fix 버그 수정
- [x] refactor 기능 변경 없는 코드 개선
- [ ] chore 빌드, 설정, 의존성 등 기타
- [ ] docs 문서
- [ ] test 테스트
- [ ] infra Terraform / AWS 인프라

## 관련 이슈
- closes #

## 체크리스트
- [ ] 로컬 컴파일 확인 (`./gradlew compileJava`)
- [ ] 기존 기능 영향 범위 파악 (브릿지 Kafka key 결정 로직만 변경)
- [ ] Phase에 맞는 변경인지 확인 (Phase 5 — 파티션 분산 효율화)