### PR TITLE
feat: #54 Phase A - ASG 수평 확장 + 모니터링 redis-exporter 중복 수집 수정

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,913 @@
+# 1Million Campaign Orchestration System — 아키텍처 문서
+
+> 작성일: 2026-04-27
+> v1(10만 트래픽) → v3 Redis-first(100만 트래픽 목표) 전체 설계 및 구현 정리
+> 현재 상태: Phase A(ASG) 완료, Phase B(100만 테스트) 진행 예정
+
+---
+
+## 목차
+
+1. [프로젝트 개요](#1-프로젝트-개요)
+2. [전체 데이터 흐름](#2-전체-데이터-흐름)
+3. [API 계층 — 참여 요청 처리](#3-api-계층--참여-요청-처리)
+4. [Redis 설계](#4-redis-설계)
+5. [ParticipationBridge — Redis to Kafka](#5-participationbridge--redis-to-kafka)
+6. [Kafka 구성](#6-kafka-구성)
+7. [ParticipationEventConsumer — DB 최종 기록](#7-participationeventconsumer--db-최종-기록)
+8. [모니터링 아키텍처](#8-모니터링-아키텍처)
+9. [인프라 구성 (AWS + Terraform)](#9-인프라-구성-aws--terraform)
+10. [CI/CD 파이프라인](#10-cicd-파이프라인)
+11. [부하 테스트 결과 및 병목 개선 히스토리](#11-부하-테스트-결과-및-병목-개선-히스토리)
+12. [설계 결정 근거](#12-설계-결정-근거)
+13. [앞으로 할 작업 로드맵](#13-앞으로-할-작업-로드맵)
+
+---
+
+## 1. 프로젝트 개요
+
+### 목표
+선착순 캠페인 참여 시스템에서 **100만 트래픽**을 정합성 보장 하에 처리한다.
+
+### 핵심 요구사항
+- **공정성**: 먼저 요청한 사람이 먼저 당첨 (선착순)
+- **정합성**: 재고 초과 발급 0건
+- **가용성**: 단일 장애점(SPOF) 제거
+- **성능**: 목표 TPS 1,000/s 이상
+
+### 기술 스택
+| 분류 | 기술 |
+|------|------|
+| 언어/프레임워크 | Java 21, Spring Boot (Virtual Thread) |
+| 메시지 큐 | Apache Kafka (KRaft, 3-broker) |
+| 캐시/큐 | Redis (ElastiCache CME 3샤드, Valkey 7.2) |
+| DB | MySQL 8.0 (AWS RDS db.t3.micro) |
+| 인프라 | AWS EC2, ALB, ElastiCache, RDS, CodeDeploy |
+| IaC | Terraform |
+| 모니터링 | Prometheus, Grafana, CloudWatch, Micrometer |
+| 부하 테스트 | k6 |
+
+---
+
+## 2. 전체 데이터 흐름
+
+```
+[클라이언트]
+    |
+    | POST /api/campaigns/{id}/participation
+    v
+[ALB — alb-batch-kafka-api]
+    |
+    v
+[Spring Boot App — batch-kafka-app EC2]
+    |
+    |-- 1. RateLimitService     SET NX EX 10  →  [Redis CME]
+    |-- 2. RedisStockService    Lua DECR      →  [Redis CME]  (비활성/소진 즉시 컷)
+    |-- 3. RedisQueueService    Lua LPUSH     →  [Redis CME]  queue:campaign:{id}
+    |
+    | 202 Accepted 반환 (DB 미접촉)
+    |
+    v
+[ParticipationBridge — @Scheduled 100ms]
+    |
+    |-- SMEMBERS active:campaigns
+    |-- RPOP queue:campaign:{id}  (동적 batchSize: 500/1000/2000)
+    |
+    v
+[Kafka — campaign-participation-topic]
+    | 파티션 10개, RF=3, min.ISR=2
+    | 파티션 키: userId (균등 분산)
+    |
+    v
+[ParticipationEventConsumer — concurrency=10]
+    |
+    |-- INSERT IGNORE INTO participation_history (멱등성 보장)
+    |-- Redis 결과 캐시 적재  participation:result:{userId}:{campaignId}
+    |
+    v
+[MySQL RDS — batch-kafka-db]
+```
+
+### 핵심 설계 원칙
+
+**선착순 번호 확정 시점 = Redis DECR 시점**
+```
+sequence = totalStock - remaining
+```
+- API 진입 시 Redis DECR 한 번으로 선착순 번호가 원자적으로 확정됨
+- Kafka 순서와 무관 (파티션 여러 개여도 공정성 보장)
+- DB INSERT는 Consumer가 비동기로 처리 → API 응답 경로에서 DB 완전 제거
+
+---
+
+## 3. API 계층 — 참여 요청 처리
+
+### ParticipationService (핵심 진입점)
+
+```java
+public void participate(Long campaignId, Long userId) {
+    // Step 1: 동일 유저 10초 내 재요청 차단
+    if (!rateLimitService.isAllowed(campaignId, userId)) {
+        throw new RateLimitExceededException(campaignId, userId);
+    }
+
+    // Step 2: 원자적 재고 감소 (Lua 스크립트)
+    // EXISTS active:campaign:{id} → DECR stock → DEL flag(remaining==0) → GET total
+    long[] stockResult = redisStockService.checkDecrTotal(campaignId);
+    long remaining = stockResult[0];
+    long total     = stockResult[1];
+
+    // 비활성(-999) 또는 소진(<0) 즉시 컷 — DB 미접촉
+    if (remaining == RedisStockService.INACTIVE_CAMPAIGN) {
+        throw new StockExhaustedException(campaignId);
+    }
+    if (remaining < 0) {
+        throw new StockExhaustedException(campaignId);
+    }
+
+    // remaining == 0: 마지막 재고 소진 → DB 캠페인 CLOSED 처리
+    if (remaining == 0) {
+        campaignRepository.closeAndResetStock(campaignId, CampaignStatus.CLOSED);
+    }
+
+    // Step 3: 선착순 번호 확정 (원자적)
+    long sequence = total - remaining;
+
+    // Step 4: Redis Queue에 적재 (Kafka 발행은 Bridge가 비동기 처리)
+    String message = buildMessage(campaignId, userId, sequence);
+    redisQueueService.push(campaignId, message);
+    // 202 반환 — 여기서 응답 완료
+}
+```
+
+**메시지 구조:**
+```json
+{ "campaignId": 13, "userId": 1042, "sequence": 5001 }
+```
+
+### RateLimitService — 동일 유저 중복 요청 차단
+
+```java
+public boolean isAllowed(Long campaignId, Long userId) {
+    // 키: ratelimit:campaign:{id}:user:{userId}
+    // SET NX EX 10 — 키 없으면 저장(통과), 키 있으면 무시(차단)
+    String key = "ratelimit:campaign:" + campaignId + ":user:" + userId;
+    Boolean result = redisTemplate.opsForValue()
+            .setIfAbsent(key, "1", 10, TimeUnit.SECONDS);
+    return Boolean.TRUE.equals(result);
+}
+```
+
+- 10초 TTL: 동일 유저가 10초 내 재요청 시 429 반환
+- Boolean.TRUE.equals(): Redis 연결 오류 시 null 방어
+
+### RedisQueueService — 큐 적재 (Lua 원자적)
+
+```lua
+-- push-queue.lua
+-- LLEN 체크 후 100,000 초과 시 적재 거부
+local size = redis.call('LLEN', KEYS[1])
+if size >= tonumber(ARGV[1]) then
+    return 0
+end
+redis.call('LPUSH', KEYS[1], ARGV[2])
+return 1
+```
+
+- MAX_QUEUE_SIZE = 100,000 (시스템 과부하 방지)
+- LLEN + LPUSH 원자적 실행으로 race condition 없음
+
+---
+
+## 4. Redis 설계
+
+### 키 구조
+
+| 키 | 타입 | 역할 | TTL |
+|----|------|------|-----|
+| `ratelimit:campaign:{id}:user:{userId}` | String | 중복 요청 차단 플래그 | 10s |
+| `active:campaigns` | Set | Bridge가 순회할 활성 캠페인 목록 | 영구 |
+| `active:campaign:{id}` | String | Lua용 캠페인 활성 플래그 (해시태그) | 영구(재고 소진 시 DEL) |
+| `stock:campaign:{id}` | String | 캠페인 잔여 재고 (DECR 대상) | 영구 |
+| `total:campaign:{id}` | String | 캠페인 총 재고 (sequence 계산용) | 영구 |
+| `queue:campaign:{id}` | List | API → Bridge 버퍼 큐 | 영구 |
+| `participation:result:{userId}:{campaignId}` | String | Consumer 처리 결과 캐시 | 300s |
+
+### Redis Cluster 해시태그 설계
+
+ElastiCache CME(3샤드)에서 Lua 스크립트는 **동일 슬롯**의 키만 접근 가능합니다.
+`{id}` 해시태그로 `active:campaign:{id}`, `stock:campaign:{id}`, `total:campaign:{id}` 세 키를 동일 슬롯에 배치합니다.
+
+```
+active:campaign:{13} → 해시태그 {13} → 슬롯 X
+stock:campaign:{13}  → 해시태그 {13} → 슬롯 X  (동일)
+total:campaign:{13}  → 해시태그 {13} → 슬롯 X  (동일)
+```
+
+### check-decr-total.lua (핵심 Lua 스크립트)
+
+```lua
+-- KEYS[1] = active:campaign:{id}   (캠페인 활성 플래그)
+-- KEYS[2] = stock:campaign:{id}    (잔여 재고)
+-- KEYS[3] = total:campaign:{id}    (총 재고)
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return {-999, 0}      -- 비활성 캠페인: 즉시 차단
+end
+
+local remaining = redis.call('DECR', KEYS[2])
+
+if remaining == 0 then
+    redis.call('DEL', KEYS[1])  -- 마지막 재고 소진 → active flag 제거
+end
+
+local total = tonumber(redis.call('GET', KEYS[3])) or 0
+return {remaining, total}
+```
+
+**3가지 케이스:**
+1. `remaining == -999`: 비활성 캠페인 → 즉시 400
+2. `remaining < 0`: 재고 소진 후 추가 DECR → 보상 INCR 후 400
+3. `remaining >= 0`: 정상 → `sequence = total - remaining` 확정 후 LPUSH
+
+### 활성 캠페인 이중 관리 구조
+
+```
+active:campaigns (전역 Set)       active:campaign:{id} (캠페인별 플래그)
+    ↑                                     ↑
+    Bridge SMEMBERS 순회용               Lua DECR 가드용
+    (Lua 밖에서만 접근)                   (해시태그 슬롯 통일)
+
+캠페인 생성 시: SADD + SET 1
+재고 소진 시:   Lua가 DEL (플래그만) → Bridge가 RPOP null 시 SREM (전역 Set)
+```
+
+---
+
+## 5. ParticipationBridge — Redis to Kafka
+
+Bridge는 API와 Kafka 사이의 **유량 조절 버퍼** 역할을 합니다.
+API는 즉시 202를 반환하고, Bridge가 100ms마다 큐를 소비해 Kafka에 발행합니다.
+
+```java
+@Scheduled(fixedDelay = 100)  // 이전 실행 완료 후 100ms 대기
+public void drainQueues() {
+    drainTimer.record(() -> {
+        // active:campaigns Set 순회
+        Set<String> campaignIds = redisTemplate.opsForSet().members("active:campaigns");
+        for (String campaignIdStr : campaignIds) {
+            drainCampaignQueue(Long.parseLong(campaignIdStr));
+        }
+    });
+}
+
+private void drainCampaignQueue(Long campaignId) {
+    String queueKey = "queue:campaign:" + campaignId;
+    Long queueSize = redisTemplate.opsForList().size(queueKey);
+    int batchSize = resolveBatchSize(queueSize);  // 동적 배치 크기
+
+    for (int i = 0; i < batchSize; i++) {
+        String message = redisTemplate.opsForList().rightPop(queueKey);  // RPOP
+        if (message == null) {
+            // 큐 비었고 active flag도 없으면 재고 소진 완료 → 전역 Set 정리
+            if (!redisStockService.isActive(campaignId)) {
+                redisStockService.deactivateCampaign(campaignId);
+            }
+            break;
+        }
+        publishWithRetry(campaignId, message);
+    }
+}
+```
+
+### 동적 batchSize
+
+큐 적체량에 따라 드레인 속도를 자동 조절합니다:
+
+| 큐 크기 | batchSize |
+|---------|-----------|
+| < 10,000 | 500 |
+| < 100,000 | 1,000 |
+| >= 100,000 | 2,000 |
+
+### Kafka 발행 신뢰성
+
+```java
+private void publishWithRetry(Long campaignId, String message) {
+    String partitionKey = extractUserIdKey(message, campaignId); // userId로 파티션 분산
+
+    for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+        try {
+            kafkaTemplate.send(TOPIC_NAME, partitionKey, message);
+            return; // 성공
+        } catch (Exception e) {
+            long backoffMs = (long) Math.pow(2, attempt) * 100L; // 200ms → 400ms
+            Thread.sleep(backoffMs);
+        }
+    }
+    // MAX_RETRY(3회) 소진 → DLQ + Slack 알림
+    sendToDlqWithSlack(campaignId, message, "MAX_RETRY_EXCEEDED");
+}
+```
+
+**파티션 키 = userId**: campaignId로 키를 설정하면 단일 캠페인의 모든 메시지가 한 파티션으로 쏠림.
+userId로 변경 시 Consumer 지연 1.25s → 200ms (-84%) 개선 확인 (6차 테스트).
+
+---
+
+## 6. Kafka 구성
+
+### 클러스터 구성
+
+```
+kafka-1 (172.31.5.164,  public_2a)  ← Leader 역할 분산
+kafka-2 (172.31.16.164, public_2b)
+kafka-3 (172.31.32.164, public_2c)
+```
+
+- **KRaft 모드**: ZooKeeper 없음, 브로커가 직접 메타데이터 관리
+- **cluster.id**: 9CA3K977Q5GdJDSdlKZVEw
+
+### 토픽 설정
+
+```
+campaign-participation-topic
+  PartitionCount: 10
+  ReplicationFactor: 3
+  min.insync.replicas: 2
+```
+
+- 파티션 10개 → Consumer 10개 병렬 처리
+- RF=3, min.ISR=2 → 브로커 1대 장애 시에도 쓰기 가능
+
+### KafkaConfig — 파티션 수 자동 감지
+
+```java
+// 앱 기동 시 실제 토픽 파티션 수를 AdminClient로 조회
+// → concurrency 자동 설정 (코드 수정 없이 파티션 변경 가능)
+private int getTopicPartitionCount(String topicName) {
+    try (AdminClient adminClient = AdminClient.create(configs)) {
+        TopicDescription desc = adminClient.describeTopics(...)
+                .allTopicNames().get(5, SECONDS).get(topicName);
+        return desc.partitions().size();  // 10 반환
+    }
+    // 조회 실패 시 기본값 1 사용
+    return 1;
+}
+
+factory.setConcurrency(partitionCount);  // Consumer 스레드 = 파티션 수
+```
+
+### Producer 설정
+
+```yaml
+kafka:
+  producer:
+    buffer-memory: 536870912  # 512MB — 대량 메시지 버퍼
+    batch-size: 131072        # 128KB — 배치 효율
+    linger-ms: 5              # 5ms 대기 후 배치 전송
+    acks: all                 # 모든 ISR 승인 대기
+    enable-idempotence: true  # 멱등성 (중복 방지)
+```
+
+---
+
+## 7. ParticipationEventConsumer — DB 최종 기록
+
+v3에서 Consumer의 역할은 단순합니다: **Kafka 메시지를 받아 DB에 INSERT SUCCESS**
+
+```java
+@KafkaListener(
+    topics = "campaign-participation-topic",
+    groupId = "campaign-participation-group",
+    containerFactory = "kafkaListenerContainerFactory"
+)
+public void consumeParticipationEvent(
+        List<ConsumerRecord<String, String>> records,
+        Acknowledgment acknowledgment) {
+
+    // 1. 메시지 파싱 (sequence 없으면 DLQ)
+    List<ParticipationEvent> events = parseRecords(records);
+
+    // 2. DB INSERT IGNORE (멱등성 — UNIQUE(campaign_id, user_id) 제약)
+    for (ParticipationEvent event : events) {
+        participationHistoryRepository.insertSuccess(
+                event.getCampaignId(), event.getUserId(), event.getSequence());
+        // DataIntegrityViolationException → 중복으로 무시 (at-least-once 보장)
+    }
+
+    // 3. Redis 결과 캐시 적재 (파이프라인으로 배치 처리)
+    writeResultCache(successEvents);
+
+    // 4. Kafka 오프셋 수동 커밋 (처리 완료 후)
+    acknowledgment.acknowledge();
+}
+```
+
+### 멱등성 보장 메커니즘
+
+```sql
+-- INSERT IGNORE: UNIQUE 충돌 시 에러 없이 무시
+INSERT IGNORE INTO participation_history
+    (campaign_id, user_id, sequence, status, created_at)
+VALUES (?, ?, ?, 'SUCCESS', NOW())
+```
+
+```sql
+-- UNIQUE 제약 (V3 마이그레이션)
+ALTER TABLE participation_history
+    ADD UNIQUE KEY uq_campaign_user (campaign_id, user_id);
+```
+
+Kafka at-least-once 재전송으로 동일 메시지가 다시 와도 INSERT IGNORE가 조용히 무시합니다.
+
+### 결과 캐시 (폴링 API 지원)
+
+Consumer 처리 완료 후 Redis에 결과를 캐시합니다:
+```
+KEY: participation:result:{userId}:{campaignId}
+VALUE: "SUCCESS"
+TTL: 300s
+```
+
+클라이언트가 `GET /api/campaigns/{id}/participation/{userId}/result`로 폴링하면:
+1. Redis 캐시 확인 → 있으면 즉시 반환
+2. 없으면 DB fallback
+
+---
+
+## 8. 모니터링 아키텍처
+
+### 전체 구성
+
+```
+[Spring Boot App :8080]          [kafka-1 :9092]      [ElastiCache :6379]
+    /actuator/prometheus              |                      |
+         |                    [kafka-exporter :9308]  [redis-exporter :9121]
+         |                           |                      |
+         +---------------------------+----------------------+
+                                     |
+                            [Prometheus :9090]
+                                     |
+                            [Grafana :3000]
+                       (terraform-mcp EC2에서 실행)
+```
+
+### 커스텀 비즈니스 메트릭 4종
+
+| 메트릭명 | 타입 | 설명 |
+|---------|------|------|
+| `bridge.drain.duration` | Timer | Bridge drainQueues() 전체 소요시간 |
+| `bridge.messages.published{campaignId}` | Counter | 캠페인별 Kafka 발행 성공 건수 |
+| `consumer.pending_to_success.latency` | Timer | API LPUSH ~ Consumer INSERT 지연 |
+| `redis.queue.size{campaignId}` | Gauge | 캠페인별 Redis Queue 현재 적재량 |
+
+### QueueMetricsScheduler — Gauge 설계
+
+```java
+// Gauge는 "현재 값"을 표현 — Queue 적재량에 최적
+// Counter/Timer와 달리 감소도 표현 가능
+
+@Scheduled(fixedDelay = 10_000)  // 10초 주기
+public void collectQueueSizes() {
+    for (String campaignIdStr : activeIds) {
+        Long campaignId = Long.parseLong(campaignIdStr);
+        long size = redisTemplate.opsForList().size("queue:campaign:" + campaignId);
+
+        // 첫 등장 시만 Gauge 등록 (이후 Map 값만 갱신)
+        queueSizes.computeIfAbsent(campaignId, id -> {
+            Gauge.builder("redis.queue.size", queueSizes,
+                          m -> m.getOrDefault(id, 0L).doubleValue())
+                    .tag("campaignId", String.valueOf(id))
+                    .register(meterRegistry);
+            return 0L;
+        });
+
+        queueSizes.put(campaignId, size);  // Gauge가 다음 스크래핑에서 이 값 반환
+    }
+}
+```
+
+### Grafana 대시보드 패널 구성 (13개)
+
+| 번호 | 패널 | 핵심 쿼리 |
+|------|------|-----------|
+| 1 | API TPS | `rate(http_server_requests_seconds_count[1m])` |
+| 2 | API p95 응답시간 | `histogram_quantile(0.95, ...)` |
+| 3 | API p99 응답시간 | `histogram_quantile(0.99, ...)` |
+| 4 | API 에러율 (5xx) | `rate(http_server_requests_seconds_count{status=~"5.."}[1m])` |
+| 5 | Bridge 드레인 속도 | `rate(bridge_messages_published_total[1m])` |
+| 6 | Bridge 사이클 소요시간 | `bridge_drain_duration_seconds` |
+| 7 | Redis Queue 적재량 | `redis_queue_size` |
+| 8 | Consumer PENDING→SUCCESS 지연 | `consumer_pending_to_success_latency_seconds` |
+| 9 | Kafka Consumer Group Lag | `kafka_consumergroup_lag` |
+| 10 | Redis 메모리 사용량 | `redis_memory_used_bytes` |
+| 11 | HikariCP 커넥션 풀 | `hikaricp_connections` (pending/active/idle/max) |
+| 12 | HikariCP 활성율 | `hikaricp_connections_active / hikaricp_connections_max` |
+| 13 | CPU 사용률 | `process_cpu_usage` |
+
+### CloudWatch 지표 (AWS 측)
+
+- RDS: CPUUtilization, DatabaseConnections, WriteIOPS, DiskQueueDepth
+- RDS: Slow Query Log (long_query_time=0.5s, log_output=TABLE)
+- EC2: CPU Credit Balance/Usage (t3 burst 모니터링)
+
+---
+
+## 9. 인프라 구성 (AWS + Terraform)
+
+### AWS 리소스 전체 구성
+
+```
+VPC (172.31.0.0/16)
+├── 퍼블릭 서브넷
+│   ├── public_2a — kafka-1 (172.31.5.164),   terraform-mcp
+│   ├── public_2b — kafka-2 (172.31.16.164)
+│   ├── public_2c — kafka-3 (172.31.32.164)
+│   └── public_2d
+├── 프라이빗 서브넷
+│   ├── private_app_2a (172.31.100.0/24) — ASG 인스턴스
+│   └── private_app_2b (172.31.101.0/24) — ASG 인스턴스 (multi-AZ)
+│
+├── ASG (batch-kafka-app-asg, min=2, max=3)
+│   ├── Launch Template: ami-01c64e7a84a57e681 (Docker+CodeDeploy)
+│   └── Target Tracking: CPU 60% (scale-in 비활성)
+│
+├── ALB (alb-batch-kafka-api, internet-facing)
+│   └── Target Group → batch-kafka-app:8080
+│
+├── ElastiCache CME (Valkey 7.2)
+│   ├── 샤드 1: primary + replica
+│   ├── 샤드 2: primary + replica
+│   └── 샤드 3: primary + replica
+│   (cache.t3.micro × 6, 총 6노드)
+│
+└── RDS (batch-kafka-db, MySQL 8.0.44, db.t3.micro)
+```
+
+### Terraform 파일 구성
+
+| 파일 | 관리 리소스 |
+|------|------------|
+| `main.tf` | Provider, S3 backend, DynamoDB lock |
+| `vpc.tf` | VPC, IGW, Subnets, Route Tables |
+| `security_groups.tf` | ALB/App/RDS/Kafka/ElastiCache SG |
+| `ec2.tf` | IAM Role/Profile/Policy, kafka-1/2/3, terraform-mcp |
+| `asg.tf` | Launch Template, ASG, Target Tracking Scaling Policy |
+| `codedeploy.tf` | CodeDeploy App/DG, Service Role (ASG 연결) |
+| `rds.tf` | RDS 인스턴스, 파라미터 그룹 (slow query) |
+| `elasticache.tf` | ElastiCache CME, SSM 자동 등록 |
+| `alb.tf` | ALB, Target Group, HTTP Listener |
+| `iam.tf` | GitHub Actions OIDC Role |
+| `dynamodb.tf` | terraform-lock (State Lock) |
+
+### ElastiCache CME Terraform
+
+```hcl
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id       = "batch-kafka-redis"
+  engine                     = "valkey"
+  engine_version             = "7.2"
+  node_type                  = "cache.t3.micro"
+  num_node_groups            = 3    # 샤드 3개
+  replicas_per_node_group    = 1    # 샤드당 replica 1개
+  parameter_group_name       = "default.valkey7.cluster.on"
+  automatic_failover_enabled = true
+}
+
+# terraform apply 시 SSM 자동 등록
+resource "aws_ssm_parameter" "redis_cluster_nodes" {
+  name  = "/batch-kafka/prod/SPRING_DATA_REDIS_CLUSTER_NODES"
+  type  = "SecureString"
+  value = "${aws_elasticache_replication_group.redis.configuration_endpoint_address}:6379"
+  lifecycle { ignore_changes = [value] }
+}
+```
+
+### SSM Parameter Store 관리
+
+앱이 기동할 때 `beforeInstall.sh`가 SSM에서 환경변수를 자동 주입합니다:
+
+```bash
+# /batch-kafka/prod/* 경로에서 환경변수 로드
+SPRING_DATASOURCE_URL=$(aws ssm get-parameter ...)
+SPRING_DATA_REDIS_CLUSTER_NODES=$(aws ssm get-parameter ...)
+SPRING_KAFKA_BOOTSTRAP_SERVERS=$(aws ssm get-parameter ...)
+SLACK_WEBHOOK_URL=$(aws ssm get-parameter ...)
+```
+
+SSH를 완전히 차단하고 SSM Session Manager로만 접속합니다. 민감 정보가 코드에 노출되지 않습니다.
+
+---
+
+## 10. CI/CD 파이프라인
+
+```
+[GitHub push to main]
+    | (app/campaign-core/** 변경 시만 트리거)
+    v
+[GitHub Actions]
+    |-- OIDC → AWS IAM Role 임시 자격증명 (키 없음)
+    |-- ./gradlew build
+    |-- docker build → ECR push
+    |-- appspec.yml + scripts/ → S3 upload
+    |-- CodeDeploy 배포 트리거
+    v
+[CodeDeploy Blue-Green]
+    |-- beforeInstall.sh: SSM에서 환경변수 로드 → .env 파일 생성
+    |-- applicationStart.sh: docker compose down → docker compose up
+    v
+[batch-kafka-app EC2]
+    (무중단 배포 완료)
+```
+
+### 보안 포인트
+- OIDC 기반 인증: AWS Access Key 없음 (깃허브 OIDC → IAM Role 임시 토큰)
+- EC2 SSH 포트 차단: SSM Session Manager만 허용
+- Secrets: SSM SecureString (KMS 암호화)
+- ECR: Private Registry (퍼블릭 노출 없음)
+
+---
+
+## 11. 부하 테스트 결과 및 병목 개선 히스토리
+
+### 테스트 인프라
+- k6 실행 위치: **terraform-mcp EC2 (VPC 내부)** → 인터넷 레이턴시 제거
+- 캠페인 생성: `POST /api/admin/campaigns` (매 테스트 신규 생성)
+- executor: `shared-iterations` (정확한 요청 수 제어)
+
+### 전체 결과 추이
+
+| 차수 | 핵심 변경 | TPS | p95 | HikariCP pending | 정합성 |
+|------|----------|-----|-----|-----------------|--------|
+| 1차 | 기준선 (pool=10) | 246/s | 6.34s | ~980 | ✅ |
+| 2차 | HikariCP pool=20 | 275/s | 5.71s | ~950 | ✅ |
+| 3차 | pool=40, mcp k6 | 323/s | - | ~900 | ✅ |
+| 4차 | **v3 Redis-first** | 526/s | 3.33s | **거의 0** | ✅ |
+| 5차 | 파티션 3개 (campaignId 키) | 543/s | 4.39s | 거의 0 | ✅ |
+| 6차 | 파티션 3개 (userId 키) | 550/s | 3.12s | 거의 0 | ✅ |
+| 7차 | 3브로커 + 파티션 10개, 12만 | ~1,150/s | - | 거의 0 | ✅ |
+| 8차 | 3브로커 + 파티션 10개, 50만 | ~1,220/s | 2.81s | 거의 0 | ✅ |
+
+### 병목 분석 및 해결
+
+#### 1~3차: HikariCP pool 튜닝 한계 확인
+
+```
+VU 1,000개 동시 INSERT 구조:
+pool=20 → 20개 처리, 980개 대기 → pending 950
+pool=40 → 40개 처리, 960개 대기 → pending 900
+결론: pool을 아무리 늘려도 동시 INSERT 구조가 유지되면 근본 해결 불가
+```
+
+#### 4차: v3 Redis-first 전환 (구조적 해결)
+
+**변경 전 (v2):**
+```
+API: DECR → DB PENDING INSERT → LPUSH → 202
+```
+
+**변경 후 (v3):**
+```
+API: DECR → LPUSH → 202  (DB 미접촉)
+Consumer: Kafka 메시지 수신 → DB INSERT SUCCESS 직접
+```
+
+**결과:**
+- HikariCP pending: ~950 → 거의 0 (완전 해소)
+- TPS: 323/s → 526/s (+63%)
+- RDS CPU: 26.5% → 정상 수준
+
+#### 5~6차: Kafka 파티션 키 최적화
+
+campaignId → userId 파티션 키 변경으로 Consumer 지연 1.25s → 200ms (-84%)
+
+파티션 키가 campaignId면 단일 캠페인 트래픽이 한 파티션으로 집중됩니다.
+userId로 변경하면 10개 파티션에 고르게 분산되어 Consumer 10개가 병렬 처리합니다.
+
+#### 7~8차: 앱 CPU 병목 확인 (현재 상태)
+
+3브로커 + 파티션 10개 적용 후에도 TPS 상한이 ~1,220/s에 수렴합니다.
+Grafana 확인 결과 앱 CPU 80~90% 고착 — t3.small 단일 인스턴스 한계.
+
+```
+HikariCP pending: 거의 0 (DB 병목 아님)
+RDS CPU: 9.44% (DB 서버 여유 충분)
+앱 CPU: 80~90% (유일한 병목)
+```
+
+**다음 단계: ASG 수평 확장**
+
+스케일업(t3.xlarge) 대신 ASG를 선택한 이유:
+- vCPU 2→4개, 비용 4배 vs t3.small 2대 = vCPU 4개 + 비용 2배 + 가용성
+- 단일 인스턴스 SPOF 그대로 vs ASG로 SPOF 제거
+- 트래픽 변화에 따른 자동 조절 불가 vs Target Tracking으로 자동 스케일인/아웃
+
+---
+
+## 12. 설계 결정 근거
+
+### 공정성: Redis DECR 시점에 선착순 확정
+
+```
+sequence = totalStock - remaining
+```
+
+Kafka 파티션 여러 개를 써도 공정성이 깨지지 않는 이유:
+- 선착순 번호는 API 진입 시 DECR 시점에 원자적으로 확정됨
+- Kafka는 단순 전달 수단 (순서 보장 불필요)
+- Consumer 재정렬 버퍼 같은 복잡한 구조 불필요
+
+### Redis List를 Queue로 사용 (Redis Stream 미사용)
+
+Kafka가 이미 영속성/재처리/병렬화를 담당합니다.
+Redis Stream까지 도입하면 복잡도만 증가하고 실익이 없습니다.
+Redis List LPUSH/RPOP으로 충분한 버퍼링이 가능합니다.
+
+### Consumer: INSERT 직접 (PENDING UPDATE 방식 제거)
+
+v2: API에서 PENDING INSERT → Consumer가 SUCCESS UPDATE
+v3: API에서 INSERT 없음 → Consumer가 SUCCESS INSERT 직접
+
+v3가 나은 이유:
+- API 경로에서 DB 완전 제거 → HikariCP pending 해소
+- PENDING 레코드 없으니 Spring Batch 복구 로직 단순화
+- UNIQUE INSERT IGNORE로 멱등성 충분 보장
+
+### Kafka acks=all + min.ISR=2
+
+```
+acks=all: 모든 ISR 브로커가 메시지 저장 확인 후 응답
+min.ISR=2: ISR 2개 이상일 때만 쓰기 허용
+```
+
+3브로커 중 1대 장애 시에도 ISR=2 유지 → 데이터 유실 없음.
+
+### Spring Boot Virtual Thread 활용
+
+Virtual Thread(Java 21)로 스레드 풀 고갈 없이 수천 개 동시 요청 처리.
+1~3차 테스트에서 HikariCP 대기 시간이 30초에 달해도 서비스가 유지된 이유입니다.
+
+---
+
+*이 문서는 실험 → 측정 → 개선 사이클을 통해 데이터 기반으로 결정된 내용을 정리한 것입니다.*
+
+---
+
+## 13. 앞으로 할 작업 로드맵
+
+### Phase A — Auto Scaling Group ✅ 완료 (2026-04-27)
+
+**배경**: 7~8차 테스트에서 앱 CPU 80~90% 고착 확인. t3.small 단일 인스턴스 TPS 상한 ~1,220/s.
+스케일업(xlarge) 대신 ASG 수평 확장 선택 — 비용 효율 + SPOF 제거 + 탄력성.
+
+**완료된 작업:**
+- AMI 생성 (ami-01c64e7a84a57e681 — Docker/CodeDeploy 포함)
+- `infra/asg.tf` — Launch Template + ASG(min=2,max=3) + Target Tracking(CPU 60%, scale-in 비활성)
+- `infra/codedeploy.tf` — CodeDeploy import 후 ASG 연결 IaC화
+- `infra/vpc.tf` — private_app_2b 서브넷 추가 (multi-AZ)
+- 기존 단일 EC2 제거 (ALB 중복 등록 방지)
+- Prometheus EC2 Service Discovery 전환 (고정 IP → Name 태그 동적 감지, 2/2 UP)
+
+**결과**: ASG 2대 운영 중, CodeDeploy 배포 시 2대 순차 배포 확인.
+
+---
+
+### Phase B — 9차 부하 테스트: 100만 트래픽 (다음 작업)
+
+ASG 구성 완료 후 실행합니다.
+
+**테스트 설정:**
+```bash
+# 캠페인 생성 (재고 1,000,000)
+curl -X POST $BASE_URL/api/admin/campaigns \
+  -H "Content-Type: application/json" \
+  -d '{"name":"load-test-1M","totalStock":1000000,"startDate":"2026-04-27","endDate":"2026-12-31"}'
+
+# 테스트 실행
+CAMPAIGN_ID=<id> \
+TOTAL_REQUESTS=1200000 \
+MAX_VUS=3000 \
+DURATION=2400 \
+bash ~/1milion-campaign-orchestration-system/stress-test/run-test.sh prod
+```
+
+**검증 포인트:**
+- TPS: 단일 인스턴스 대비 인스턴스 수에 비례해서 향상되는지 (수평 확장 효과)
+- CPU: 인스턴스별 40% 수준 분산 여부
+- 정합성: SUCCESS = 1,000,000 정확히 일치 (재고 초과 발급 0건)
+- HikariCP pending: 거의 0 유지 (v3 효과 유지)
+- Redis Queue: 테스트 종료 후 0 수렴
+
+---
+
+### Phase C — API 엔드포인트 정리 (v3 기준 재정비)
+
+v1/v2 잔재 엔드포인트를 v3 아키텍처 기준으로 정리합니다.
+
+**주요 작업:**
+
+| 작업 | 내용 |
+|------|------|
+| 불필요한 컨트롤러 제거 | v1 LoadTestController, TestController, KafkaManagementController 등 정리 |
+| 폴링 API 개선 | `GET /api/campaigns/{id}/participation/{userId}/result` — Redis 캐시 우선, DB fallback |
+| 캠페인 상태 조회 API | 재고/상태 Redis 우선 조회 (DB 미접촉) |
+| Admin API 정리 | 캠페인 생성 시 Redis 초기화 (stock, total, active flag) 흐름 명확화 |
+| API 문서화 | Swagger/OpenAPI 또는 README에 엔드포인트 명세 정리 |
+
+---
+
+### Phase D — Spring Batch 안전망 구현
+
+v3에서 PENDING 레코드가 없어졌지만 Redis 장애 시 LPUSH 실패 → 유실 가능성에 대한 안전망이 필요합니다.
+
+**구현할 Job 2개:**
+
+#### 1. 재고 정합성 검증 Job (새벽 3시)
+```
+ItemReader:    캠페인별 (Redis stock 잔량) vs (totalStock - DB SUCCESS 건수) 비교
+ItemProcessor: 불일치 감지 시 Slack 알림 + 보정값 계산
+ItemWriter:    Redis stock 보정 (필요 시)
+```
+
+#### 2. Redis Queue 유실 복구 Job (5분 주기)
+```
+문제 상황: DECR은 됐는데 LPUSH 실패 → DB에 기록 없음 + Redis Queue에도 없음
+           sequence 번호는 할당됐으나 DB에 행 없는 상태
+
+ItemReader:    sequence 기준으로 DB에 없는 번호 탐지
+               (totalStock - Redis stock) - DB SUCCESS 건수 > 0 이면 유실 있음
+ItemProcessor: Redis Queue 재발행 가능 여부 판단 (캠페인 활성 여부)
+ItemWriter:    LPUSH 재적재 → Bridge → Kafka → Consumer INSERT
+```
+
+**기존 Batch (유지):**
+- `aggregateParticipationJob` — 새벽 2시, participation_history → campaign_stats 통계 집계
+
+---
+
+### Phase E — MCP 서버 (AI 자율 운영)
+
+`mcp-server/` 디렉터리에 Python/FastAPI 기반 AI 운영 서버를 구현합니다.
+
+**목표**: Claude가 Prometheus/Grafana 지표를 보고 자율적으로 운영 판단 + Slack 승인 후 실행
+
+**아키텍처:**
+```
+[Grafana Alert / Prometheus]
+    |
+    v
+[MCP Server — FastAPI on terraform-mcp EC2]
+    |-- Prometheus API 조회 (TPS, CPU, Queue 크기, Lag)
+    |-- 이상 감지 로직 (임계치 판단)
+    |-- Claude API 호출 → 원인 분석 + 조치 추천
+    |
+    v
+[Slack Webhook — 승인 요청]
+    |
+    | (승인 시)
+    v
+[AWS SDK 실행]
+    |-- ASG DesiredCapacity 조정 (스케일아웃/인)
+    |-- CodeDeploy 재배포 트리거
+    |-- Kafka 파티션 상태 확인
+    |-- DynamoDB에 감사 로그 기록 (무엇을/왜/누가 승인)
+```
+
+**MCP Tool 목록 (예정):**
+| Tool | 설명 |
+|------|------|
+| `get_metrics` | Prometheus에서 현재 TPS/CPU/Queue 조회 |
+| `analyze_bottleneck` | Claude에게 병목 원인 분석 요청 |
+| `scale_out` | ASG DesiredCapacity +1 (Slack 승인 필요) |
+| `scale_in` | ASG DesiredCapacity -1 (Slack 승인 필요) |
+| `redeploy` | CodeDeploy 재배포 트리거 |
+| `get_audit_log` | DynamoDB 감사 로그 조회 |
+
+**구현 스택:**
+- Python 3.11 + FastAPI
+- boto3 (AWS SDK)
+- anthropic SDK (Claude API)
+- prometheus_api_client
+
+---
+
+### 전체 로드맵 요약
+
+```
+[완료] v3 Redis-first 아키텍처 전환
+[완료] Kafka 3-broker KRaft 클러스터
+[완료] ElastiCache CME 3샤드
+[완료] 8차 테스트 (50만, TPS ~1,220/s, 정합성 완벽)
+
+[진행 중] Phase A — ASG Terraform 구성
+              codedeploy.tf + asg.tf + user-data-app.sh
+              기존 단일 EC2 제거 + Prometheus EC2 SD 전환
+
+[예정] Phase B — 9차 테스트 (100만, TPS ~2,400/s 기대)
+[예정] Phase C — API 엔드포인트 v3 기준 정리
+[예정] Phase D — Spring Batch 안전망 (재고 정합성 검증 + 유실 복구)
+[예정] Phase E — MCP 서버 (AI 자율 운영)
+```
+
+**최종 목표**: 100만 트래픽 처리 + AI가 자율적으로 운영 판단하는 시스템

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1019 +1,154 @@
 # 프로젝트 컨텍스트 — 1Million Campaign Orchestration System
 
 > 이 파일은 Claude Code 세션 시작 시 자동으로 로드됩니다.
-> 새 대화를 시작할 때 이 내용을 기반으로 바로 이어서 작업합니다.
+> 상세 설계: `ARCHITECTURE.md` 참고
 
 ---
 
 ## 프로젝트 개요
 
-v1(`event-driven-batch-kafka-system`, 10만 트래픽)을 기반으로
-v2(`1milion-campaign-orchestration-system`, 100만 트래픽 + AI 자율 운영)로 고도화하는 모노레포.
+선착순 캠페인 참여 시스템, 100만 트래픽 + AI 자율 운영 목표.
 
 - **레포**: https://github.com/hskhsmm/1milion-campaign-orchestration-system
 - **담당자**: 데브옵스 직무 취준생, 면접 준비 중
-- **설계 문서**: `DESIGN_GUIDE_V2.md` (루트)
 
 ---
 
 ## 레포 구조
 
 ```
-app/campaign-core/     ← Spring Boot 앱 (v1 코드 + Kafka 수동 관리 전환 완료)
-infra/                 ← Terraform (Phase 1 진행 중 — v1 기존 리소스 import 완료)
-mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase 3, 미작성)
+app/campaign-core/     ← Spring Boot 앱 (v3 Redis-first)
+infra/                 ← Terraform IaC
+mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase E, 미작성)
 stress-test/           ← k6 부하 테스트 스크립트
-.github/workflows/     ← deploy.yml (루트에 있어야 GitHub Actions 인식)
+.github/workflows/     ← deploy.yml
 ```
 
 ---
 
-## v1 현황 (app/campaign-core 현재 코드)
+## v3 아키텍처 (현재 코드)
 
-### 달성한 것
-- Redis Lua DECR 원자적 즉시컷 (`stock:campaign:{campaignId}`)
-- Kafka 파티션 1개 + concurrency=1 → violation_count=0 (완벽한 순서 보장)
-- DB 원자적 UPDATE (`WHERE current_stock > 0`) 이중 안전망
-- DLQ 토픽으로 Consumer 실패 격리
-- Spring Batch 새벽 2시 통계 집계 (participation_history → campaign_stats)
-- GitHub Actions → ECR → S3 → CodeDeploy Blue-Green CI/CD
-- SSH 차단 + SSM Session Manager + Parameter Store
-
-### 최근 변경 (2026-03-27)
-- **Kafka 수동 파티션 관리 전환**: `KafkaTopicService` 삭제, `KafkaAdmin` Bean 제거
-  - 이유: 서버 기동 시 Kafka 브로커 연결 필수 → 로컬/테스트 환경 불편
-  - 토픽 생성은 Kafka CLI로 수동 관리 (`kafka-topics.sh --create`)
-  - `KafkaConfig.java`에서 `KafkaAdmin`, `NewTopic` 빈 제거
-  - `LoadTestService`에서 `KafkaTopicService` 의존성 제거
-- **모니터링 추가**: `micrometer-registry-prometheus` 의존성 추가 (build.gradle)
-  - `/actuator/prometheus` 엔드포인트 노출 → Prometheus 수집 예정
-
-### 실험 결과 (핵심)
-| 파티션 | DB TPS | switch_ratio | violation_count |
-|--------|--------|--------------|-----------------|
-| 1개    | 278    | 0            | 0               |
-| 3개    | 505    | 0.0023       | 0               |
-| 5개    | 595    | 0.0018       | 0               |
-
-- Redis 도입 전: 파티션 늘려도 TPS ~285 수렴 → 원인: MySQL Row Lock 경합
-- Redis 도입 후: 파티션 5개에서 2.1배 향상 확인
-- 최종 선택: **파티션 1개** (공정성 우선)
-
-### v1 한계
-1. 단일 파티션 → 278 TPS 상한, 100만 트래픽 불가
-2. Consumer에서 Redis DECR + DB 쓰기 → 핵심 흐름이 v2와 다름
-3. Kafka 단일 브로커 SPOF
-4. Redis 단일 인스턴스 SPOF
-5. 인프라 수동 관리 (IaC 없음)
-6. PENDING 선점 구조 없음 (장애 복구 기준점 없음)
-7. RateLimitService 없음
-8. Bridge/Queue 패턴 없음
-
----
-
-## v2 핵심 설계 결정 (확정)
-
-### 공정성 보장 방식 (가장 중요)
-```
-현재(v1): Kafka 단일 파티션으로 처리 순서 = 선착순
-v2:       Redis DECR 시점에 선착순 확정 → Kafka 순서 무관
-          sequence = totalStock - remaining (원자적 할당)
-```
-
-**왜 Consumer 재정렬(INCR + Reorder Buffer) 방식보다 나은가:**
-- Head-of-line Blocking 없음
-- Consumer 단순화 (재정렬 버퍼 불필요)
-- 재고 소진 요청은 API 진입 시점 즉시 컷 (Kafka 진입 없음)
-- Redis 키 하나로 sequence + stock 동시 처리
-
-### v2 처리 흐름
 ```
 POST /api/campaigns/{id}/participation
-  1. RateLimitService (SET NX EX 10, 10초 내 동일 요청 차단)
-  2. Redis DECR → remaining < 0이면 보상 INCR + 즉시 400
-  3. sequence = totalStock - remaining (선착순 번호 원자적 확정)
-  4. DB PENDING INSERT → historyId 획득 (자리 선점, 지수 백오프 재시도 3회)
-     - DuplicateKeyException + 같은 sequence → 기존 historyId 반환
-     - DuplicateKeyException + 다른 sequence → 보상 INCR + 409
-     - INSERT 실패(DB 장애) → 재시도, MAX_RETRY 소진 시 보상 INCR + 503
-  5. Redis Queue LPUSH (queue:campaign:{id}) → 실패 시 Spring Batch 안전망
-  6. 202 반환
+  1. RateLimitService     SET NX EX 10
+  2. Redis Lua            SISMEMBER + DECR + GET total (check-decr-total.lua)
+     remaining < 0  → 보상 INCR + 400
+     remaining == 0 → DB CLOSED + active flag DEL
+  3. sequence = total - remaining (선착순 확정)
+  4. RedisQueueService    LPUSH queue:campaign:{id}
+  5. 202 반환 (DB 미접촉)
 
 ParticipationBridge (@Scheduled 100ms)
-  → active:campaigns 순회 → RPOP batchSize개 → Kafka 발행
-
-Kafka Consumer (10 파티션)
-  → historyId PK로 PENDING 조회 → SUCCESS/FAIL UPDATE만
-```
-
-### Kafka 메시지 구조 (v2)
-```json
-{ "campaignId": 13, "userId": 1042, "historyId": 101868 }
-```
-- historyId 포함 → Consumer가 O(1) PK 조회
-- sequence 불포함 → DECR 반환값(잔여재고)이 이미 순번
-
----
-
-## v2 구현 TODO (이슈 기준)
-
-### #2 선행 — 공통 인터페이스 확정 ✅ 완료 (B파트에서 처리)
-- [x] `ParticipationStatus.java` — PENDING 추가
-- [x] `ParticipationHistory.java` — sequence 필드, PENDING 생성자 추가
-- [x] `ParticipationEvent.java` — historyId 필드 추가
-- [x] `db/migration/V2__add_sequence_to_participation_history.sql` — Flyway 마이그레이션
-- Redis Queue 키 형식: `queue:campaign:{campaignId}` 확정
-
-### #3 A파트 — API 진입 ~ Queue 적재 (leepg 담당) ✅ 완료 (2026-04-13, PR 올리기 전)
-
-#### ✅ 완료
-- [x] `RateLimitService` 신규 — SET NX EX 10, 키: `ratelimit:campaign:{id}:user:{userId}`
-- [x] `RedisQueueService` 신규 — Lua LLEN+LPUSH 원자적 실행, MAX_QUEUE_SIZE=100,000
-- [x] `scripts/push-queue.lua` 신규 — LLEN 체크 후 LPUSH, 100,000 초과 시 return 0
-- [x] `RedisStockService` v2 전환 — Lua DECR 제거 → 단순 DECR + `incrementStock()` 보상 INCR 추가
-- [x] `RedisConfig` 정리 — `decreaseStockScript` Bean 제거, `pushQueueScript` Bean 추가
-- [x] `CampaignService` — 캠페인 생성 시 `SADD active:campaigns` 추가 (Bridge 인식용)
-- [x] `ParticipationHistory` — PENDING 생성자 `sequence` 파라미터 추가
-- [x] `V3__add_unique_constraint_campaign_user.sql` — (campaign_id, user_id) UNIQUE 제약 추가
-- [x] `ErrorCode` 추가 — RATE_LIMIT_EXCEEDED(429), STOCK_EXHAUSTED(400), PARTICIPATION_SERVICE_UNAVAILABLE(503), DUPLICATE_PARTICIPATION(409)
-- [x] 예외 클래스 4개 신규 — `RateLimitExceededException`, `StockExhaustedException`, `DuplicateParticipationException`, `ParticipationServiceUnavailableException`
-- [x] `ParticipationService` 전면 재작성 — RateLimit → DECR → PENDING INSERT → LPUSH → 202
-  - `@Transactional` 제거: `save()` 즉시 커밋 → LPUSH는 반드시 커밋 이후 실행 보장
-  - DuplicateKeyException sequence 비교로 TTL 만료 재요청 vs 동일 요청 구분
-  - INSERT 실패 시 exponential backoff 재시도 (200ms → 400ms, 최대 3회)
-  - 보상 INCR 3경로 모두 처리 (재고 소진 / DuplicateKey 다른 sequence / MAX_RETRY 소진)
-- [x] `ParticipationController` — 200 OK → 202 Accepted
-
-### #4 B파트 — Queue 소비 ~ DB 최종 기록 (hskhsmm 담당) ✅ 코드 완료
-
-> 설계 문서: `A파트_장애시나리오_설계_v4.pdf` (루트)
-> PR #34 (feat/test-infra-setup), PR #35 (refactor/phase-part-A) → main 머지 완료 (2026-04-20)
-> 현재 브랜치: refactor/phase-part-A
-
-#### ✅ 완료
-- [x] `ParticipationStatus.java` — PENDING 추가
-- [x] `ParticipationHistory.java` — sequence 필드, PENDING 생성자 추가
-- [x] `ParticipationEvent.java` — historyId 필드 추가
-  - **버그 수정 (2026-04-19)**: `campaignId`, `userId` setter 추가 — Jackson 역직렬화 시 null 되어 `writeResultCache` 캐시 키 `participation:result:null:null` 오동작 수정
-- [x] `ParticipationHistoryRepository.java` — bulkUpdateSuccess(AND status=PENDING 멱등성), findByCampaignIdAndUserId 추가
-- [x] `ParticipationEventConsumer.java` — v2 전면 재작성 + Redis 결과 캐시 + Slack 연동 + fallbackIndividual
-- [x] `SlackNotificationService.java` — 신규 생성
-- [x] `ParticipationBridge.java` — 신규 작성
-  - @Scheduled(fixedDelay=100ms), active:campaigns 순회, RPOP
-  - **큐 크기 기반 동적 batchSize (2026-04-19)**: < 10,000 → 500 / < 100,000 → 1,000 / >= 100,000 → 2,000
-  - MAX_RETRY 3회 + exponential backoff (200ms→400ms), DLQ+Slack
-  - 파티션 키: String.valueOf(campaignId), LPUSH 재적재 금지
-- [x] `PollingController.java` — 신규 작성
-  - GET /api/campaigns/{campaignId}/participation/{userId}/result
-  - Redis cache 우선 → DB fallback
-- [x] `CampaignCoreApplication.java` — @EnableScheduling 추가
-- [x] `application-prod.yml` — 3-broker 플레이스홀더, partitions=10, replication-factor=3, slack.webhook-url 추가
-- [x] `application-local.yml` — slack.webhook-url 추가
-
-#### 📌 배포 전 AWS 작업 (인프라 올릴 때)
-- Slack Incoming Webhook URL 발급 → SSM `/batch-kafka/prod/SLACK_WEBHOOK_URL` 등록
-- SSM에 `KAFKA_BROKER_1`, `KAFKA_BROKER_2`, `KAFKA_BROKER_3` 등록 (3-broker 구성 후)
-
-### #5 Redis 클러스터링 — ElastiCache Cluster 모드 전환 (hskhsmm 담당) ✅ 코드 완료 (2026-04-25)
-
-#### ✅ 완료
-- [x] `scripts/check-and-decr.lua` 삭제 — v3에서 미사용 dead code
-- [x] `scripts/check-decr-total.lua` — CROSSSLOT 해결: `active:campaigns`(전역 Set) → `active:campaign:{id}`(해시태그 플래그)로 교체, `SISMEMBER`→`EXISTS`, `SREM`→`DEL`
-- [x] `RedisConfig.java` — `checkAndDecrScript` Bean 제거
-- [x] `RedisStockService.java` — 키 해시태그 추가 (`stock:campaign:{id}`, `total:campaign:{id}`), `getActiveFlagKey()` 신규, `activateCampaign()`/`deactivateCampaign()` 전역 Set + 플래그 둘 다 처리, `isActive()` 신규
-- [x] `CampaignService.java` — `redisTemplate` 직접 의존 제거, `activateCampaign()` 위임
-- [x] `ParticipationBridge.java` — RPOP null 시 `isActive()` 확인 → `deactivateCampaign()` cleanup (Known Issue 해결)
-- [x] `docker-compose.yml` — 단일 redis → redis-1/2/3 + redis-cluster-init (3노드 로컬 클러스터)
-- [x] `application-local.yml` — `cluster.nodes: localhost:7001,7002,7003` 추가 (로컬 표준은 compose 실행)
-- [x] `application-prod.yml` — `host/port` → `cluster.nodes: ${SPRING_DATA_REDIS_CLUSTER_NODES}`
-- [x] `deploy/scripts/beforeInstall.sh` — `SPRING_DATA_REDIS_HOST` → `SPRING_DATA_REDIS_CLUSTER_NODES`, `REDIS_EXPORTER_ADDR`, `SLACK_WEBHOOK_URL` 추가
-- [x] `deploy/docker-compose.prod.yml` — redis-exporter `REDIS_ADDR` SSM 주입, `REDIS_EXPORTER_IS_CLUSTER: "true"` 추가
-- [x] `infra/elasticache.tf` — CME 3샤드 1레플리카 + AOF 커스텀 파라미터 그룹 (`valkey7-cluster-aof`)
-
-#### ✅ 코드리뷰 반영 완료 (2026-04-25)
-- [x] `infra/elasticache.tf` — `aws_ssm_parameter` 2개 추가: terraform apply 시 SSM 자동 등록
-  - `/batch-kafka/prod/SPRING_DATA_REDIS_CLUSTER_NODES` — configuration endpoint 기반 자동 생성
-  - `/batch-kafka/prod/REDIS_EXPORTER_ADDR` — 동일
-  - `lifecycle { ignore_changes = [value] }` — 수동 업데이트 보호
-- [x] `infra/elasticache.tf` — `output "redis_configuration_endpoint"` 추가
-- [x] `docker-compose.yml` — `redis-cluster-init` idempotent 처리: 클러스터 존재 시 create 생략
-- [x] `application-local.yml` — IDE 직접 실행 불가 이유 주석 추가 (cluster redirect 문제)
-
-#### ✅ terraform apply 완료 (2026-04-26)
-- CMD → CME 전환은 in-place 불가 → `terraform destroy -target=...redis` 후 신규 생성
-- AOF 커스텀 파라미터 그룹 제거: ElastiCache CME에서 appendonly 파라미터 수정 불가 (AWS 자체 관리)
-  - 로컬 docker-compose.yml은 `--appendonly yes` 유지
-  - `default.valkey7.cluster.on` 기본 그룹 사용 (Valkey는 standalone/CME 모두 family `valkey7` 하나)
-  - `valkey7.cluster.on` family는 존재하지 않음 — AWS CLI describe-cache-parameter-groups로 확인
-- SSM null 조건 처리 추가: plan 시 configuration_endpoint_address null 에러 방지
-- ElastiCache CME 3샤드 1레플리카 생성 완료
-  - SSM `/batch-kafka/prod/SPRING_DATA_REDIS_CLUSTER_NODES` 자동 등록 ✅
-  - SSM `/batch-kafka/prod/REDIS_EXPORTER_ADDR` 자동 등록 ✅
-- 비용: cache.t3.micro × 6개 (3샤드 × primary+replica) — 단일 노드 대비 약 6배
-  - 작업 후 비용 절감 시: `terraform destroy -target=aws_elasticache_replication_group.redis`
-
-#### 📌 남은 작업
-- `/batch-kafka/prod/SPRING_DATA_REDIS_HOST` SSM 삭제 (구 단일 노드 키, 앱에서 미사용)
-- feature/redis-cluster → develop → main 머지 → CI/CD 재배포
-
-### #6 Kafka 3-broker (hskhsmm 담당) ✅ 완료 (2026-04-26)
-- [x] EC2 kafka-2 (172.31.16.164, public_2b), kafka-3 (172.31.32.164, public_2c) 추가 — `ec2.tf`
-- [x] Kafka SG self-ingress 추가 (9092 브로커 내부, 9094 controller quorum) — `security_groups.tf`
-- [x] RDS slow query 파라미터 그룹 (`aws_db_parameter_group.slow`) — `rds.tf`
-- [x] `application-prod.yml` — 10파티션 3브로커 기준 설정 반영 (max-poll-records: 100, buffer-memory: 512MB 등)
-- [x] kafka-2, kafka-3 브로커 직접 설치 및 KRaft 3브로커 클러스터 구성
-  - cluster.id: 9CA3K977Q5GdJDSdlKZVEw, MaxFollowerLag: 0 (브로커 전체 정상)
-- [x] 토픽 campaign-participation-topic — PartitionCount: 10, ReplicationFactor: 3, min.insync.replicas=2
-- [x] SSM `SPRING_KAFKA_BOOTSTRAP_SERVERS` 3브로커 값으로 업데이트
-
-### Spring Batch v2 PENDING 재처리 (A/B 머지 + 인프라 구성 후)
-- [ ] ItemReader: 5분 초과 PENDING 조회
-- [ ] ItemProcessor: Redis Queue 재발행 가능 여부 판단
-- [ ] ItemWriter: 재발행 성공 → 유지, 실패 → FAIL UPDATE
-
-### 모니터링 — #22~#25 (진행 중)
-
-> 진행 순서: 로컬 인프라 구성 → 커스텀 메트릭 코드 → Grafana 대시보드 + k6 검증 → AWS 반영
-> 작업 브랜치: `feature/monitoring`
-
-#### #22 로컬 모니터링 인프라 ✅ 완료 (2026-04-15, leepg)
-- [x] `docker-compose.yml` — kafka-exporter(:9308), redis-exporter(:9121), Prometheus(:9090), Grafana(:3000) 추가
-  - kafka-exporter: 내부 리스너 `kafka:29092` 사용 (컨테이너 내부 통신이므로 외부 9092 아님)
-  - 포트는 `.env` 변수로 분리, 모든 모니터링 서비스 `campaign-net` 네트워크 포함
-- [x] `monitoring/prometheus.yml` — spring-boot(app:8080), kafka-exporter(9308), redis-exporter(9121) 3개 타겟
-- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — 기동 시 자동 프로비저닝, `editable: false`
-- [x] `.env` — KAFKA_EXPORTER_PORT, REDIS_EXPORTER_PORT, PROMETHEUS_PORT, GRAFANA_PORT, GRAFANA_USER, GRAFANA_PASSWORD 추가
-- 로컬 검증 완료: `localhost:9090/targets` 3개 모두 UP
-
-#### #23 커스텀 비즈니스 메트릭 ✅ 완료 (2026-04-15, leepg)
-- [x] `ParticipationBridge.java` — `bridge.drain.duration` (Timer, drainQueues() 전체 소요시간), `bridge.messages.published` (Counter, campaignId 태그)
-  - Timer는 Spring Bean 아니므로 생성자 수동 작성 (`MeterRegistry` 주입 후 Timer 초기화)
-- [x] `ParticipationEventConsumer.java` — `consumer.pending_to_success.latency` (Timer, 배치 내 가장 오래된 createdAt 기준)
-- [x] `QueueMetricsScheduler.java` 신규 — `redis.queue.size` (Gauge, campaignId 태그, 10초 주기)
-  - `ConcurrentHashMap<Long, Long>` + `computeIfAbsent`로 신규 캠페인 최초 발견 시에만 Gauge 등록, 이후 Map 값만 갱신
-- 로컬 검증 완료: `/actuator/prometheus` 커스텀 메트릭 4종 수집 확인
-  - `bridge_drain_duration_seconds` — count=5062, sum=18.77s
-  - `bridge_messages_published_total{campaignId="1"}` — 1.0
-  - `consumer_pending_to_success_latency_seconds` — count=1, sum=2.683s
-  - `redis_queue_size{campaignId="1"}` — 0.0 (큐 소진 정상)
-
-#### 📌 #22/#23 코드리뷰에서 발견된 알려진 이슈 → 모두 수정 완료 (2026-04-17)
-- **[완료]** `spring.task.scheduling.pool.size: 2` — `application-local.yml` 추가
-- **[완료]** `.env` `KAFKA_BOOTSTRAP_SERVERS=kafka:29092` — 이미 올바른 값으로 존재 확인
-- **[잔존]** `consumer.pending_to_success.latency` Timer 배치 대표값 1회 기록 → 추후 개선 권장
-
-#### #24 Grafana 대시보드 구성 + k6 부하 검증 ✅ 완료 (2026-04-17, hskhsmm)
-- [x] 알려진 이슈 수정: 스케줄러 스레드 풀 설정 (`application-local.yml`)
-- [x] `monitoring/grafana/dashboards/campaign.json` — 13개 패널 구성
-  - 패널 1~10: API TPS/p95/p99/에러율, Bridge, Redis Queue, Consumer 지연, Kafka Lag, Redis 메모리 (기존)
-  - 패널 11: HikariCP 커넥션 풀 4종 (pending/active/idle/max), pending 라인 빨간색 강조
-  - 패널 12: HikariCP 활성율 (active/max), thresholds 0.7=yellow/0.95=red (color.mode: thresholds)
-  - 패널 13: CPU 사용률, thresholds 0.7=yellow/0.85=red (color.mode: thresholds)
-  - **수정**: 패널 9 Consumer Group명 `campaign-group` → `campaign-participation-group` (KafkaConfig.java 실제 값)
-- [x] `monitoring/grafana/provisioning/dashboards/dashboard.yml` — 자동 프로비저닝 설정
-- [x] `monitoring/grafana/provisioning/datasources/prometheus.yml` — `uid: prometheus` 고정 (dashboard.json UID 매칭)
-- [x] `docker-compose.yml` — JVM `MaxMetaspaceSize` 128m → 256m 상향 (OOM 방지)
-- [x] `stress-test/k6-load-test.js` — `__ITER` → `exec.scenario.iterationInTest` 교체 (VU 간 userId 중복 방지)
-- [x] k6 로컬 검증 완료 (VU=10, 300 요청, 100% 202 성공)
-- [x] Grafana 실시간 수집 확인
-  - API TPS, p95/p99 응답시간(85~130ms), 에러율 0 ✅
-  - Bridge 드레인 속도, 사이클 소요시간(2~10ms) ✅
-  - `redis_queue_size` 0 수렴 ✅ ← 핵심 완료 기준
-- 트러블슈팅 기록:
-  - Grafana datasource UID 불일치 → provisioning yml에 `uid: prometheus` 고정으로 해결
-  - k6 `__ITER` per-VU 문제 → 전역 iterationInTest 사용으로 해결
-  - JVM Metaspace OOM (좀비 현상) → MaxMetaspaceSize 256m으로 해결
-
-#### #24-추가 모니터링 코드 보완 ✅ 완료 (2026-04-20, leepg)
-- [x] `ParticipationService.java` — `[TIMING]` 로그 추가 (`DB_INSERT`, `REDIS_PUSH`, `TOTAL` ms 단위)
-  - DB_INSERT = HikariCP 대기 + SQL 실행 시간 합산 → 병목 진단 핵심 지표
-- [x] `build.gradle` — `micrometer-registry-cloudwatch2` 의존성 추가
-  - `application-prod.yml` cloudwatch.enabled: true인데 의존성 없으면 Spring Boot가 조용히 무시함
-  - EC2 IAM `CloudWatchAgentServerPolicy`로 IAM 권한은 기존에 충족
-- [x] `application-prod.yml` — `metrics` 액추에이터 엔드포인트 노출 추가 (CLI 디버깅용)
-- [x] `application-prod.yml` — `spring.task.scheduling.pool.size: 2` 추가
-  - 기본값 1 → Bridge(100ms)가 QueueMetricsScheduler(10s)를 기아시켜 `redis_queue_size` 지표 누락 방지
-- [x] `application-local.yml` — 죽은 설정 `spring.kafka.consumer.group-id: campaign-group` 제거
-  - KafkaConfig.java가 `campaign-participation-group` 하드코딩으로 덮어씌우므로 무의미
-- [x] RDS slow query 파라미터 그룹 설정 (AWS 콘솔)
-  - `mysql8.0` family 신규 파라미터 그룹 생성, `slow_query_log=1`, `long_query_time=0.5`, `log_output=TABLE`
-  - RDS 인스턴스 파라미터 그룹 교체 + 재부팅 후 적용 확인
-
-#### #25 AWS 모니터링 인프라 반영 — terraform (hskhsmm 담당) 🔄 진행 중 (2026-04-18)
-
-##### ✅ 완료
-- [x] `ec2.tf` — terraform-mcp-sg에 9090(Prometheus)/3000(Grafana) ingress 추가
-- [x] `security_groups.tf` — app-sg에 8080/9121(redis-exporter) from terraform-mcp-sg ingress 추가
-- [x] `security_groups.tf` — kafka-sg에 9092 from terraform-mcp-sg ingress 추가
-- [x] `elasticache.tf` — Valkey 단일 노드 (`aws_elasticache_replication_group`) 생성 완료
-  - engine: valkey 7.2, cache.t3.micro, replication_group_id: batch-kafka-redis
-  - 엔드포인트: `batch-kafka-redis.3uttxb.ng.0001.apn2.cache.amazonaws.com`
-  - SSM `/batch-kafka/prod/SPRING_DATA_REDIS_HOST` 등록 완료
-- [x] `iam.tf` — GitHub Actions SSM 경로 `/campaign/prod` → `/batch-kafka/prod` 통일 + PutParameter 권한 추가
-- [x] `beforeInstall.sh` — SSM 경로 `/batch-kafka/prod/*` 통일
-- [x] `deploy.yml` — ECR_IMAGE SSM 경로 `/batch-kafka/prod/ECR_IMAGE` 통일
-- [x] `docker-compose.prod.yml` — t3.small 기준 JVM 메모리 수정 (mem_limit 1500m, Xmx1g)
-- [x] `application-prod.yml` — Kafka bootstrap-servers 환경변수명 SSM 키와 통일
-- [x] EC2 3대 + RDS start 완료
-- [x] terraform apply 완료 (ElastiCache Valkey, SG, IAM 반영)
-- [x] terraform-mcp SSM 접속 → Docker 설치 완료
-- [x] terraform-mcp — Prometheus + Grafana + kafka-exporter 컨테이너 실행 완료
-  - prometheus.yml: spring-boot(172.31.100.157:8080), kafka-exporter(localhost:9308), redis-exporter(172.31.100.157:9121)
-  - grafana datasource: prometheus uid 고정 (http://172.31.15.217:9090)
-- [x] `ec2.tf` — batch-kafka-app, kafka-1 `associate_public_ip_address = true` 수정 + `private_ip` 고정
-- [x] `ec2.tf` — EC2 3대 `lifecycle.ignore_changes = [associate_public_ip_address]` 추가 (stopped 상태 시 terraform plan drift 방지)
-  - batch-kafka-app: `172.31.100.157`, kafka-1: `172.31.5.164`
-  - 재생성 후에도 private IP 고정 → prometheus.yml 수정 불필요
-- [x] terraform apply 완료 — batch-kafka-app, kafka-1 재생성 (퍼블릭 IP 할당)
-- [x] kafka-1 SSM 접속 → Docker 설치 + Kafka 브로커 시작 + 토픽 2개 생성
-- [x] batch-kafka-app SSM 접속 → Docker + CodeDeploy 에이전트 설치
-- [x] `docker-compose.prod.yml` — redis-exporter 추가 (CI/CD 시 자동 실행, 포트 9121)
-- [x] terraform-mcp — kafka-exporter 정상 연결 확인 (Up 상태)
-
-##### CI/CD 트러블슈팅 기록 (2026-04-18)
-- ECR 레포명 `campaign-core` → `batch-kafka-system` 수정
-- S3 버킷명 `campaign-deploy-` → `batch-kafka-deploy-` 수정
-- CodeDeploy 앱명 `campaign-core-app` → `batch-kafka-app`, 배포그룹 `campaign-prod-dg` → `batch-kafka-prod-dg` 수정
-- `deploy.yml` paths에 `.github/workflows/**` 추가 (workflow 변경 시 CI/CD 트리거)
-- `flyway-core` 의존성 누락 추가 (`flyway-mysql`만으로는 Flyway 미실행)
-- DB 완전 초기화 후 `V1__init.sql` 없어서 `missing table [campaign]` 오류 → V1 마이그레이션 추가
-- Spring Boot 4에서 `spring.batch.jdbc.initialize-schema` 제거됨 → `V4__batch_schema.sql` Flyway로 추가
-- `iam.tf` S3 버킷 권한 `batch-kafka-deploy-` 로 수정 + terraform apply
-- `baseline-version: 1` → `0` 수정 (V1 베이스라인으로 인식해서 V1__init.sql 건너뛰던 문제)
-- `applicationStart.sh` — `docker-compose down` 먼저 실행 (포트 8080 충돌 방지)
-- Flyway 로그 미출력 문제 → DB `show tables` 직접 확인으로 정상 실행 확인 (13개 테이블 생성 완료)
-
-##### ✅ 완료 (2026-04-18)
-- [x] Flyway 정상 실행 확인 — DB에 campaign, participation_history, BATCH_* 등 13개 테이블 생성 확인
-- [x] CI/CD 배포 성공 → `/actuator/health` UP 확인
-- [x] Prometheus targets 3개 UP — kafka-exporter 컨테이너 IP(172.17.0.3) 이슈 해결
-  - prometheus.yml `localhost:9308` → `172.17.0.3:9308` 수정 (`/home/ec2-user/prometheus.yml` 마운트)
-  - terraform-mcp 재시작 시 자동 반영 (`--restart unless-stopped` + 볼륨 마운트)
-- [x] Grafana 대시보드 import 완료 (`campaign.json` 수동 import)
-- [x] k6 ALB 부하 테스트 완료 → 1차 성능 측정 결과 확보
-
-##### 📌 인프라 메모
-- ElastiCache는 Valkey 사용 (Redis보다 약 20% 저렴, 클러스터링 전환 시도 유지)
-- 퍼블릭 IP는 EC2 running 시 무료 (EIP 아님), stop 시 자동 반납
-- 프라이빗 IP는 재시작해도 고정 → prometheus.yml 수정 불필요
-- instance ID로 SSM 접속하므로 퍼블릭 IP 변경 무관
-- 비용 절약: EC2/RDS 콘솔 stop, ElastiCache는 `terraform destroy -target=aws_elasticache_replication_group.redis`
-
-
-### 로컬 통합 테스트 결과 (2026-04-19, A+B파트 머지 후)
-
-#### 검증 항목 및 결과
-| 항목 | 결과 |
-|------|------|
-| SUCCESS 100건 (totalStock=100, 200건 요청) | ✅ |
-| sequence 중복 | 0건 ✅ |
-| RateLimit 429 (동일 userId 10초 내 재요청) | ✅ |
-| 재고 소진 400 | ✅ |
-| result 캐시 키 (`participation:result:{userId}:{campaignId}`) | ✅ (setter 버그 수정으로 정상화) |
-
-#### 수정된 버그
-- `ParticipationEvent.java` — `campaignId`, `userId` setter 누락 → Jackson 역직렬화 시 null, writeResultCache 키가 `participation:result:null:null`로 고정되는 버그
-
-#### Known Issue — 재고 소진 시 큐 잔류 (설계 허용 범위)
-- 흐름: `remaining == 0` → Lua `SREM active:campaigns` 즉시 실행 → 큐에 잔류 메시지 Bridge 드레인 불가
-- 안전망: Spring Batch `pendingRecoveryJob`이 5분 초과 PENDING 재처리 → 결국 SUCCESS
-- 해결 시점: 1순위 코드 개선 "캠페인 자동 종료 + SISMEMBER" 항목에서 처리 예정
-
-#### HikariCP prod 설정 수정 (2026-04-19)
-- 원인: `SPRING_PROFILES_ACTIVE: prod`만 활성화 → `maximum-pool-size` 미설정 → HikariCP 기본값 **10** 적용
-- 결과: AWS 1차 테스트 avg 3.94s / max 18.4s의 주요 원인 중 하나
-- 수정: `application-prod.yml`에 `maximum-pool-size: 20`, `minimum-idle: 10` 추가
-- p2/p3 프로필은 기존 설정(25/30) 유지 (파티션 증가 시 덮어씌움)
-
----
-
-### 1차 부하 테스트 결과 (2026-04-18, AWS 환경)
-
-#### 테스트 환경
-- 앱: batch-kafka-app t3.small 단일 인스턴스
-- DB: batch-kafka-db db.t3.micro (MySQL 8.0.44)
-- Redis: ElastiCache Valkey 단일 노드
-- Kafka: kafka-1 단일 브로커, 파티션 1개
-- ALB: alb-batch-kafka-api
-
-#### k6 설정
-- TOTAL_REQUESTS: 15,000 (재고 10,000 초과 시나리오)
-- MAX_VUS: 1,000
-- DURATION: 60s
-
-#### 결과
-
-| 지표 | 값 |
-|------|-----|
-| TPS | **246/s** |
-| avg latency | 3.94s |
-| p95 | 6.34s |
-| max | 18.4s |
-| 성공 (202) | **9,990건** |
-| 재고 초과 차단 (400) | 5,010건 |
-| 재고 초과 발급 | **0건** ← 정합성 완벽 |
-
-#### Grafana 확인 결과
-- Bridge 드레인 속도: 피크 180 req/s, API TPS와 동일하게 움직임 → 정상
-- Bridge 드레인 사이클: 피크 450ms → 감당 가능
-- Redis Queue 피크: 15개 수준 → 거의 즉시 소비
-
-#### 병목 분석
-- **병목 위치**: HikariCP 커넥션 풀 고갈 (pool-size=10, 기본값) — INSERT SQL 자체는 빠름
-- Bridge/Queue/Consumer는 병목 아님
-- Virtual Thread(Spring Boot 4) 덕분에 스레드 풀 고갈 없이 대기 처리 → max 18.4s에도 시스템 유지
-- HikariCP 기본 타임아웃 30s 이내 처리되어 타임아웃 에러 없음
-- 이후 `application-prod.yml`에 `maximum-pool-size: 20` 추가 (2026-04-19)
-
-#### 성능 개선 방향 (설계 철학: 공정성·정합성 우선)
-- PENDING INSERT는 API 경로 유지 (장애 복구 기준점 — 빼면 Spring Batch 복구 불가)
-- DB 스케일: RDS Proxy + Aurora 전환 (MySQL 대비 write TPS 최대 5배, 코드 변경 없음)
-- Consumer 병렬화: Kafka 10파티션 + Consumer 10개 → SUCCESS UPDATE 선형 확장
-- Redis: ElastiCache Cluster 3샤드 → TPS 향상 아님, 가용성(SPOF 제거) 목적
-
-### 2차 부하 테스트 결과 (2026-04-20, AWS 파티션 1 — HikariCP 20 적용)
-
-#### 테스트 환경 (1차와 동일)
-- 앱: batch-kafka-app t3.small 단일 인스턴스
-- DB: batch-kafka-db db.t3.micro (MySQL 8.0.44, gp3 IOPS 3,000)
-- Redis: ElastiCache Valkey 단일 노드
-- Kafka: kafka-1 단일 브로커, 파티션 1개
-- ALB: alb-batch-kafka-api
-
-#### k6 설정
-- TOTAL_REQUESTS: 15,000 (재고 15,000 = 전량 202 시나리오)
-- MAX_VUS: 1,000
-- DURATION: 60s
-
-#### 결과
-
-| 지표 | 1차 (pool=10) | 2차 (pool=20) | 변화 |
-|------|---------------|---------------|------|
-| TPS | 246/s | **275/s** | +12% |
-| avg latency | 3.94s | **3.54s** | -10% |
-| p95 | 6.34s | **5.71s** | -10% |
-| max | 18.4s | **15.4s** | -16% |
-| 성공 (202) | 9,990건 | **15,000건** | 100% |
-| 재고 초과 발급 | 0건 | **0건** | 정합성 유지 |
-
-#### Grafana 확인 결과
-- HikariCP pending 피크: **950** (pool=20임에도 여전히 포화)
-- HikariCP active/max: **100%** 지속 → 풀이 여전히 부족
-- RDS CPU: **7.27%** (DB 서버 측 여유 충분)
-- WriteIOPS: **189/s** (gp3 3,000 IOPS 대비 6% 수준)
-- DiskQueueDepth: **0.46** (임계치 아님)
-- Slow query log: **비어있음** (0.5s 기준, SQL 자체는 빠름)
-
-#### 확정 병목 분석 — HikariCP 커넥션 대기 (5가지 근거)
-
-| 근거 | 데이터 | 결론 |
-|------|--------|------|
-| TIMING 로그 (tail, 테스트 말미 저VU) | DB_INSERT 12~23ms | SQL 자체는 빠름 |
-| TIMING 로그 (head, 피크 고VU) | DB_INSERT 52~522ms | HikariCP 대기 포함 |
-| Grafana HikariCP pending | 950 지속 | 커넥션 부족 확실 |
-| CloudWatch RDS CPU | 7.27% | DB 서버 여유 충분 |
-| Slow query log | 비어있음 | SQL 느린 것 아님 |
-
-**결론**: 병목은 DB 서버나 SQL이 아니라 순수하게 HikariCP 커넥션 대기.
-pool=20에도 1,000 VU 동시 요청 → INSERT 완료까지 점유 → 대부분 대기.
-해결 방향: pool-size 증가 or DB 커넥션 사용 횟수 자체 감소 (totalStock Redis 캐싱으로 `findById` 제거).
-
-### 3차 부하 테스트 결과 (2026-04-21, AWS 파티션 1 — HikariCP pool=40, terraform-mcp k6)
-
-#### 테스트 환경
-- 앱: batch-kafka-app t3.small 단일 인스턴스
-- DB: batch-kafka-db db.t3.micro (MySQL 8.0.44, gp3 IOPS 3,000)
-- Redis: ElastiCache Valkey 단일 노드
-- Kafka: kafka-1 단일 브로커, 파티션 1개
-- k6 실행 위치: **terraform-mcp EC2** (이전은 로컬 PC → 내부 네트워크로 변경, 측정 정확도 향상)
-
-#### k6 설정
-- TOTAL_REQUESTS: 15,000 (재고 10,000 초과 시나리오)
-- MAX_VUS: 1,000
-- DURATION: 60s (실제 완료: 46.4s)
-
-#### 결과
-
-| 지표 | 2차 (pool=20, 로컬 k6) | 3차 (pool=40, mcp k6) | 변화 |
-|------|----------------------|----------------------|------|
-| TPS | 275/s | **323/s** | +17% |
-| avg latency | 3.54s | **3.01s** | -15% |
-| max | 15.4s | **14.53s** | -6% |
-| 성공 (202) | 15,000건 | **10,000건** | (재고 10K 기준 변경) |
-| 재고 초과 발급 | 0건 | **0건** | 정합성 유지 ✅ |
-
-> ⚠️ 2차는 재고=15,000 (전량 성공 시나리오), 3차는 재고=10,000 (5,000건 차단 시나리오) — 조건이 달라 직접 비교 시 참고
-
-#### Grafana 확인 결과
-- HikariCP pending 피크: **~900** (pool=20 때 950과 거의 동일 → pool 증가 효과 없음)
-- HikariCP 활성율: **100%** 지속 포화
-- 앱 CPU: **90%** (pool=40으로 동시 처리 증가 → 앱 CPU 부하 증가)
-- RDS CPU: **23.9%** (이전 7.27% → 3배 증가, pool 증가로 동시 INSERT 늘어난 효과)
-- DiskQueueDepth: **0.03** (이전 0.46 → 크게 개선, gp3 효과 확인)
-- DatabaseConnections: **20.2** (pool=40이나 실제 동시 활성 커넥션은 20 수준)
-- 5xx 에러율: **0** ✅
-- Bridge 드레인 속도: 피크 45 req/s
-- Consumer PENDING→SUCCESS 지연: 피크 35s
-
-#### 결론 — pool 증가는 근본 해결책이 아님
-
-```
-VU 1000개 동시 요청 기준:
-pool=20 → 20개 처리, ~980개 대기 → pending 950
-pool=40 → 40개 처리, ~960개 대기 → pending 900
-pool=100 → 100개 처리, ~900개 대기 → pending 여전히 높음
-```
-
-pool을 몇 배로 늘려도 VU 1,000개 동시 INSERT 구조가 유지되는 한 pending 근본 해결 불가.
-**근본 해결: API 경로에서 DB INSERT 자체를 제거 → Redis-first 구조로 전환.**
-
-#### k6 실행 위치 변경 (2026-04-21 확정)
-- 이전: 로컬 PC → 인터넷 → AWS ALB (인터넷 레이턴시 포함, 측정 노이즈)
-- 현재: **terraform-mcp EC2 → VPC 내부 → AWS ALB** (네트워크 노이즈 제거, 정확한 앱 성능 측정)
-- terraform-mcp k6 설치: `sudo dnf install -y https://dl.k6.io/rpm/repo.rpm && sudo dnf install -y k6`
-- 레포 clone: `git clone https://github.com/hskhsmm/1milion-campaign-orchestration-system.git`
-
----
-
-### 로컬 검증 결과 (2026-04-22, v3 Redis-first)
-
-#### 테스트 환경
-- 로컬 Docker (MySQL, Redis, Kafka, 앱 단일 컨테이너)
-- k6.exe 로컬 실행
-
-#### 캠페인 1 (재고 1,000 / 요청 1,500 / VU 100)
-
-| 지표 | 값 |
-|------|-----|
-| TPS | **807/s** |
-| avg latency | **115ms** |
-| p95 | **219ms** |
-| 202 성공 | **1,000건** (재고 정확히 소진) ✅ |
-| 400 초과 차단 | **500건** ✅ |
-| 재고 초과 발급 | **0건** ✅ |
-
-#### 캠페인 2 (재고 5,000 / 요청 7,000 / VU 200)
-
-| 지표 | 값 |
-|------|-----|
-| TPS | **1,331/s** |
-| avg latency | **147ms** |
-| p95 | **234ms** |
-| 202 성공 | **5,000건** (재고 정확히 소진) ✅ |
-| 400 초과 차단 | **2,000건** ✅ |
-| 재고 초과 발급 | **0건** ✅ |
-
-#### Known Issue 재확인 — 재고 소진 시 active:campaigns SREM → 큐 잔류
-- 재고 소진 시 `SREM active:campaigns` 즉시 실행 → Bridge 드레인 중단 → 큐 잔류
-- `SADD active:campaigns {id}` 수동 복구 시 정상 드레인 → DB 최종 기록 완료 확인
-- 해결: 다음 단계 인프라 작업 시 처리 예정
-
----
-
-### 4차 부하 테스트 결과 (2026-04-22, AWS 파티션 1개 — v3 Redis-first)
-
-#### 테스트 환경
-- 앱: batch-kafka-app t3.small / DB: db.t3.micro / Redis: ElastiCache Valkey / Kafka: 파티션 1개
-- k6: terraform-mcp EC2 (VPC 내부)
-- 조건: TOTAL_REQUESTS=15,000, 재고=10,000, MAX_VUS=1,000
-
-#### 결과
-
-| 지표 | 3차 (v2, pool=40) | 4차 (v3 Redis-first) | 변화 |
-|------|------------------|---------------------|------|
-| TPS | 323/s | **526/s** | +63% |
-| avg | 3.01s | **1.83s** | -39% |
-| p95 | - | **3.33s** | - |
-| max | 14.53s | **6.48s** | -55% |
-| 재고 초과 발급 | 0건 | **0건** | ✅ |
-
-#### Grafana 핵심 지표
-- HikariCP pending: **거의 0** (3차 ~900 → 완전 해소) ✅
-- HikariCP 활성율: **5% 미만** (3차 100% 포화)
-- Consumer 지연: **800ms** (3차 35s → 44배 개선)
-- Redis Queue 잔류: ~330건 (Known Issue — SREM으로 Bridge 드레인 중단)
-- 5xx 에러: **0** ✅
-
----
-
-### 5차 부하 테스트 결과 (2026-04-23, AWS 파티션 3개)
-
-#### 테스트 환경 (4차와 동일, 파티션만 3개로 변경)
-- kafka-topics.sh --alter --partitions 3, KafkaConfig 자동 감지 → concurrency=3
-- application-p3.yml 적용 (HikariCP pool=15)
-
-#### 결과
-
-| 지표 | 4차 (파티션 1) | 5차 (파티션 3) | 변화 |
-|------|--------------|--------------|------|
-| TPS | 526/s | **543/s** | +3% |
-| avg | 1.83s | **1.79s** | -2% |
-| p95 | 3.33s | **4.39s** | +32% ↑ |
-| max | 6.48s | **7.41s** | +14% ↑ |
-| 재고 초과 발급 | 0건 | **0건** | ✅ |
-
-#### Grafana 핵심 지표
-- HikariCP pending: **거의 0** 유지 ✅
-- RDS CPU: **4.7%** (4차 26.5% → 대폭 감소 — Consumer 3개 분산 효과)
-- DatabaseConnections: **11.3** (4차 20.2 → 감소)
-- Consumer 지연: **1.25s** (4차 800ms → 소폭 증가, 파티션 편향)
-- Redis Queue: **0 수렴** ✅ (4차 330 잔류 → 이번엔 깨끗하게 소진)
-- 5xx 에러: **0** ✅
-
-#### 결론 — 파티션 확장 효과 미미, 병목은 t3.small 단일 인스턴스
-
-```
-API 병목: t3.small 2 vCPU → 1,000 VU 동시 Redis 연산 + JSON 직렬화로 CPU 포화
-파티션 늘려도 API TPS 한계 동일 → 수평 확장(Auto Scaling + ALB)이 근본 해결
-파티션 5개 테스트 스킵 → 3브로커 + Redis Cluster로 직행
+  → SMEMBERS active:campaigns → RPOP → Kafka publish (userId 파티션 키)
+  → 동적 batchSize: <10K→500 / <100K→1000 / >=100K→2000
+
+Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
+  → INSERT IGNORE (멱등성) → Redis 결과 캐시
 ```
 
 ---
 
-### 7차 부하 테스트 결과 (2026-04-26, AWS 파티션 10개 — 3브로커 + Redis CME 3샤드, 12만)
+## 부하 테스트 결과 요약
 
-#### 테스트 환경
-- 앱: batch-kafka-app t3.small / DB: db.t3.micro / Redis: ElastiCache CME 3샤드
-- Kafka: 3-broker KRaft, 파티션 10개, replication-factor=3
-- k6: terraform-mcp EC2 (VPC 내부)
-- 조건: TOTAL_REQUESTS=120,000, 재고=100,000, MAX_VUS=1,000
+| 차수 | 핵심 변경 | TPS | 병목 |
+|------|----------|-----|------|
+| 1차 | 기준선 (pool=10) | 246/s | HikariCP pending ~980 |
+| 2차 | pool=20 | 275/s | HikariCP pending ~950 |
+| 3차 | pool=40, mcp k6 | 323/s | pool 증가 효과 없음 확인 |
+| 4차 | **v3 Redis-first** | 526/s | HikariCP pending 거의 0 |
+| 5차 | 파티션 3개 (campaignId 키) | 543/s | Consumer 지연 1.25s |
+| 6차 | 파티션 3개 (userId 키) | 550/s | Consumer 지연 200ms |
+| 7차 | 3브로커+파티션 10개, 12만 | ~1,150/s | **앱 CPU 90%** |
+| 8차 | 3브로커+파티션 10개, 50만 | ~1,220/s | **앱 CPU 80%** |
 
-#### 결과
-
-| 지표 | 값 |
-|------|-----|
-| TPS | **~1,150/s** (역대 최고) |
-| 앱 CPU | **90%** 병목 확인 |
-| HikariCP pending | 거의 0 ✅ |
-| RDS CPU | 낮음 ✅ |
-| SUCCESS | 100,000건 ✅ |
-| 재고 초과 발급 | 0건 ✅ |
-
----
-
-### 8차 부하 테스트 결과 (2026-04-26, AWS 파티션 10개 — 50만)
-
-#### 테스트 환경 (7차와 동일)
+### 8차 테스트 상세 (현재 한계)
 - 조건: TOTAL_REQUESTS=600,000, 재고=500,000, MAX_VUS=2,000, DURATION=1,200s
-
-#### 결과
-
-| 지표 | 값 |
-|------|-----|
-| TPS | **~1,220/s** (평균) |
-| avg | 1.63s |
-| p95 | 2.81s |
-| max | 7.46s |
-| 앱 CPU | **80%** 병목 확인 |
-| HikariCP pending | 거의 0 ✅ |
-| HikariCP 활성율 | ~50% ✅ (이전 100% 포화 → 해소) |
-| RDS CPU | **9.44%** ✅ (DB 완전 여유) |
-| WriteIOPS | 피크 240/s (Consumer 500K INSERT 처리) |
-| Redis Queue | 피크 100K → 테스트 종료 후 0 수렴 ✅ |
-| Bridge 드레인 사이클 | 최대 4.17분 (큐 100K 소진 시간) |
-| Consumer 지연 | 150ms → 1.25s (큐 쌓이는 구간 증가) |
-| 5xx 에러 | 0건 ✅ |
-| SUCCESS | 500,000건 ✅ (정합성 완벽) |
-| 재고 초과 발급 | 0건 ✅ |
-| 완료 시간 | 8분 11초 |
-
-#### 확정 병목 분석
-- 앱 CPU 80~90% 고착 (7차/8차 모두) → t3.small 단일 인스턴스 한계
-- HikariCP pending 거의 0 → DB 병목 아님 (v3 Redis-first 효과 완벽 유지)
-- RDS CPU 9.44% → DB 서버 여유 충분
-- **결론**: 수직 확장(스케일업) 대신 ASG 수평 확장으로 해결 → #7 이슈 작성 완료
+- HikariCP pending: 거의 0 ✅ / RDS CPU: 9.44% ✅ / 5xx: 0 ✅
+- **확정 병목: 앱 CPU 80~90% 고착 — t3.small 단일 인스턴스 한계**
+- 다음 단계: ASG 수평 확장 (스케일업 대비 비용 2배 + SPOF 제거 + 탄력성)
 
 ---
 
-### 6차 부하 테스트 결과 (2026-04-23, AWS 파티션 3개 — userId 파티션 키 변경)
+## 구현 이슈 현황
 
-#### 변경 사항
-- `ParticipationBridge.java` — 파티션 키 `campaignId` → `userId` 변경
-  - regex 추출 → `JsonMapper` 역직렬화 방식으로 개선 (코드리뷰 반영)
-  - fallback: userId 추출 실패 시 campaignId 사용 유지
-
-#### 테스트 환경 (5차와 동일)
-- 앱: batch-kafka-app t3.small / DB: db.t3.micro / Redis: ElastiCache Valkey / Kafka: 파티션 3개
-- k6: terraform-mcp EC2 (VPC 내부)
-- 조건: TOTAL_REQUESTS=15,000, 재고=10,000, MAX_VUS=1,000
-
-#### 결과
-
-| 지표 | 5차 (campaignId 키) | 6차 (userId 키) | 변화 |
-|------|-------------------|----------------|------|
-| TPS | 543/s | **550/s** | +1.3% |
-| avg | 1.79s | **1.77s** | -1% |
-| p95 | 4.39s | **3.12s** | **-29%** |
-| max | 7.41s | 9.93s | +34% ↑ |
-| 재고 초과 발급 | 0건 | **0건** | ✅ |
-
-#### Grafana 핵심 지표
-- HikariCP pending: **거의 0** 유지 ✅
-- HikariCP 활성율: **0%** ✅
-- Consumer 지연: **200~245ms** (5차 1.25s → **-84%** ✅)
-- RDS CPU: **30.2%** ✅
-- 앱 CPU: **85% spike** → max 9.93s 원인 (t3.small CPU credit 순간 소진)
-- Redis Queue: **0 수렴** ✅
-- 5xx 에러: **0** ✅
-
-#### kafka-exporter 확인 결과
-```
-kafka_consumergroup_lag{partition="0"} 0
-kafka_consumergroup_lag{partition="1"} 0
-kafka_consumergroup_lag{partition="2"} 0
-kafka_consumergroup_members = 3
-```
-- Consumer Group Lag = 0 → Consumer 완벽하게 처리 ✅
-- Grafana "No data" = lag=0이라 표시 안 된 것 (문제 아님)
-
-#### 파티션 분산 이슈 (잔존)
-- partition 0: 92%, partition 1: 2%, partition 2: 1% → 여전히 편향
-- 원인: k6 userId가 1~15,000 순차 정수 → Kafka murmur2 해시가 균등 분산 못함
-- 실제 서비스(userId 넓게 분포)에서는 균등 분산 기대 가능
-- Consumer 지연 -84% 개선은 파티션 분산 효과 확실히 확인
-
-#### p95 개선 해석
-- API 응답(202 반환)은 Redis만 타므로 파티션 키와 무관해야 하나 29% 개선
-- 원인 불명확 — t3.small CPU credit 상태 차이, 환경 변동성으로 추정
-- Consumer 지연 -84%만 파티션 분산의 확실한 성과로 해석
-
----
-
-## 아키텍처 전환 결정 (2026-04-21 확정)
-
-### 배경
-3차 테스트까지 pool 튜닝 시도 → 효과 없음 데이터로 확인 → 구조적 해결로 방향 전환.
-설계가 흔들리는 게 아니라 **실험 → 측정 → 개선** 사이클을 제대로 밟은 결과.
-
-### 확정 아키텍처 (Redis-first)
-
-```
-POST /participate
-  1. RateLimit     (Redis SET NX EX)
-  2. DECR + LPUSH  (Redis Lua 원자적)
-  3. 202 반환      ← DB 미접촉
-
-Bridge (100ms) → RPOP → Kafka publish
-
-Consumer (10파티션) → DB INSERT SUCCESS 직접
-                    → UNIQUE 제약 멱등성 보장
-                    → 실패 시 DLQ
-```
-
-### 각 선택의 근거
-
-| 결정 | 이유 |
+| 이슈 | 상태 |
 |------|------|
-| API에서 DB 제거 | HikariCP pending 근본 해결, 업계 표준 (토스/카카오/쿠팡) |
-| Redis List 유지 | Kafka 있으니 Redis Stream 중복, 복잡도만 증가 |
-| Redis Stream 미사용 | Kafka가 영속/재처리/병렬화 역할 이미 담당 |
-| Consumer INSERT | UNIQUE 제약으로 멱등성 충분 |
-| Aurora는 선택 | 10파티션 Consumer 병렬화로 먼저 해결 시도, 부족 시 Aurora |
-
-### 복구 전략 변경
-
-| 항목 | 기존 | 변경 후 |
-|------|------|---------|
-| 복구 기준점 | DB PENDING 레코드 | Kafka at-least-once |
-| Consumer 실패 | Spring Batch PENDING 재처리 | DLQ → Slack 알림 |
-| 중복 방지 | DuplicateKeyException + sequence 비교 | UNIQUE INSERT |
-| Redis 장애 유실 | Spring Batch 복구 | Bridge 100ms 이내 미처리분 (수십 건) |
-
-### 수정 파일 (✅ 완료 — 2026-04-22, feature/redis-first-api, develop PR 예정)
-
-| 파일 | 변경 내용 |
-|------|-----------|
-| `ParticipationEvent.java` | `historyId` → `sequence` (Redis DECR 시점 선착순 번호) |
-| `ParticipationHistoryRepository.java` | `bulkUpdateSuccess`, `bulkUpdateFail` 제거 → `insertSuccess` (INSERT IGNORE) 추가 |
-| `ParticipationService.java` | `insertPendingWithRetry` 제거, DECR → sequence 확정 → LPUSH → 202 반환 |
-| `ParticipationEventConsumer.java` | `bulkUpdateSuccess` → `insertSuccess` 직접 호출, fallbackIndividual 제거 |
-| `PendingRecoveryJobConfig.java` | `bulkUpdateFail` 제거, `historyId` → `sequence` (v3에서 PENDING 없음 → 배치 no-op) |
-
-### 100만 트래픽 로드맵
-
-```
-이번:     API DB 제거           → HikariCP pending 해소, TPS 1,000/s+ 예상
-다음:     10파티션 + 3브로커    → Consumer INSERT 10배 병렬화
-그 다음:  Redis Cluster 3샤드   → SPOF 제거
-선택:     Aurora                → Consumer INSERT 병목 시 적용
-```
-
-**이 3단계(코드 + 파티션 + 클러스터)면 100만 트래픽 달성 가능.**
-Aurora는 Consumer DB INSERT가 병목으로 확인될 때 결정.
-
-### 이슈 및 브랜치
-- 이슈 초안: `issue_draft.md` (루트)
-- 브랜치: `feature/redis-first-api` → develop PR 진행 중 (2026-04-22)
-
-### 테스트 로드맵 (2026-04-26 기준)
-
-> 상세 설계: `TEST_ROADMAP.md` (루트) 참고
-
-| Phase | 핵심 변경 | 상태 |
-|-------|-----------|------|
-| 0 | 기준선 (TPS 246/s, p95 6.34s, pool=10) | ✅ 완료 |
-| 1 | HikariCP prod 기본값 수정 (pool=20) + [TIMING] 로그 | ✅ 완료 (TPS 275/s, p95 5.71s) |
-| 1-b | pool=40 테스트 | ✅ 완료 (TPS 323/s, pending ~900 — pool 효과 없음 확인) |
-| 2 | **API DB 제거 (Redis-first 전환)** | ✅ 완료 — 로컬 검증 완료 (TPS 1,331/s, 정합성 완벽) |
-| 3 | AWS 4차 테스트 — 파티션 1개 (v3 before/after 비교) | ✅ 완료 (TPS 526/s, HikariCP pending 0, 정합성 완벽) |
-| 4 | AWS 5차 테스트 — 파티션 3개 (campaignId 키) | ✅ 완료 (TPS 543/s — 파티션 편향, Consumer 지연 1.25s) |
-| 4-b | AWS 6차 테스트 — 파티션 3개 (userId 키) | ✅ 완료 (TPS 550/s, Consumer 지연 200ms, p95 3.12s) |
-| 5 | Kafka 3브로커 + 파티션 10개 | ✅ 완료 (2026-04-26, 파티션 10개/RF=3/ISR=3 확인) |
-| 5-a | 7차 테스트 — 12만, 파티션 10개, 3브로커 | ✅ 완료 (TPS ~1,150/s, CPU 90%, 정합성 완벽) |
-| 5-b | 8차 테스트 — 50만, 파티션 10개, 3브로커 | ✅ 완료 (TPS ~1,220/s, CPU 80%, 정합성 완벽) |
-| 6 | Redis Cluster 3샤드 | ✅ terraform apply 완료 (2026-04-26) |
-| 7 | 앱 Auto Scaling (t3.small 단일 CPU 한계 해결) | 🔄 진행 중 — codedeploy.tf + asg.tf Terraform 작업 |
-| 8 | Aurora *(Consumer INSERT 병목 시)* | 선택 |
-| 9 | 백만 Spike 최종 검증 | 대기 |
-
-#### k6 테스트 인프라 (2026-04-21 업데이트)
-- `stress-test/k6-load-test.js` — BASE_URL env var 처리, thresholds 추가
-- `stress-test/run-test.sh` — 환경별(local/prod) 실행 스크립트
-  - terraform-mcp에서: `CAMPAIGN_ID=<id> TOTAL_REQUESTS=15000 MAX_VUS=1000 DURATION=60 bash stress-test/run-test.sh prod`
-  - 파라미터 오버라이드: `CAMPAIGN_ID=2 TOTAL_REQUESTS=30000 ./run-test.sh prod`
-
-#### 테스트 전 캠페인 생성 (매번 필요)
-- 캠페인 생성 엔드포인트: **`POST /api/admin/campaigns`** (`/api/campaigns` 아님)
-- terraform-mcp에서 실행:
-  ```bash
-  curl -X POST $BASE_URL/api/admin/campaigns \
-    -H "Content-Type: application/json" \
-    -d '{"name":"load-test","totalStock":10000,"startDate":"2026-04-22","endDate":"2026-04-30"}'
-  ```
-- BASE_URL은 `~/.bashrc`에 영구 저장됨 (`http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com`)
-
-#### 파티션별 yml (단일 브로커 한계 테스트용)
-- `application-p2.yml`, `application-p3.yml`, `application-p5.yml`, `application-p10.yml`
-- Consumer concurrency는 KafkaConfig가 Kafka 토픽 파티션 수 자동 감지 (yml 변경 불필요)
-- yml은 HikariCP + Kafka Producer 튜닝용 (v1 기준으로 작성됨 → v2 테스트 후 조정 필요)
-- 파티션 변경 방법: `kafka-topics.sh --alter --partitions N` → 앱 재시작
+| #2 공통 인터페이스 (PENDING, sequence, historyId) | ✅ 완료 |
+| #3 API 진입 ~ Queue 적재 (A파트) | ✅ 완료 |
+| #4 Queue 소비 ~ DB 최종 기록 (B파트) | ✅ 완료 |
+| #5 Redis 클러스터링 (ElastiCache CME 3샤드) | ✅ 완료 (terraform apply 완료) |
+| #6 Kafka 3-broker KRaft | ✅ 완료 (파티션 10개, RF=3, ISR=3) |
+| #7 ASG 수평 확장 | ✅ 완료 (2026-04-27, ASG 2대 운영 중) |
+| Spring Batch PENDING 재처리 | 미작성 |
+| 모니터링 #22~#25 | ✅ 완료 (Grafana 13패널, 커스텀 메트릭 4종) |
 
 ---
 
-### 성능 개선 계획 (1차 테스트 기반)
+## 다음 작업 — Phase B: 9차 부하 테스트 (100만)
 
-> 상세 설계: `DESIGN_IMPROVEMENTS.md` 참고
-> 설계 철학: 공정성·정합성 우선, 처리량은 안정적이면 충분
+**목표**: ASG 2대 환경에서 100만 트래픽 처리 검증. TPS ~2,400/s, CPU 각 ~40% 분산 기대.
 
-#### ~~0순위 — 파티션 키 변경~~ ✅ 완료 (2026-04-23)
-
-- `ParticipationBridge.java` 파티션 키 `campaignId` → `userId` 변경
-- userId 추출: regex → `JsonMapper` 역직렬화 방식 (코드리뷰 반영)
-- 6차 테스트 결과: Consumer 지연 1.25s → 200ms (-84%) 확인
-
-#### 1순위 — 코드 개선 (인프라 무관, 즉시 적용 가능)
-
-| 항목 | 내용 | 효과 |
-|------|------|------|
-| 캠페인 자동 종료 + SISMEMBER | Lua로 SISMEMBER + DECR 원자화, remaining==0 시 DB CLOSED + active:campaigns 제거 | 재고 소진 후 Redis 낭비 제거, Bridge 빈 큐 순회 제거 |
-| totalStock Redis 캐싱 | 캠페인 생성 시 `total:campaign:{id}` 저장, Lua 1번으로 SISMEMBER + DECR + GET 통합 | `findById()` DB 조회 완전 제거 → 커넥션 풀 INSERT 전용 확보 |
-
-**기대 효과:**
+### 전체 로드맵
 ```
-DB 커넥션 사용: 25,000번 → 10,000번 (60% 감소)
-avg latency: 3.94s → 2~3s
-hikaricp_connections_pending 감소
+[완료] v3 Redis-first, Kafka 3-broker, ElastiCache CME, 8차 테스트 (50만 TPS ~1,220/s)
+[완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, EC2 SD, min=2 운영 중)
+[진행] Phase B — 9차 테스트 (100만)
+[예정] Phase C — API 엔드포인트 v3 정리
+[예정] Phase D — Spring Batch 안전망
+[예정] Phase E — MCP 서버 (AI 자율 운영)
 ```
-
-**검증 순서:** 단위 테스트 → 통합 테스트 → k6 before/after 비교 → hikaricp 지표 확인
-
-#### 2순위 — 인프라 + 코드 세트
-
-| 항목 | 내용 | 선행 조건 |
-|------|------|-----------|
-| Redis Cluster + AOF | ElastiCache Cluster 3샤드, AOF 활성화 | elasticache.tf 수정 |
-| Intent Key (의도 기록) | DECR + intent key Lua 원자화, 앱 크래시 시 double DECR 방지 | Redis Cluster + AOF 필수 |
-
-#### 3순위 — Spring Batch 안전망
-
-| 항목 | 내용 |
-|------|------|
-| 재고 복구 스케줄러 | Redis 키 없을 때 `total - SUCCESS - PENDING` 공식으로 자동 복구 |
-| 5분 초과 PENDING 재처리 | ItemReader(PENDING 조회) → ItemProcessor(Queue 재발행) → ItemWriter(FAIL UPDATE) |
-
-#### 인프라 개선 (DB 병목 근본 해결)
-
-| 항목 | 효과 | 비고 |
-|------|------|------|
-| ~~EBS gp2 → **gp3** 변경~~ ✅ 완료 | IOPS 3,000 안정 보장 (버스트 없이) | 콘솔 + rds.tf 반영 완료 |
-| RDS Proxy 추가 | 앱 2대 이상 시 커넥션 멀티플렉싱 | 앱 스케일아웃 시 필수 |
-| RDS → **Aurora** 전환 | write TPS 최대 5배, 분산 스토리지 I/O | 코드 변경 없음, 엔드포인트만 교체 |
-
-> ~~현재 db.t3.micro EBS gp2~~ → gp3 전환 완료 (IOPS 3,000 안정 보장)
-> 코드 개선(커넥션 절약) + Aurora(INSERT 속도) 추가 개선 가능
-
-### Phase 1: Terraform (infra/ 전체 작성)
-
-#### ✅ 완료된 작업 (2026-04-13 기준, terraform apply 완료)
-
-| 파일 | 리소스 수 | 내용 |
-|------|-----------|------|
-| `main.tf` | - | provider, S3 backend + **DynamoDB lock** (terraform-lock) |
-| `variables.tf` | - | region, account_id, vpc_id, subnet_id, github_repo |
-| `vpc.tf` | 8개 | VPC(172.31.0.0/16), IGW, Route Table, 퍼블릭 서브넷 4개(2a~2d), private_app_2a |
-| `security_groups.tf` | 5개 | alb-public(80/443), app-sg(8080), rds-mysql(3306), Kafka-SG(9092/9094), elasticache-redis(6379) |
-| `ec2.tf` | 11개 | IAM Role×2, Instance Profile×2, Policy×3, Policy Attachment×6, EC2×3 (batch-kafka-app, kafka-1, terraform-mcp) |
-| `rds.tf` | 1개 | batch-kafka-db (MySQL 8.0.44, db.t3.micro, SSM Parameter Store 비밀번호 연동) |
-| `dynamodb.tf` | 1개 | terraform-lock (PAY_PER_REQUEST, Terraform state lock용) |
-| `alb.tf` | 3개 | alb-batch-kafka-api, tg-api-8080, HTTP 리스너 — import 완료 |
-| `elasticache.tf` | 1개 | batch-kafka 서브넷 그룹 import 완료, Redis 클러스터 주석처리 (모니터링 후 활성화 예정) |
-| `iam.tf` | 2개 | GitHubActions S3/SSM 최소권한 커스텀 정책 추가 |
-
-**핵심 결정 사항:**
-- Route Table Association: 암시적 메인 라우팅 테이블 연결 유지 (명시적 association 코드 없음)
-- RDS 비밀번호: SSM `/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD` 에서 가져옴 + `lifecycle { ignore_changes = [password] }`
-- kafka-1 EC2: `associate_public_ip_address = true` + `private_ip = "172.31.5.164"` 고정 (SSM 접속 위해 퍼블릭 IP 필요)
-- security_groups description: 실제 AWS 값 그대로 사용 (forces replacement 방지)
-- ALB Listener: `default_action` `ignore_changes` 추가 (stickiness 속성 Terraform provider 충돌 방지)
-- RDS engine_version: AWS 자동 업그레이드로 8.0.43 → 8.0.44 반영
-- GitHub Actions IAM: S3FullAccess → `campaign-deploy` 버킷 전용, SSMFullAccess → `/campaign/prod/*` 읽기 전용
-- terraform-mcp EC2: public_2a 서브넷, 퍼블릭 IP 활성화 (MCP 서버 Phase 3 대비), 현재 중지 상태
-
-#### 🔲 남은 작업
-- [ ] Kafka 3-broker EC2 추가 (v2 목표) — `ec2.tf`
-- [ ] ElastiCache Redis 클러스터 apply (모니터링 구성 후) — `elasticache.tf`
-
-#### 📌 배포 전 AWS 작업 완료
-- [x] SSM `/batch-kafka/prod/SLACK_WEBHOOK_URL` 등록 완료
-
-### Phase 3: MCP 서버 (mcp-server/)
-- [ ] Python/FastAPI MCP 서버
-- [ ] AI 오케스트레이션 파이프라인
-- [ ] Slack 승인 + DynamoDB 감사 로그
 
 ---
 
-## 배치 현황 및 v2 방향
-
-### 현재 배치 평가
-- Spring Batch 인프라(Job/Step/Tasklet) 사용 중이나 실제 처리는 단일 GROUP BY 쿼리
-- @Scheduled 대비 가치: 실행 이력(JobRepository), 재실행 API, 중복 방지
-- Chunk processing 미활용 → Spring Batch 진가 발휘 못함
-
-### v2에서 진짜 Spring Batch가 필요한 케이스
-1. **PENDING 재처리** (ItemReader: 5분 초과 PENDING → ItemProcessor: 재발행 판단 → ItemWriter: 상태 UPDATE)
-2. **Redis ↔ DB 정합성 검증** (캠페인별 stock 비교 → 불일치 알림)
-3. **participation_history 대용량 아카이빙** (Chunk 단위 이동, Lock 방지)
-
----
-
-## AWS 리소스 (현재 존재)
+## AWS 리소스
 
 | 리소스 | 이름/값 |
 |--------|---------|
 | Account ID | 631124976154 |
 | Region | ap-northeast-2 |
 | VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
-| ECR | campaign-core |
-| S3 (배포) | campaign-deploy-631124976154 |
+| ASG (앱) | batch-kafka-app-asg (t3.small, min=2/max=3, private_app_2a+2b) |
+| EC2 (Kafka) | kafka-1/2/3 (t3.small, public 2a/2b/2c) |
+| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana 실행 중) |
+| RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro) |
+| ALB | alb-batch-kafka-api → tg-api-8080 |
+| ElastiCache | CME 3샤드 (Valkey 7.2, cache.t3.micro × 6) |
+| ECR | batch-kafka-system |
+| S3 (배포) | batch-kafka-deploy-631124976154 |
 | S3 (tfstate) | campaign-terraform-state-631124976154 |
-| DynamoDB (lock) | terraform-lock |
-| CodeDeploy App | campaign-core-app |
-| Deployment Group | campaign-prod-dg |
-| IAM Role (CI/CD) | github-actions-campaign-deploy-role ✅ 신규 레포 연동 완료 |
-| IAM Role (앱 EC2) | ec2-batchkafka-role |
-| IAM Role (MCP EC2) | terraform-mcp-role |
-| EC2 (앱) | batch-kafka-app (t3.small, private-app-subnet-1) |
-| EC2 (Kafka) | kafka-1 (t3.small, public-2a) |
-| EC2 (MCP) | terraform-mcp (t3.small, AL2023) |
-| RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro, ap-northeast-2b) |
-| ALB | alb-batch-kafka-api (internet-facing, 2a/2b, HTTP 80 → tg-api-8080) |
-| ElastiCache | 서브넷 그룹 batch-kafka (존재), 클러스터 삭제 상태 (비용 절감) |
-| SSM (앱) | /batch-kafka/prod/* |
-| SSM (CI/CD) | /campaign/prod/ |
-
-### OIDC 상태
-Terraform으로 완료 — `repo:hskhsmm/1milion-campaign-orchestration-system:*` 적용됨
+| CodeDeploy | App: batch-kafka-app / DG: batch-kafka-prod-dg (ASG 연결, IaC 완료) |
+| SSM | /batch-kafka/prod/* |
 
 ---
 
-## CI/CD 현황
+## CI/CD
 
-`.github/workflows/deploy.yml` (루트) — 정상 위치
-- main 브랜치 push + `app/campaign-core/**` 변경 시 트리거
-- OIDC → ECR → S3 → CodeDeploy 순서
-
----
-
-## 기술 스택 (v2 목표)
-
-| 분류 | v1 | v2 |
-|------|----|----|
-| Kafka | EC2 단일 브로커 | EC2 3-broker 클러스터 |
-| Redis | ElastiCache 단일 | ElastiCache Cluster (3샤드) |
-| 인프라 | 수동 콘솔 | Terraform IaC |
-| 운영 | 없음 | Claude MCP 자율 운영 |
-| 파티션 | 1개 | 10개 |
+`.github/workflows/deploy.yml` — main 브랜치 + `app/campaign-core/**` 변경 시 트리거
+OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.AllAtOnce`)
 
 ---
 
-## 면접 핵심 멘트 (데브옵스 직무)
+## 테스트 실행 (terraform-mcp에서)
 
-**프로젝트 소개:**
-"Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트"
+```bash
+# 캠페인 생성
+curl -X POST $BASE_URL/api/admin/campaigns \
+  -H "Content-Type: application/json" \
+  -d '{"name":"load-test","totalStock":1000000,"startDate":"2026-04-27","endDate":"2026-12-31"}'
 
-**CI/CD:**
-"OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, Blue-Green 무중단 배포"
+# 테스트 실행
+CAMPAIGN_ID=<id> TOTAL_REQUESTS=1200000 MAX_VUS=3000 DURATION=2400 \
+  bash ~/1milion-campaign-orchestration-system/stress-test/run-test.sh prod
+```
 
-**한계 인지:**
-"단일 파티션 278 TPS 상한 + 단일 브로커 SPOF → v2에서 Terraform + 3-broker + Redis Cluster로 해결"
+BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com`
+
+---
+
+## 면접 핵심 멘트
+
+**프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트"
+
+**CI/CD**: "OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, Blue-Green 무중단 배포"
+
+**한계 인지**: "단일 인스턴스 CPU 한계 → ASG 수평 확장, 데이터로 근거 제시"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,13 +216,15 @@ Kafka Consumer (10 파티션)
 - `/batch-kafka/prod/SPRING_DATA_REDIS_HOST` SSM 삭제 (구 단일 노드 키, 앱에서 미사용)
 - feature/redis-cluster → develop → main 머지 → CI/CD 재배포
 
-### #6 Kafka 3-broker (hskhsmm 담당) 🔄 진행 중 (2026-04-26)
+### #6 Kafka 3-broker (hskhsmm 담당) ✅ 완료 (2026-04-26)
 - [x] EC2 kafka-2 (172.31.16.164, public_2b), kafka-3 (172.31.32.164, public_2c) 추가 — `ec2.tf`
 - [x] Kafka SG self-ingress 추가 (9092 브로커 내부, 9094 controller quorum) — `security_groups.tf`
 - [x] RDS slow query 파라미터 그룹 (`aws_db_parameter_group.slow`) — `rds.tf`
 - [x] `application-prod.yml` — 10파티션 3브로커 기준 설정 반영 (max-poll-records: 100, buffer-memory: 512MB 등)
-- [ ] kafka-2, kafka-3 브로커 직접 설치 및 KRaft 3브로커 클러스터 구성
-- [ ] SSM `SPRING_KAFKA_BOOTSTRAP_SERVERS` 3브로커 값으로 업데이트
+- [x] kafka-2, kafka-3 브로커 직접 설치 및 KRaft 3브로커 클러스터 구성
+  - cluster.id: 9CA3K977Q5GdJDSdlKZVEw, MaxFollowerLag: 0 (브로커 전체 정상)
+- [x] 토픽 campaign-participation-topic — PartitionCount: 10, ReplicationFactor: 3, min.insync.replicas=2
+- [x] SSM `SPRING_KAFKA_BOOTSTRAP_SERVERS` 3브로커 값으로 업데이트
 
 ### Spring Batch v2 PENDING 재처리 (A/B 머지 + 인프라 구성 후)
 - [ ] ItemReader: 5분 초과 PENDING 조회
@@ -628,6 +630,61 @@ API 병목: t3.small 2 vCPU → 1,000 VU 동시 Redis 연산 + JSON 직렬화로
 
 ---
 
+### 7차 부하 테스트 결과 (2026-04-26, AWS 파티션 10개 — 3브로커 + Redis CME 3샤드, 12만)
+
+#### 테스트 환경
+- 앱: batch-kafka-app t3.small / DB: db.t3.micro / Redis: ElastiCache CME 3샤드
+- Kafka: 3-broker KRaft, 파티션 10개, replication-factor=3
+- k6: terraform-mcp EC2 (VPC 내부)
+- 조건: TOTAL_REQUESTS=120,000, 재고=100,000, MAX_VUS=1,000
+
+#### 결과
+
+| 지표 | 값 |
+|------|-----|
+| TPS | **~1,150/s** (역대 최고) |
+| 앱 CPU | **90%** 병목 확인 |
+| HikariCP pending | 거의 0 ✅ |
+| RDS CPU | 낮음 ✅ |
+| SUCCESS | 100,000건 ✅ |
+| 재고 초과 발급 | 0건 ✅ |
+
+---
+
+### 8차 부하 테스트 결과 (2026-04-26, AWS 파티션 10개 — 50만)
+
+#### 테스트 환경 (7차와 동일)
+- 조건: TOTAL_REQUESTS=600,000, 재고=500,000, MAX_VUS=2,000, DURATION=1,200s
+
+#### 결과
+
+| 지표 | 값 |
+|------|-----|
+| TPS | **~1,220/s** (평균) |
+| avg | 1.63s |
+| p95 | 2.81s |
+| max | 7.46s |
+| 앱 CPU | **80%** 병목 확인 |
+| HikariCP pending | 거의 0 ✅ |
+| HikariCP 활성율 | ~50% ✅ (이전 100% 포화 → 해소) |
+| RDS CPU | **9.44%** ✅ (DB 완전 여유) |
+| WriteIOPS | 피크 240/s (Consumer 500K INSERT 처리) |
+| Redis Queue | 피크 100K → 테스트 종료 후 0 수렴 ✅ |
+| Bridge 드레인 사이클 | 최대 4.17분 (큐 100K 소진 시간) |
+| Consumer 지연 | 150ms → 1.25s (큐 쌓이는 구간 증가) |
+| 5xx 에러 | 0건 ✅ |
+| SUCCESS | 500,000건 ✅ (정합성 완벽) |
+| 재고 초과 발급 | 0건 ✅ |
+| 완료 시간 | 8분 11초 |
+
+#### 확정 병목 분석
+- 앱 CPU 80~90% 고착 (7차/8차 모두) → t3.small 단일 인스턴스 한계
+- HikariCP pending 거의 0 → DB 병목 아님 (v3 Redis-first 효과 완벽 유지)
+- RDS CPU 9.44% → DB 서버 여유 충분
+- **결론**: 수직 확장(스케일업) 대신 ASG 수평 확장으로 해결 → #7 이슈 작성 완료
+
+---
+
 ### 6차 부하 테스트 결과 (2026-04-23, AWS 파티션 3개 — userId 파티션 키 변경)
 
 #### 변경 사항
@@ -748,7 +805,7 @@ Aurora는 Consumer DB INSERT가 병목으로 확인될 때 결정.
 - 이슈 초안: `issue_draft.md` (루트)
 - 브랜치: `feature/redis-first-api` → develop PR 진행 중 (2026-04-22)
 
-### 테스트 로드맵 (2026-04-23 기준)
+### 테스트 로드맵 (2026-04-26 기준)
 
 > 상세 설계: `TEST_ROADMAP.md` (루트) 참고
 
@@ -761,9 +818,11 @@ Aurora는 Consumer DB INSERT가 병목으로 확인될 때 결정.
 | 3 | AWS 4차 테스트 — 파티션 1개 (v3 before/after 비교) | ✅ 완료 (TPS 526/s, HikariCP pending 0, 정합성 완벽) |
 | 4 | AWS 5차 테스트 — 파티션 3개 (campaignId 키) | ✅ 완료 (TPS 543/s — 파티션 편향, Consumer 지연 1.25s) |
 | 4-b | AWS 6차 테스트 — 파티션 3개 (userId 키) | ✅ 완료 (TPS 550/s, Consumer 지연 200ms, p95 3.12s) |
-| 5 | Kafka 3브로커 + 파티션 10개 | 🔄 진행 중 (kafka-2/3 EC2 생성 완료, 브로커 설치 대기) |
+| 5 | Kafka 3브로커 + 파티션 10개 | ✅ 완료 (2026-04-26, 파티션 10개/RF=3/ISR=3 확인) |
+| 5-a | 7차 테스트 — 12만, 파티션 10개, 3브로커 | ✅ 완료 (TPS ~1,150/s, CPU 90%, 정합성 완벽) |
+| 5-b | 8차 테스트 — 50만, 파티션 10개, 3브로커 | ✅ 완료 (TPS ~1,220/s, CPU 80%, 정합성 완벽) |
 | 6 | Redis Cluster 3샤드 | ✅ terraform apply 완료 (2026-04-26) |
-| 7 | 앱 Auto Scaling (t3.small 단일 CPU 한계 해결) | 대기 |
+| 7 | 앱 Auto Scaling (t3.small 단일 CPU 한계 해결) | 🔄 진행 중 — codedeploy.tf + asg.tf Terraform 작업 |
 | 8 | Aurora *(Consumer INSERT 병목 시)* | 선택 |
 | 9 | 백만 Spike 최종 검증 | 대기 |
 

--- a/app/campaign-core/deploy/docker-compose.prod.yml
+++ b/app/campaign-core/deploy/docker-compose.prod.yml
@@ -17,14 +17,4 @@ services:
       - /opt/campaign-core/.env.prod
     restart: unless-stopped
 
-  redis-exporter:
-    image: oliver006/redis_exporter
-    container_name: redis-exporter
-    ports:
-      - "9121:9121"
-    environment:
-      REDIS_ADDR: ${REDIS_EXPORTER_ADDR}        # SSM /batch-kafka/prod/REDIS_EXPORTER_ADDR 주입
-      REDIS_EXPORTER_IS_CLUSTER: "true"         # 클러스터 전체 샤드 메트릭 수집
-    env_file:
-      - /opt/campaign-core/.env.prod
-    restart: unless-stopped
+  # redis-exporter는 terraform-mcp에서 단독 실행 (ASG 다중 인스턴스 중복 수집 방지)

--- a/app/campaign-core/deploy/scripts/beforeInstall.sh
+++ b/app/campaign-core/deploy/scripts/beforeInstall.sh
@@ -38,7 +38,6 @@ fetch_param SPRING_DATASOURCE_USERNAME    "/batch-kafka/prod/SPRING_DATASOURCE_U
 fetch_param SPRING_DATASOURCE_PASSWORD    "/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD"
 fetch_param SPRING_KAFKA_BOOTSTRAP_SERVERS "/batch-kafka/prod/SPRING_KAFKA_BOOTSTRAP_SERVERS"
 fetch_param SPRING_DATA_REDIS_CLUSTER_NODES "/batch-kafka/prod/SPRING_DATA_REDIS_CLUSTER_NODES"
-fetch_param REDIS_EXPORTER_ADDR            "/batch-kafka/prod/REDIS_EXPORTER_ADDR"
 fetch_param SLACK_WEBHOOK_URL             "/batch-kafka/prod/SLACK_WEBHOOK_URL"
 fetch_param ECR_IMAGE                     "/batch-kafka/prod/ECR_IMAGE"
 

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -1,0 +1,75 @@
+# ──────────────────────────────────────────
+# Launch Template
+# ──────────────────────────────────────────
+resource "aws_launch_template" "app" {
+  name          = "batch-kafka-app-lt"
+  image_id      = "ami-01c64e7a84a57e681"  # batch-kafka-app-ami (Docker + CodeDeploy 포함)
+  instance_type = "t3.small"
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.batch_kafka_app.name
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.app.id]
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "batch-kafka-app"
+    }
+  }
+}
+
+# ──────────────────────────────────────────
+# Auto Scaling Group
+# ──────────────────────────────────────────
+resource "aws_autoscaling_group" "app" {
+  name                = "batch-kafka-app-asg"
+  min_size            = 2
+  max_size            = 3
+  desired_capacity    = 2
+  vpc_zone_identifier = [
+    aws_subnet.private_app_2a.id,
+    aws_subnet.private_app_2b.id,
+  ]
+
+  launch_template {
+    id      = aws_launch_template.app.id
+    version = "$Latest"
+  }
+
+  target_group_arns = [aws_lb_target_group.api_8080.arn]
+
+  health_check_type         = "ELB"
+  health_check_grace_period = 180  # 앱 기동 시간 여유 (초)
+
+  tag {
+    key                 = "Name"
+    value               = "batch-kafka-app"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    ignore_changes = [desired_capacity]  # 수동 스케일 조정 보호
+  }
+}
+
+# ──────────────────────────────────────────
+# Target Tracking Scaling Policy (CPU 60%)
+# ──────────────────────────────────────────
+resource "aws_autoscaling_policy" "cpu_target_tracking" {
+  name                   = "batch-kafka-app-cpu-tracking"
+  autoscaling_group_name = aws_autoscaling_group.app.name
+  policy_type            = "TargetTrackingScaling"
+
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value     = 60.0
+    disable_scale_in = true  # 스케일인 비활성화 — 수동으로만 축소
+  }
+}

--- a/infra/codedeploy.tf
+++ b/infra/codedeploy.tf
@@ -1,0 +1,53 @@
+# ──────────────────────────────────────────
+# CodeDeploy IAM Role (서비스 롤)
+# ──────────────────────────────────────────
+resource "aws_iam_role" "codedeploy" {
+  name = "CodeDeployServiceRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "codedeploy.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy" {
+  role       = aws_iam_role.codedeploy.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+}
+
+# ──────────────────────────────────────────
+# CodeDeploy Application
+# import: terraform import aws_codedeploy_app.app batch-kafka-app
+# ──────────────────────────────────────────
+resource "aws_codedeploy_app" "app" {
+  name             = "batch-kafka-app"
+  compute_platform = "Server"
+}
+
+# ──────────────────────────────────────────
+# CodeDeploy Deployment Group
+# import: terraform import aws_codedeploy_deployment_group.app batch-kafka-app:batch-kafka-prod-dg
+# ──────────────────────────────────────────
+resource "aws_codedeploy_deployment_group" "app" {
+  app_name               = aws_codedeploy_app.app.name
+  deployment_group_name  = "batch-kafka-prod-dg"
+  service_role_arn       = aws_iam_role.codedeploy.arn
+
+  deployment_config_name = "CodeDeployDefault.OneAtATime"
+
+  autoscaling_groups = [aws_autoscaling_group.app.name]
+
+  deployment_style {
+    deployment_option = "WITHOUT_TRAFFIC_CONTROL"
+    deployment_type   = "IN_PLACE"
+  }
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -22,6 +22,21 @@ resource "aws_iam_role_policy_attachment" "terraform_mcp_ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+# Prometheus EC2 Service Discovery용 — ASG 인스턴스 동적 감지
+resource "aws_iam_role_policy" "terraform_mcp_ec2_describe" {
+  name = "EC2Describe-for-prometheus"
+  role = aws_iam_role.terraform_mcp.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ec2:DescribeInstances"]
+      Resource = "*"
+    }]
+  })
+}
+
 # terraform-mcp 보안 그룹
 resource "aws_security_group" "terraform_mcp" {
   name        = "terraform-mcp-sg"
@@ -143,33 +158,7 @@ resource "aws_iam_role_policy_attachment" "batch_kafka_ssm_parameter_read" {
   policy_arn = aws_iam_policy.ssm_parameter_read.arn
 }
 
-# ──────────────────────────────────────────
-# batch-kafka-app EC2
-# ──────────────────────────────────────────
-
-resource "aws_instance" "batch_kafka_app" {
-  ami                         = "ami-0b818a04bc9c2133c"
-  instance_type               = "t3.small"
-  subnet_id                   = aws_subnet.private_app_2a.id
-  vpc_security_group_ids      = [aws_security_group.app.id]
-  iam_instance_profile        = aws_iam_instance_profile.batch_kafka_app.name
-  associate_public_ip_address = true
-  private_ip                  = "172.31.100.157"
-
-  root_block_device {
-    volume_type = "gp3"
-    volume_size = 8
-    encrypted   = false
-  }
-
-  tags = {
-    Name = "batch-kafka-app"
-  }
-
-  lifecycle {
-    ignore_changes = [associate_public_ip_address]
-  }
-}
+# batch-kafka-app EC2는 ASG(asg.tf)로 대체됨
 
 # ──────────────────────────────────────────
 # kafka-1 EC2

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -66,8 +66,7 @@ resource "aws_subnet" "public_2d" {
   tags = {}
 }
 
-# 앱 서브넷 (이름만 Private, 실제론 IGW 연결된 Public)
-# v2에서 NAT Gateway 추가 후 진짜 Private으로 전환 예정
+# 앱 서브넷 2a (이름만 Private, 실제론 IGW 연결된 Public)
 resource "aws_subnet" "private_app_2a" {
   vpc_id                  = aws_vpc.main.id
   cidr_block              = "172.31.100.0/24"
@@ -76,5 +75,17 @@ resource "aws_subnet" "private_app_2a" {
 
   tags = {
     Name = "private-app-subnet-1"
+  }
+}
+
+# 앱 서브넷 2b (ASG multi-AZ용, 이름만 Private 실제론 IGW 연결된 Public)
+resource "aws_subnet" "private_app_2b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "172.31.101.0/24"
+  availability_zone       = "ap-northeast-2b"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "private-app-subnet-2"
   }
 }


### PR DESCRIPTION
# PR #54 — Phase A: ASG 수평 확장 + 모니터링 수정

## 연관 이슈
closes #54

---

## 배경 및 목적

7,8차 부하 테스트(50만 트래픽)에서 앱 CPU 80~90% 고착이 확정 병목으로 확인됐다.

| 지표 | 8차 결과 |
|------|---------|
| TPS | ~1,220/s |
| 앱 CPU | **80~90%** (t3.small 한계) |
| HikariCP pending | 거의 0 (DB 병목 없음) |
| RDS CPU | 9.44% (DB 서버 여유) |

DB도, Kafka도, Redis도 아닌 **앱 서버 CPU 단일 인스턴스 한계**가 병목이었다.

### 스케일업 대신 ASG 수평 확장을 선택한 이유

| 비교 | 스케일업 (t3.xlarge) | ASG 수평 확장 |
|------|---------------------|--------------|
| 비용 | 단일 인스턴스 고정 비용 증가 | 트래픽 없을 때 min=2 유지 |
| SPOF | 여전히 단일 인스턴스 | 1대 장애 시 나머지 대응 |
| 탄력성 | 없음 | CPU 60% 초과 시 자동 스케일아웃 |
| 면접 포인트 | 약함 | 클라우드 네이티브 설계 |

**결론**: ASG를 선택했다.

---

## 변경 내용

### 1. `infra/asg.tf` (신규)

**Launch Template + ASG + Target Tracking Scaling Policy** IaC화.

```hcl
# Launch Template
resource "aws_launch_template" "app" {
  name          = "batch-kafka-app-lt"
  image_id      = "ami-01c64e7a84a57e681"  # Docker + CodeDeploy 포함 AMI
  instance_type = "t3.small"
  ...
}

# ASG
resource "aws_autoscaling_group" "app" {
  min_size         = 2
  max_size         = 3
  desired_capacity = 2
  vpc_zone_identifier = [
    aws_subnet.private_app_2a.id,
    aws_subnet.private_app_2b.id,  # multi-AZ
  ]
  target_group_arns         = [aws_lb_target_group.api_8080.arn]
  health_check_type         = "ELB"
  health_check_grace_period = 180
  lifecycle {
    ignore_changes = [desired_capacity]  # 수동 스케일 조정 보호
  }
}

# Target Tracking Scaling Policy (CPU 60%)
resource "aws_autoscaling_policy" "cpu_target_tracking" {
  policy_type = "TargetTrackingScaling"
  target_tracking_configuration {
    predefined_metric_type = "ASGAverageCPUUtilization"
    target_value           = 60.0
    disable_scale_in       = true  # 스케일인 비활성 — 수동으로만 축소
  }
}
```

**min_size=2 + disable_scale_in=true 설정 이유**:
- 부하 테스트 중 CPU가 잠시 낮아지면 Target Tracking이 자동으로 1대로 줄여버리는 문제 방지
- 테스트 중에는 항상 2대를 유지해야 정확한 측정 가능

---

### 2. `infra/codedeploy.tf` (신규)

콘솔에서 수동 생성되어 IaC로 관리되지 않던 CodeDeploy 리소스를 import 후 ASG에 연결했다.

```bash
# import 명령
terraform import aws_codedeploy_app.app batch-kafka-app
terraform import aws_codedeploy_deployment_group.app batch-kafka-app:batch-kafka-prod-dg
```

CodeDeploy Deployment Group에 ASG를 연결함으로써 스케일아웃 시 새 인스턴스에 앱이 자동 배포된다.
기존에는 단일 EC2에만 배포됐지만 이제 ASG 멤버 전체에 순차 배포(`OneAtATime`)된다.

---

### 3. `infra/vpc.tf` — private_app_2b 서브넷 추가

ASG multi-AZ 구성을 위해 ap-northeast-2b에 앱 전용 서브넷을 추가했다.

```hcl
resource "aws_subnet" "private_app_2b" {
  cidr_block        = "172.31.101.0/24"
  availability_zone = "ap-northeast-2b"
}
```

2a + 2b 두 AZ에 걸쳐 인스턴스가 분산되어 AZ 장애에도 대응 가능하다.

---

### 4. `infra/ec2.tf` — 단일 EC2 제거 + EC2 Describe 권한 추가

**단일 EC2 제거 이유**:
기존 `aws_instance.batch_kafka_app`과 ASG가 동시에 존재하면 ALB Target Group에 중복 등록되어 트래픽이 3곳으로 분산된다. ASG 외 인스턴스가 트래픽을 받으면 배포 대상에서 빠져 있어 구버전 앱이 응답할 수 있다.

**EC2 Describe 권한 추가 이유**:
Prometheus EC2 Service Discovery를 사용하면 terraform-mcp의 Prometheus가 AWS API를 직접 호출해 ASG 인스턴스를 동적으로 감지한다. 이 API 호출에 `ec2:DescribeInstances` 권한이 필요하다.

---

### 5. Prometheus EC2 Service Discovery 전환

기존 prometheus.yml은 고정 IP(`172.31.100.157`)로 앱 인스턴스를 타겟팅했다.

**문제**: ASG는 인스턴스가 교체될 때마다 새 IP를 할당받기 때문에 고정 IP 방식으로는 새 인스턴스를 감지할 수 없다.

**해결**: EC2 Service Discovery로 전환해 Name 태그 `batch-kafka-app`을 기준으로 동적 감지.

```yaml
- job_name: 'spring-boot'
  ec2_sd_configs:
    - region: ap-northeast-2
      filters:
        - name: tag:Name
          values: [batch-kafka-app]
  relabel_configs:
    - source_labels: [__meta_ec2_private_ip]
      target_label: __address__
      replacement: '${1}:8080'
```

**트러블슈팅 — IMDS hop limit 문제**:

EC2 Service Discovery 적용 후 Prometheus 타겟이 Empty로 표시됐다.

원인: terraform-mcp의 Prometheus가 Docker 컨테이너 안에서 실행되므로 AWS SDK가 EC2 메타데이터(IMDS)에 접근할 때 hop이 2단계(컨테이너 → 호스트 → IMDS)가 필요하다. 그런데 기본 hop limit이 1로 설정되어 있어 컨테이너에서 메타데이터 접근이 막혔다.

```bash
# 해결: terraform-mcp의 hop limit을 2로 변경
aws ec2 modify-instance-metadata-options \
  --instance-id <terraform-mcp-instance-id> \
  --http-put-response-hop-limit 2 \
  --http-endpoint enabled
```

이후 Prometheus targets에서 spring-boot 2/2 UP, redis-exporter 2/2 UP 확인.

---

### 6. redis-exporter ASG 중복 수집 문제 수정

**문제**:
`docker-compose.prod.yml`에 redis-exporter가 포함되어 있어 ASG 2대 모두에서 실행된다.
두 인스턴스가 동일한 ElastiCache CME를 바라보고 Prometheus가 양쪽 9121 포트를 스크래핑하면 같은 Redis 메트릭이 2번 수집된다.

Redis 메트릭은 전부 Gauge(현재 상태값)이므로 `sum()`으로 집계하면 실제값의 2배가 나온다.
예: `redis_memory_used_bytes` 실제 512MB → Grafana에서 1024MB로 표시.

**해결**:
- `docker-compose.prod.yml`에서 redis-exporter 서비스 제거
- `beforeInstall.sh`에서 `REDIS_EXPORTER_ADDR` SSM 주입 라인 제거
- SSM 키 자체는 유지 (terraform-mcp에서 docker run 시 참조)
- terraform-mcp에서 redis-exporter 1개만 단독 실행

kafka-exporter도 동일한 이유로 terraform-mcp에서 단독 실행하고 있어 일관된 구조가 됐다.

```
[이전]
ASG 인스턴스 1 → redis-exporter → ElastiCache CME
ASG 인스턴스 2 → redis-exporter → ElastiCache CME (중복!)
Prometheus: 2개 타겟 스크래핑 → 2배 메트릭

[이후]
terraform-mcp → redis-exporter → ElastiCache CME
Prometheus: 1개 타겟 스크래핑 → 정확한 메트릭
```

**재배포 후 terraform-mcp에서 1회 실행 필요**:
```bash
REDIS_ADDR=$(aws ssm get-parameter \
  --name /batch-kafka/prod/REDIS_EXPORTER_ADDR \
  --with-decryption --query Parameter.Value --output text)

docker run -d \
  --name redis-exporter \
  --restart unless-stopped \
  -p 9121:9121 \
  -e REDIS_ADDR="$REDIS_ADDR" \
  -e REDIS_EXPORTER_IS_CLUSTER=true \
  oliver006/redis_exporter
```

---

## 변경 파일 요약

| 파일 | 변경 내용 |
|------|-----------|
| `infra/asg.tf` | 신규 — Launch Template, ASG, Target Tracking Policy |
| `infra/codedeploy.tf` | 신규 — CodeDeploy App/DG IaC화, ASG 연결 |
| `infra/vpc.tf` | private_app_2b 서브넷 추가 (multi-AZ) |
| `infra/ec2.tf` | batch-kafka-app 단일 EC2 제거, EC2 Describe 권한 추가 |
| `deploy/docker-compose.prod.yml` | redis-exporter 서비스 제거 |
| `deploy/scripts/beforeInstall.sh` | REDIS_EXPORTER_ADDR SSM 주입 라인 제거 |
| `ARCHITECTURE.md` | Phase A 완료 반영, 인프라 구성도 ASG로 업데이트 |
| `CLAUDE.md` | 다음 작업 Phase B로 변경, ASG 리소스 반영 |

---

## 기대 효과

- 인스턴스 2대: TPS ~2,400/s, CPU 각 ~40% (단일 80~90% → 분산)
- AZ 이중화: 1대 장애 시 나머지 1대 계속 서비스
- 모니터링 정확도: redis 메트릭 중복 수집 제거
- 이후 Phase B에서 100만 트래픽 검증 예정
