### PR TITLE
[Batch] 선착순 시스템 장애 복구용 DLQ 재처리 / 정합성 복구 배치 

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -808,19 +808,62 @@ bash ~/1milion-campaign-orchestration-system/stress-test/run-test.sh prod
 
 ---
 
-### Phase C — API 엔드포인트 정리 (v3 기준 재정비)
+### Phase C — API 엔드포인트 정리 + 프론트 운영 콘솔화
 
-v1/v2 잔재 엔드포인트를 v3 아키텍처 기준으로 정리합니다.
+v1/v2 잔재 제거 + 프론트를 "성능 실험실"에서 "운영 콘솔"로 재편합니다.
 
-**주요 작업:**
+#### 백엔드 API 분류
 
-| 작업 | 내용 |
-|------|------|
-| 불필요한 컨트롤러 제거 | v1 LoadTestController, TestController, KafkaManagementController 등 정리 |
-| 폴링 API 개선 | `GET /api/campaigns/{id}/participation/{userId}/result` — Redis 캐시 우선, DB fallback |
-| 캠페인 상태 조회 API | 재고/상태 Redis 우선 조회 (DB 미접촉) |
-| Admin API 정리 | 캠페인 생성 시 Redis 초기화 (stock, total, active flag) 흐름 명확화 |
-| API 문서화 | Swagger/OpenAPI 또는 README에 엔드포인트 명세 정리 |
+| 분류 | API | 조치 |
+|------|-----|------|
+| A. 핵심 유지 | `POST /api/campaigns/{id}/participation` | 유지 |
+| A. 핵심 유지 | `GET /api/campaigns/{id}/participation/{userId}/result` | 유지 |
+| A. 핵심 유지 | `GET/POST /api/admin/campaigns` | 유지 |
+| A. 핵심 유지 | `GET /api/admin/stats/daily` | 유지 |
+| A. 핵심 유지 | `GET /api/admin/stats/campaign/{id}` | 유지 |
+| A. 핵심 유지 | `POST/GET /api/admin/batch/*` | 유지 |
+| B. 보조 | `GET /api/campaigns/{id}/status` | 유지 (운영 요약 목적으로 제한) |
+| B. 보조 | `POST /api/admin/kafka/reload-consumers` | 내부 운영용으로만 |
+| C. 실험용 | `LoadTestController` 전체 | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/raw` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/order-analysis/{id}` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/order-violations/{id}` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `AdminLogController` 전체 | 비노출 + @deprecated 표기 |
+| C. 실험용 | `POST /api/admin/test/participate-bulk` | 비노출 + @deprecated 표기 |
+| v2 잔재 | `POST /api/campaigns/{id}/participation-sync` | 제거 대상 |
+| 불필요 | `AdminViewController` | React SPA라면 제거 |
+
+> 이번 단계는 **삭제가 아니라 비노출 + @deprecated 표기**. 실제 미사용 확인 후 최종 삭제.
+
+#### 프론트 목표 구조
+
+```
+사용자 영역
+  /               랜딩 + 진행 중 캠페인 요약
+  /campaigns      캠페인 목록 + 참여 + 결과 확인
+
+관리자 영역
+  /admin/campaigns    캠페인 생성/조회/상태/재고
+  /admin/stats        일별 통계 + 캠페인별 통계
+  /admin/operations   배치 실행/이력 + DLQ 재처리 + 정합성 점검/복구
+  /admin/system       운영 링크 포털 (Grafana/CloudWatch/Kafka UI 링크)
+```
+
+제거 대상 라우트: `/admin/performance`, `/admin/load-test`, `/admin/monitoring`
+
+> Grafana/CloudWatch가 하는 모니터링을 프론트에서 재구현하지 않는다.
+> `/admin/system`은 직접 차트를 그리는 게 아니라 운영 링크 포털 역할만 수행.
+
+#### 단계별 실행
+
+```
+1단계. App.tsx/Layout.tsx 라우트 + 메뉴 재구성
+2단계. 실험용 페이지 라우트 제거 (파일은 유지)
+3단계. 실험용 API에 @deprecated 주석 추가
+4단계. StatsDashboard + CampaignDetailStats → /admin/stats 통합
+5단계. BatchManagement → /admin/operations 재구성 (시뮬레이션 제거)
+6단계. /admin/system 신설 (Grafana/CloudWatch/Kafka UI 링크 카드)
+```
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # 1Million Campaign Orchestration System — 아키텍처 문서
 
-> 작성일: 2026-04-27
-> v1(10만 트래픽) → v3 Redis-first(100만 트래픽 목표) 전체 설계 및 구현 정리
-> 현재 상태: Phase A(ASG) 완료, Phase B(100만 테스트) 진행 예정
+> 작성일: 2026-04-27  최종 업데이트: 2026-04-28
+> v1(10만 트래픽) → v3 Redis-first(100만 트래픽) 전체 설계 및 구현 정리
+> 현재 상태: Phase B(100만 테스트) 완료 ✅ — TPS ~2,442/s, 정합성 1,000,000건
 
 ---
 
@@ -81,8 +81,8 @@
     v
 [ParticipationEventConsumer — concurrency=10]
     |
-    |-- INSERT IGNORE INTO participation_history (멱등성 보장)
-    |-- Redis 결과 캐시 적재  participation:result:{userId}:{campaignId}
+    |-- jdbcTemplate.batchUpdate() INSERT IGNORE (배치, DB 왕복 N→1)
+    |-- (Redis 결과 캐시 제거 — CME pipeline 병목 원인이었음)
     |
     v
 [MySQL RDS — batch-kafka-db]
@@ -174,8 +174,9 @@ redis.call('LPUSH', KEYS[1], ARGV[2])
 return 1
 ```
 
-- MAX_QUEUE_SIZE = 100,000 (시스템 과부하 방지)
+- MAX_QUEUE_SIZE = 1,000,000 (100만 트래픽 기준, 데이터 유실 방지)
 - LLEN + LPUSH 원자적 실행으로 race condition 없음
+- Queue 상한 초과 시 push() false 반환 → DECR 이미 완료된 상태로 유실 위험 → 상한을 충분히 크게 유지
 
 ---
 
@@ -374,7 +375,7 @@ kafka:
 
 ## 7. ParticipationEventConsumer — DB 최종 기록
 
-v3에서 Consumer의 역할은 단순합니다: **Kafka 메시지를 받아 DB에 INSERT SUCCESS**
+v3에서 Consumer의 역할은 단순합니다: **Kafka 메시지를 받아 DB에 배치 INSERT SUCCESS**
 
 ```java
 @KafkaListener(
@@ -389,19 +390,22 @@ public void consumeParticipationEvent(
     // 1. 메시지 파싱 (sequence 없으면 DLQ)
     List<ParticipationEvent> events = parseRecords(records);
 
-    // 2. DB INSERT IGNORE (멱등성 — UNIQUE(campaign_id, user_id) 제약)
-    for (ParticipationEvent event : events) {
-        participationHistoryRepository.insertSuccess(
-                event.getCampaignId(), event.getUserId(), event.getSequence());
-        // DataIntegrityViolationException → 중복으로 무시 (at-least-once 보장)
-    }
+    // 2. 배치 INSERT IGNORE (DB 왕복 N→1, rewriteBatchedStatements=true)
+    List<Object[]> batchArgs = events.stream()
+        .map(e -> new Object[]{e.getCampaignId(), e.getUserId(), e.getSequence()})
+        .toList();
+    jdbcTemplate.batchUpdate(
+        "INSERT IGNORE INTO participation_history (campaign_id, user_id, sequence, status, created_at) VALUES (?, ?, ?, 'SUCCESS', NOW())",
+        batchArgs
+    );
+    // 배치 실패 시 단건 폴백 + DLQ
 
-    // 3. Redis 결과 캐시 적재 (파이프라인으로 배치 처리)
-    writeResultCache(successEvents);
-
-    // 4. Kafka 오프셋 수동 커밋 (처리 완료 후)
+    // 3. Kafka 오프셋 수동 커밋
     acknowledgment.acknowledge();
 }
+// Redis 결과 캐시(writeResultCache) 제거 — ElastiCache CME pipeline 병목 원인
+// 제거 전: Kafka lag 9K 누적, Consumer 지연 200ms+
+// 제거 후: lag 거의 0, Consumer 지연 7.5~15ms
 ```
 
 ### 멱등성 보장 메커니즘
@@ -648,6 +652,9 @@ SSH를 완전히 차단하고 SSM Session Manager로만 접속합니다. 민감 
 | 6차 | 파티션 3개 (userId 키) | 550/s | 3.12s | 거의 0 | ✅ |
 | 7차 | 3브로커 + 파티션 10개, 12만 | ~1,150/s | - | 거의 0 | ✅ |
 | 8차 | 3브로커 + 파티션 10개, 50만 | ~1,220/s | 2.81s | 거의 0 | ✅ |
+| 9차 | **ASG 2대**, 50만 | ~2,014/s | - | 거의 0 | ✅ |
+| 10차 | **writeResultCache 제거 + 배치 INSERT**, 100만 | ~2,613/s | 2.22s | 거의 0 | ❌ 574,888 (Queue 오버플로우) |
+| **11차** | **MAX_QUEUE_SIZE 1M**, 100만 | **~2,442/s** | **2.74s** | **거의 0** | **✅ 1,000,000** |
 
 ### 병목 분석 및 해결
 
@@ -899,15 +906,18 @@ ItemWriter:    LPUSH 재적재 → Bridge → Kafka → Consumer INSERT
 [완료] Kafka 3-broker KRaft 클러스터
 [완료] ElastiCache CME 3샤드
 [완료] 8차 테스트 (50만, TPS ~1,220/s, 정합성 완벽)
+[완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, min=2/max=3, CPU 60% Target Tracking)
+[완료] Phase B — 100만 트래픽 테스트 ✅
+              - 9차: ASG 2대, TPS ~2,014/s
+              - writeResultCache 제거 (CME pipeline 병목)
+              - Consumer jdbcTemplate.batchUpdate() + rewriteBatchedStatements=true
+              - MAX_QUEUE_SIZE 500K → 1M (데이터 유실 방지)
+              - terraform-mcp t3.large (k6 OOM 방지)
+              - 11차 최종: TPS ~2,442/s, 정합성 1,000,000 ✅
 
-[진행 중] Phase A — ASG Terraform 구성
-              codedeploy.tf + asg.tf + user-data-app.sh
-              기존 단일 EC2 제거 + Prometheus EC2 SD 전환
-
-[예정] Phase B — 9차 테스트 (100만, TPS ~2,400/s 기대)
 [예정] Phase C — API 엔드포인트 v3 기준 정리
 [예정] Phase D — Spring Batch 안전망 (재고 정합성 검증 + 유실 복구)
 [예정] Phase E — MCP 서버 (AI 자율 운영)
 ```
 
-**최종 목표**: 100만 트래픽 처리 + AI가 자율적으로 운영 판단하는 시스템
+**최종 목표**: 100만 트래픽 처리 ✅ + AI가 자율적으로 운영 판단하는 시스템

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ POST /api/campaigns/{id}/participation
      remaining < 0  → 보상 INCR + 400
      remaining == 0 → DB CLOSED + active flag DEL
   3. sequence = total - remaining (선착순 확정)
-  4. RedisQueueService    LPUSH queue:campaign:{id}  (MAX_QUEUE_SIZE=500K)
+  4. RedisQueueService    LPUSH queue:campaign:{id}  (MAX_QUEUE_SIZE=1M)
   5. 202 반환 (DB 미접촉)
 
 ParticipationBridge (@Scheduled 100ms)
@@ -45,7 +45,7 @@ ParticipationBridge (@Scheduled 100ms)
 Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
   → jdbcTemplate.batchUpdate() INSERT IGNORE 배치 처리 (멱등성)
   → 배치 실패 시 단건 폴백 + DLQ
-  → Redis 결과 캐시
+  (Redis 결과 캐시 제거 — CME pipeline 병목 원인이었음)
 ```
 
 ---
@@ -63,24 +63,21 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | 7차 | 3브로커+파티션 10개, 12만 | ~1,150/s | **앱 CPU 90%** |
 | 8차 | 3브로커+파티션 10개, 50만 | ~1,220/s | **앱 CPU 80%** |
 | 9차 | **ASG 2대**, 50만 | ~2,014/s | 앱 CPU 80% (인스턴스당) |
+| 10차 | **writeResultCache 제거 + 배치 INSERT**, 100만 | ~2,613/s | Queue 500K 상한 도달 → 데이터 유실 |
+| **11차** | **MAX_QUEUE_SIZE 1M**, 100만 | **~2,442/s** | **정합성 1,000,000 완벽 ✅** |
 
-### 9차 테스트 상세 (ASG 2대, 50만)
-- 조건: TOTAL_REQUESTS=600,000, 재고=500,000, MAX_VUS=2,000, DURATION=1,200s
-- TPS ~2,014/s (+65%) / avg 988ms (-39%) / 5xx: 0 ✅ / HikariCP pending 거의 0 ✅
-- Redis Queue 100K 상한 도달 → MAX_QUEUE_SIZE 500K로 상향 완료
-- **수평 확장 효과 확인: TPS 2배, avg 절반. 인스턴스당 CPU는 동일 수준 유지**
-
-### 100만 테스트 시도 (9차 이후, 미완료)
+### 11차 테스트 상세 (100만, 최종 성공) ✅
 - 조건: TOTAL_REQUESTS=1,200,000, 재고=1,000,000, MAX_VUS=2,000
-- 78만 근처에서 k6 응답시간 폭발 → 테스트 중단
-- **원인: Redis Queue 적체 (유입 속도 > Consumer 배출 속도)**
-  - Consumer가 Kafka 메시지를 1건씩 DB INSERT → Consumer 처리 병목
-  - Kafka lag 누적 → Bridge 배출 속도 제한 → Queue 500K 상한 도달 → 신규 요청 적재 실패
-  - RDS CPU는 41%로 여유 있었음 — DB 용량 문제 아닌 순수 패턴 문제
-- **조치 완료 (develop 브랜치, 머지 대기 중)**:
-  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1) ✅
-  - SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료 ✅
-  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체 ✅
+- TPS ~2,442/s / avg 816ms / p95 2.74s / 5xx: 0 ✅
+- DB COUNT = **1,000,000** (정합성 완벽) ✅
+- Redis Queue 최대 700K (1M 상한 여유 있음) ✅
+- Consumer 지연 7.5~15ms (배치 INSERT 효과) ✅
+- Kafka lag 거의 0 (rebalancing 순간 700 스파이크 → 즉시 해소) ✅
+- HikariCP pending 거의 0 ✅ / RDS CPU 최대 47% ✅
+
+### 10차 → 11차 개선 포인트
+- 10차: writeResultCache(CME pipeline) 제거 → Kafka lag 9K→거의 0, TPS 2,613/s 달성했으나 Queue 500K 상한으로 **데이터 425K 유실**
+- 11차: MAX_QUEUE_SIZE 1M으로 상향 → Queue 700K까지만 차서 유실 0건
 
 ---
 
@@ -99,23 +96,17 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 ---
 
-## 다음 작업 — Phase B: 100만 트래픽 테스트
+## 전체 로드맵
 
-**목표**: Consumer 배치 INSERT 적용 후 100만 트래픽 처리 검증.
-
-### 배포 전 필수 작업 (모두 완료 ✅)
-- SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료
-- develop 브랜치 배치 INSERT 코드 작성 완료
-- **남은 것: develop → main 머지 → CI/CD 자동 배포**
-
-### 전체 로드맵
 ```
 [완료] v3 Redis-first, Kafka 3-broker, ElastiCache CME, 8차 테스트 (50만 TPS ~1,220/s)
 [완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, EC2 SD, min=2 운영 중)
 [완료] 9차 테스트 (ASG 2대, 50만 TPS ~2,014/s)
-[진행] Phase B — develop→main 머지 후 10만 검증 → 100만 테스트
-       → 10만 검증: batch processed 로그에서 polled= 분포 확인
-       → 통과 시 100만 테스트
+[완료] Phase B — 100만 트래픽 테스트 성공 (11차, TPS ~2,442/s, 정합성 1,000,000 ✅)
+       - writeResultCache 제거 (CME pipeline 병목)
+       - Consumer jdbcTemplate.batchUpdate() 배치 INSERT
+       - MAX_QUEUE_SIZE 500K → 1M (데이터 유실 방지)
+       - terraform-mcp t3.large (k6 OOM 방지)
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
 [예정] Phase E — MCP 서버 (AI 자율 운영)
@@ -132,7 +123,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
 | ASG (앱) | batch-kafka-app-asg (t3.small, min=2/max=3, private_app_2a+2b) |
 | EC2 (Kafka) | kafka-1/2/3 (t3.small, public 2a/2b/2c) |
-| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana+redis-exporter 실행 중) |
+| EC2 (MCP) | terraform-mcp (t3.large, public_2a, Prometheus+Grafana+redis-exporter+kafka-exporter 실행 중) |
 | RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro) |
 | ALB | alb-batch-kafka-api → tg-api-8080 |
 | ElastiCache | CME 3샤드 (Valkey 7.2, cache.t3.micro × 6) |
@@ -201,16 +192,14 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 2. kafka-1/2/3 중지
 3. terraform-mcp 중지
 4. RDS 중지
+5. (장기 미사용 시) 로컬에서:
+   terraform destroy -target=aws_elasticache_replication_group.redis
+   terraform destroy -target=aws_ssm_parameter.redis_cluster_nodes
+   terraform destroy -target=aws_ssm_parameter.redis_exporter_addr
 ```
 
-### 비용 절감 (장기 미사용)
-```bash
-terraform destroy -target=aws_elasticache_replication_group.redis \
-  -target=aws_ssm_parameter.redis_cluster_nodes \
-  -target=aws_ssm_parameter.redis_exporter_addr
-```
-
-> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES, REDIS_EXPORTER_ADDR)은 자동 갱신됨
+> ASG 인스턴스는 콘솔에서 직접 중지 금지 → desired=0으로만
+> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES) 자동 갱신
 > ASG min/max는 ignore_changes로 보호 — terraform apply가 용량을 건드리지 않음
 
 ---
@@ -241,10 +230,14 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 
 ## 면접 핵심 멘트
 
-**프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트"
+**프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트. 최종적으로 100만 트래픽, 정합성 1,000,000건, 5xx 0건 달성"
 
-**CI/CD**: "OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, Blue-Green 무중단 배포"
+**CI/CD**: "OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, CodeDeploy OneAtATime 무중단 배포"
 
-**한계 인지**: "단일 인스턴스 CPU 한계 → ASG 수평 확장, 데이터로 근거 제시"
+**한계 인지**: "단일 인스턴스 CPU 한계 → ASG 수평 확장, 데이터로 근거 제시. TPS 1,220→2,014/s (+65%) 확인"
 
-**Consumer 병목 개선**: "Kafka batch listener로 받아도 DB INSERT가 1건씩이면 소용없다는 걸 로그로 확인 후, JdbcTemplate.batchUpdate + rewriteBatchedStatements=true로 DB 왕복 N→1로 줄임"
+**Consumer 병목 개선**: "Kafka batch listener로 받아도 DB INSERT가 1건씩이면 소용없다는 걸 로그로 확인 후, JdbcTemplate.batchUpdate + rewriteBatchedStatements=true로 DB 왕복 N→1로 줄임. Consumer 지연 200ms → 7.5ms"
+
+**데이터 유실 발견 및 해결**: "10차 테스트에서 DB 정합성 검증 중 574,888건만 INSERT된 것 발견. Redis Queue 500K 상한 초과 시 LPUSH 실패해도 202 반환하는 구조적 문제. MAX_QUEUE_SIZE 1M으로 상향해 11차에서 정합성 완벽 달성"
+
+**모니터링**: "Prometheus + Grafana 커스텀 메트릭 4종(Bridge 드레인 속도/사이클, Consumer 지연, Redis Queue 적재량). Docker monitoring 네트워크로 컨테이너 이름 기반 DNS — IP 관리 불필요"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,11 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 - **원인: Redis Queue 적체 (유입 속도 > Consumer 배출 속도)**
   - Consumer가 Kafka 메시지를 1건씩 DB INSERT → Consumer 처리 병목
   - Kafka lag 누적 → Bridge 배출 속도 제한 → Queue 500K 상한 도달 → 신규 요청 적재 실패
-- **조치 (develop 브랜치, 배포 대기 중)**:
-  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1)
-  - JDBC URL `rewriteBatchedStatements=true` 추가 (SSM 업데이트 필요)
-  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체
+  - RDS CPU는 41%로 여유 있었음 — DB 용량 문제 아닌 순수 패턴 문제
+- **조치 완료 (develop 브랜치, 머지 대기 중)**:
+  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1) ✅
+  - SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료 ✅
+  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체 ✅
 
 ---
 
@@ -102,33 +103,18 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 **목표**: Consumer 배치 INSERT 적용 후 100만 트래픽 처리 검증.
 
-### 배포 전 필수 작업
-```bash
-# SSM JDBC URL에 rewriteBatchedStatements=true 추가 (terraform-mcp에서)
-CURRENT_URL=$(aws ssm get-parameter \
-  --name /batch-kafka/prod/SPRING_DATASOURCE_URL \
-  --with-decryption --query Parameter.Value --output text)
-
-if [[ "$CURRENT_URL" == *"rewriteBatchedStatements=true"* ]]; then
-  NEW_URL="$CURRENT_URL"
-elif [[ "$CURRENT_URL" == *"?"* ]]; then
-  NEW_URL="${CURRENT_URL}&rewriteBatchedStatements=true"
-else
-  NEW_URL="${CURRENT_URL}?rewriteBatchedStatements=true"
-fi
-
-aws ssm put-parameter \
-  --name /batch-kafka/prod/SPRING_DATASOURCE_URL \
-  --value "$NEW_URL" --type SecureString --overwrite
-```
+### 배포 전 필수 작업 (모두 완료 ✅)
+- SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료
+- develop 브랜치 배치 INSERT 코드 작성 완료
+- **남은 것: develop → main 머지 → CI/CD 자동 배포**
 
 ### 전체 로드맵
 ```
 [완료] v3 Redis-first, Kafka 3-broker, ElastiCache CME, 8차 테스트 (50만 TPS ~1,220/s)
 [완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, EC2 SD, min=2 운영 중)
 [완료] 9차 테스트 (ASG 2대, 50만 TPS ~2,014/s)
-[진행] Phase B — Consumer 배치 INSERT 적용 후 100만 테스트
-       → 10만 검증 먼저 (records.size() 분포, Queue slope, Kafka lag 확인)
+[진행] Phase B — develop→main 머지 후 10만 검증 → 100만 테스트
+       → 10만 검증: batch processed 로그에서 polled= 분포 확인
        → 통과 시 100만 테스트
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
@@ -146,7 +132,7 @@ aws ssm put-parameter \
 | VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
 | ASG (앱) | batch-kafka-app-asg (t3.small, min=2/max=3, private_app_2a+2b) |
 | EC2 (Kafka) | kafka-1/2/3 (t3.small, public 2a/2b/2c) |
-| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana 실행 중) |
+| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana+redis-exporter 실행 중) |
 | RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro) |
 | ALB | alb-batch-kafka-api → tg-api-8080 |
 | ElastiCache | CME 3샤드 (Valkey 7.2, cache.t3.micro × 6) |
@@ -155,6 +141,23 @@ aws ssm put-parameter \
 | S3 (tfstate) | campaign-terraform-state-631124976154 |
 | CodeDeploy | App: batch-kafka-app / DG: batch-kafka-prod-dg (ASG 연결, IaC 완료) |
 | SSM | /batch-kafka/prod/* |
+
+---
+
+## 모니터링 구성 (terraform-mcp)
+
+- Prometheus + Grafana + redis-exporter + kafka-exporter 모두 Docker 컨테이너
+- **Docker monitoring 네트워크**: 컨테이너 이름 기반 통신 (IP 변경 무관)
+  ```bash
+  # 컨테이너 재생성 시 네트워크 연결 필수
+  sudo docker network connect monitoring <container>
+  ```
+- **prometheus.yml 타겟** (IP 아닌 컨테이너 이름):
+  - spring-boot: ec2_sd_configs (ASG 동적 감지, :8080)
+  - kafka-exporter: `kafka-exporter:9308`
+  - redis-exporter: `redis-exporter:9121`
+- prometheus.yml 위치: `/home/ec2-user/prometheus.yml`
+- redis-exporter는 terraform-mcp 단독 실행 (ASG 중복 수집 방지)
 
 ---
 
@@ -167,28 +170,48 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 
 ## 인프라 ON/OFF 순서
 
-### 켤 때
+### 켤 때 (ElastiCache destroy 후 재apply 시)
 ```
-1. RDS 시작 (3~5분 대기)
-2. ASG desired=2, min=2, max=3
+1. terraform apply (ElastiCache + SSM 자동 갱신, ~10~15분)
+2. RDS 시작 (3~5분 대기)
 3. kafka-1/2/3 시작
 4. terraform-mcp 시작
-5. terraform-mcp SSM 접속 후 redis-exporter 실행:
+5. terraform-mcp에서 redis-exporter 재실행 (SSM에서 새 엔드포인트 자동 읽음):
+   sudo docker rm -f redis-exporter
    sudo docker run -d --name redis-exporter --restart unless-stopped -p 9121:9121 \
+     --network monitoring \
      -e REDIS_ADDR="$(aws ssm get-parameter --name /batch-kafka/prod/REDIS_EXPORTER_ADDR \
      --with-decryption --query Parameter.Value --output text)" \
      -e REDIS_EXPORTER_IS_CLUSTER=true oliver006/redis_exporter
+   sudo docker network connect monitoring redis-exporter
+6. ASG 콘솔에서 desired=2, min=2, max=3 (terraform apply와 독립)
+```
+
+### 켤 때 (EC2 재시작만, ElastiCache 유지 시)
+```
+1. RDS 시작
+2. kafka-1/2/3 시작
+3. terraform-mcp 시작 (--restart unless-stopped로 컨테이너 자동 복구)
+4. ASG 콘솔에서 desired=2, min=2, max=3
 ```
 
 ### 끌 때
 ```
-1. ASG desired=0, min=0, max=0
+1. ASG 콘솔에서 desired=0, min=0, max=0
 2. kafka-1/2/3 중지
 3. terraform-mcp 중지
 4. RDS 중지
 ```
 
-> ElastiCache는 중지 기능 없음 — 장기 미사용 시 terraform destroy
+### 비용 절감 (장기 미사용)
+```bash
+terraform destroy -target=aws_elasticache_replication_group.redis \
+  -target=aws_ssm_parameter.redis_cluster_nodes \
+  -target=aws_ssm_parameter.redis_exporter_addr
+```
+
+> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES, REDIS_EXPORTER_ADDR)은 자동 갱신됨
+> ASG min/max는 ignore_changes로 보호 — terraform apply가 용량을 건드리지 않음
 
 ---
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/ConsistencyRecoveryController.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/ConsistencyRecoveryController.java
@@ -1,0 +1,117 @@
+package io.eventdriven.campaign.api.controller;
+
+import io.eventdriven.campaign.api.common.ApiResponse;
+import io.eventdriven.campaign.api.dto.request.ConsistencyRecoveryRequest;
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/consistency-recovery")
+@RequiredArgsConstructor
+@SuppressWarnings("removal")
+public class ConsistencyRecoveryController {
+
+    @Qualifier("asyncJobLauncher")
+    private final JobLauncher asyncJobLauncher;
+
+    @Qualifier("consistencyRecoveryJob")
+    private final Job consistencyRecoveryJob;
+
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> run(@RequestBody(required = false) ConsistencyRecoveryRequest request) {
+        try {
+            ConsistencyRecoveryRequest effectiveRequest = request != null ? request : new ConsistencyRecoveryRequest();
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.createExecution(
+                    effectiveRequest.getRequestedBy(),
+                    effectiveRequest.getDryRun(),
+                    effectiveRequest.getAutoFix(),
+                    effectiveRequest.getCampaignId(),
+                    effectiveRequest.getMaxCampaigns()
+            );
+
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("consistencyRecoveryExecutionId", execution.getId())
+                    .addLong("ts", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution jobExecution = asyncJobLauncher.run(consistencyRecoveryJob, params);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("jobExecutionId", jobExecution.getId());
+            data.put("consistencyRecoveryExecutionId", execution.getId());
+            data.put("dryRun", execution.isDryRun());
+            data.put("autoFix", execution.isAutoFix());
+            data.put("targetCount", execution.getTargetCount());
+            data.put("maxCampaigns", execution.getMaxCampaigns());
+
+            return ResponseEntity.ok(ApiResponse.success("Consistency recovery batch started", data));
+        } catch (JobExecutionAlreadyRunningException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.fail("Consistency recovery job is already running"));
+        } catch (JobRestartException | JobInstanceAlreadyCompleteException | InvalidJobParametersException e) {
+            log.error("Failed to start consistency recovery job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to start consistency recovery job: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("Unexpected error while starting consistency recovery job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Unexpected error: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions/{executionId}")
+    public ResponseEntity<ApiResponse<?>> getExecution(@PathVariable Long executionId) {
+        try {
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.getExecution(executionId);
+            return ResponseEntity.ok(ApiResponse.success(
+                    consistencyRecoveryService.toExecutionResponse(
+                            execution,
+                            consistencyRecoveryService.getExecutionResults(executionId)
+                    )
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to read consistency recovery execution. executionId={}", executionId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read execution: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions")
+    public ResponseEntity<ApiResponse<?>> getExecutions(
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success(
+                    consistencyRecoveryService.getExecutions(Math.min(size, 100))
+            ));
+        } catch (Exception e) {
+            log.error("Failed to read consistency recovery executions", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read executions: " + e.getMessage()));
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/DlqReplayController.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/DlqReplayController.java
@@ -1,0 +1,125 @@
+package io.eventdriven.campaign.api.controller;
+
+import io.eventdriven.campaign.api.common.ApiResponse;
+import io.eventdriven.campaign.api.dto.request.DlqReplayRequest;
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/dlq-replay")
+@RequiredArgsConstructor
+@SuppressWarnings("removal")
+public class DlqReplayController {
+
+    @Qualifier("asyncJobLauncher")
+    private final JobLauncher asyncJobLauncher;
+
+    @Qualifier("dlqReplayJob")
+    private final Job dlqReplayJob;
+
+    private final DlqReplayService dlqReplayService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> replay(@RequestBody(required = false) DlqReplayRequest request) {
+        try {
+            DlqReplayRequest effectiveRequest = request != null ? request : new DlqReplayRequest();
+            DlqReplayExecution execution = dlqReplayService.createExecution(
+                    effectiveRequest.getRequestedBy(),
+                    effectiveRequest.getDryRun(),
+                    effectiveRequest.getCampaignId(),
+                    effectiveRequest.getReason(),
+                    effectiveRequest.getFromTime(),
+                    effectiveRequest.getToTime(),
+                    effectiveRequest.getMaxItems()
+            );
+
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("replayExecutionId", execution.getId())
+                    .addLong("ts", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution jobExecution = asyncJobLauncher.run(dlqReplayJob, params);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("jobExecutionId", jobExecution.getId());
+            data.put("replayExecutionId", execution.getId());
+            data.put("dryRun", execution.isDryRun());
+            data.put("targetCount", execution.getTargetCount());
+            data.put("maxItems", execution.getMaxItems());
+
+            return ResponseEntity.ok(ApiResponse.success("DLQ replay batch started", data));
+        } catch (JobExecutionAlreadyRunningException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.fail("DLQ replay job is already running"));
+        } catch (JobRestartException | JobInstanceAlreadyCompleteException | InvalidJobParametersException e) {
+            log.error("Failed to start DLQ replay job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to start DLQ replay job: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("Unexpected error while starting DLQ replay job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Unexpected error: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions/{executionId}")
+    public ResponseEntity<ApiResponse<?>> getExecution(@PathVariable Long executionId) {
+        try {
+            DlqReplayExecution execution = dlqReplayService.getExecution(executionId);
+            return ResponseEntity.ok(ApiResponse.success(
+                    dlqReplayService.toExecutionResponse(execution, dlqReplayService.getExecutionItems(executionId))
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to read DLQ replay execution. executionId={}", executionId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read execution: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<ApiResponse<?>> getMessages(
+            @RequestParam(required = false) DlqMessageProcessingStatus status,
+            @RequestParam(required = false) Long campaignId,
+            @RequestParam(required = false) String reason,
+            @RequestParam(defaultValue = "100") int size
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success(
+                    dlqReplayService.searchMessages(status, campaignId, reason, Math.min(size, 500))
+            ));
+        } catch (Exception e) {
+            log.error("Failed to read DLQ messages", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read DLQ messages: " + e.getMessage()));
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/ConsistencyRecoveryRequest.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/ConsistencyRecoveryRequest.java
@@ -1,0 +1,14 @@
+package io.eventdriven.campaign.api.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ConsistencyRecoveryRequest {
+    private String requestedBy;
+    private Boolean dryRun;
+    private Boolean autoFix;
+    private Long campaignId;
+    private Integer maxCampaigns;
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/DlqReplayRequest.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/DlqReplayRequest.java
@@ -1,0 +1,18 @@
+package io.eventdriven.campaign.api.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class DlqReplayRequest {
+    private String requestedBy;
+    private Boolean dryRun;
+    private Long campaignId;
+    private String reason;
+    private LocalDateTime fromTime;
+    private LocalDateTime toTime;
+    private Integer maxItems;
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -1,6 +1,8 @@
 package io.eventdriven.campaign.application.bridge;
 
+import io.eventdriven.campaign.application.event.DlqEventPayload;
 import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.application.service.DlqMessageService;
 import io.eventdriven.campaign.application.service.RedisStockService;
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.config.KafkaConfig;
@@ -18,66 +20,45 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Redis Queue → Kafka 유량 조절 브릿지 (v2)
- *
- * 역할: API에서 LPUSH된 메시지를 RPOP 후 Kafka로 발행.
- * - active:campaigns Set 순회 → 캠페인별 큐 드레인
- * - MAX_RETRY 3회 + exponential backoff 후 실패 시 DLQ + Slack 알림
- * - RPOP 실패 시 LPUSH 재적재 금지 (Queue 순서 뒤섞임 방지)
- * - 파티션 키: userId (파티션 균등 분산, v3에서 선착순은 Redis DECR 시점에 이미 확정)
- *
- * 주의: @EnableScheduling이 CampaignCoreApplication에 있어야 동작.
- */
 @Slf4j
 @Component
-// @RequiredArgsConstructor 미사용 이유:
-// Timer는 Spring Bean이 아닌 직접 생성 객체(Timer.builder().register())이므로
-// Lombok이 생성자 파라미터로 주입할 수 없음.
-// MeterRegistry(Bean)를 먼저 주입받은 뒤 생성자 안에서 Timer를 직접 만들어야 하므로
-// 생성자를 수동으로 작성함.
 public class ParticipationBridge {
+
+    private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
+    private static final int MAX_RETRY = 3;
 
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final RedisStockService redisStockService;
     private final SlackNotificationService slackNotificationService;
-    private final MeterRegistry meterRegistry;  // Spring Bean → 생성자 주입
+    private final MeterRegistry meterRegistry;
     private final JsonMapper jsonMapper;
-
-    private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
-    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
-    private static final int MAX_RETRY = 3;
-
-    // campaignId별 Counter 캐시
-    // campaignId는 런타임에 결정되므로 생성자에서 미리 만들 수 없음 , 첫 발행 시 lazily 생성 후 재사용
+    private final DlqMessageService dlqMessageService;
+    private final Timer drainTimer;
     private final Map<Long, Counter> publishedCounters = new ConcurrentHashMap<>();
 
-    // Timer는 Bean이 아닌 직접 생성 객체, 생성자에서 MeterRegistry를 받아 초기화
-    private final Timer drainTimer;
-
-    public ParticipationBridge(RedisTemplate<String, String> redisTemplate,
-                               KafkaTemplate<String, String> kafkaTemplate,
-                               RedisStockService redisStockService,
-                               SlackNotificationService slackNotificationService,
-                               MeterRegistry meterRegistry,
-                               JsonMapper jsonMapper) {
+    public ParticipationBridge(
+            RedisTemplate<String, String> redisTemplate,
+            KafkaTemplate<String, String> kafkaTemplate,
+            RedisStockService redisStockService,
+            SlackNotificationService slackNotificationService,
+            MeterRegistry meterRegistry,
+            JsonMapper jsonMapper,
+            DlqMessageService dlqMessageService
+    ) {
         this.redisTemplate = redisTemplate;
         this.kafkaTemplate = kafkaTemplate;
         this.redisStockService = redisStockService;
         this.slackNotificationService = slackNotificationService;
-        this.meterRegistry = meterRegistry;  // 1. Bean 주입 완료
+        this.meterRegistry = meterRegistry;
         this.jsonMapper = jsonMapper;
+        this.dlqMessageService = dlqMessageService;
         this.drainTimer = Timer.builder("bridge.drain.duration")
-                .description("drainQueues() 실행 소요시간")
-                .register(meterRegistry);    // 2. 주입된 MeterRegistry로 Timer 등록
+                .description("Time spent draining Redis queues into Kafka")
+                .register(meterRegistry);
     }
 
-    /**
-     * 100ms마다 실행 (fixedDelay: 이전 실행 완료 후 100ms 대기)
-     * active:campaigns Set에 등록된 캠페인별로 큐 드레인
-     */
     @Scheduled(fixedDelay = 100)
     public void drainQueues() {
         drainTimer.record(() -> {
@@ -90,16 +71,12 @@ public class ParticipationBridge {
                 try {
                     drainCampaignQueue(Long.parseLong(campaignIdStr));
                 } catch (Exception e) {
-                    log.error("캠페인 큐 드레인 중 예외 발생. campaignId={}", campaignIdStr, e);
+                    log.error("Failed to drain campaign queue. campaignId={}", campaignIdStr, e);
                 }
             }
         });
     }
 
-    /**
-     * 단일 캠페인 큐 드레인
-     * 큐 크기에 따라 동적으로 batchSize 결정 후 RPOP → Kafka 발행. 큐가 비면 즉시 종료.
-     */
     private void drainCampaignQueue(Long campaignId) {
         String queueKey = QUEUE_KEY_PREFIX + campaignId;
         Long queueSize = redisTemplate.opsForList().size(queueKey);
@@ -108,11 +85,9 @@ public class ParticipationBridge {
         for (int i = 0; i < dynamicBatchSize; i++) {
             String message = redisTemplate.opsForList().rightPop(queueKey);
             if (message == null) {
-                // 큐가 비었고 active flag도 없으면 재고까지 소진된 캠페인
-                // → Lua가 DEL한 active:campaign:{id}를 확인 후 전역 Set에서도 제거
                 if (!redisStockService.isActive(campaignId)) {
                     redisStockService.deactivateCampaign(campaignId);
-                    log.info("캠페인 {} 재고 소진 + 큐 드레인 완료 → active:campaigns 제거", campaignId);
+                    log.info("Campaign drained and deactivated. campaignId={}", campaignId);
                 }
                 break;
             }
@@ -120,54 +95,45 @@ public class ParticipationBridge {
         }
     }
 
-    /**
-     * 큐 크기 기반 동적 batchSize 결정
-     * 큐 적체량에 비례해 드레인 속도 자동 조절
-     */
     private int resolveBatchSize(Long queueSize) {
-        if (queueSize == null || queueSize < 10_000) return 500;
-        if (queueSize < 100_000) return 1_000;
+        if (queueSize == null || queueSize < 10_000) {
+            return 500;
+        }
+        if (queueSize < 100_000) {
+            return 1_000;
+        }
         return 2_000;
     }
 
-    /**
-     * Kafka 발행 (MAX_RETRY 3회 + exponential backoff)
-     * 최종 실패 시 DLQ 전송 + Slack 알림.
-     * 실패 메시지를 Redis Queue에 재적재하지 않음 (순서 보장 우선).
-     */
     private void publishWithRetry(Long campaignId, String message) {
         String partitionKey = extractUserIdKey(message, campaignId);
         for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
             try {
                 kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
-                // Kafka 발행 성공 카운터 — campaignId 태그로 캠페인별 구분
                 publishedCounters.computeIfAbsent(campaignId, id ->
                         Counter.builder("bridge.messages.published")
-                                .description("Kafka 발행 성공 건수")
+                                .description("Kafka messages published by bridge")
                                 .tag("campaignId", String.valueOf(id))
                                 .register(meterRegistry)
                 ).increment();
-                return; // 성공
+                return;
             } catch (Exception e) {
-                log.warn("Kafka 발행 실패 (시도 {}/{}). campaignId={}", attempt, MAX_RETRY, campaignId, e);
-
+                log.warn("Kafka publish failed. attempt={}/{}, campaignId={}", attempt, MAX_RETRY, campaignId, e);
                 if (attempt < MAX_RETRY) {
-                    long backoffMs = (long) Math.pow(2, attempt) * 100L; // 200ms → 400ms
+                    long backoffMs = (long) Math.pow(2, attempt) * 100L;
                     try {
                         Thread.sleep(backoffMs);
-                    } catch (InterruptedException ie) {
+                    } catch (InterruptedException interruptedException) {
                         Thread.currentThread().interrupt();
-                        log.error("Bridge 스레드 인터럽트. campaignId={}", campaignId);
-                        sendToDlqWithSlack(campaignId, message, "THREAD_INTERRUPTED");
+                        sendToDlqWithSlack(campaignId, partitionKey, message,
+                                "THREAD_INTERRUPTED", interruptedException.getMessage());
                         return;
                     }
                 }
             }
         }
 
-        // MAX_RETRY 모두 소진
-        log.error("Bridge MAX_RETRY({}) 초과. DLQ 전송. campaignId={}", MAX_RETRY, campaignId);
-        sendToDlqWithSlack(campaignId, message, "MAX_RETRY_EXCEEDED");
+        sendToDlqWithSlack(campaignId, partitionKey, message, "MAX_RETRY_EXCEEDED", null);
     }
 
     private String extractUserIdKey(String message, Long campaignId) {
@@ -175,26 +141,35 @@ public class ParticipationBridge {
             ParticipationEvent event = jsonMapper.readValue(message, ParticipationEvent.class);
             return String.valueOf(event.getUserId());
         } catch (Exception e) {
-            log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
+            log.warn("Failed to extract userId partition key. campaignId={}", campaignId, e);
             return String.valueOf(campaignId);
         }
     }
 
-    /**
-     * DLQ 전송 + Slack 알림
-     * DLQ 전송 자체 실패 시 로그로만 기록 (무한 루프 방지)
-     */
-    private void sendToDlqWithSlack(Long campaignId, String message, String errorReason) {
+    private void sendToDlqWithSlack(
+            Long campaignId,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
         try {
-            kafkaTemplate.send(DLQ_TOPIC, String.valueOf(campaignId), message);
-            log.info("Bridge DLQ 전송 완료. campaignId={}, reason={}", campaignId, errorReason);
+            DlqEventPayload payload = dlqMessageService.createBridgePayload(
+                    campaignId,
+                    originalKey,
+                    originalMessage,
+                    errorReason,
+                    errorMessage
+            );
+            dlqMessageService.publishAndStore(payload);
+            log.info("Bridge message moved to DLQ. campaignId={}, reason={}", campaignId, errorReason);
         } catch (Exception e) {
-            log.error("CRITICAL: Bridge DLQ 전송도 실패! campaignId={}, message={}", campaignId, message, e);
+            log.error("Failed to move bridge message to DLQ. campaignId={}", campaignId, e);
         }
 
         slackNotificationService.sendDlqAlert(
-                "Bridge Produce " + errorReason,
-                "campaignId=" + campaignId
+                "Bridge " + errorReason,
+                "campaignId=" + campaignId + ", key=" + originalKey
         );
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -18,6 +18,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -26,7 +27,8 @@ public class ParticipationBridge {
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final int MAX_RETRY = 3;
+    private static final String IMMEDIATE_SEND_FAILED = "IMMEDIATE_SEND_FAILED";
+    private static final String ASYNC_SEND_FAILED = "ASYNC_SEND_FAILED";
 
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
@@ -91,7 +93,7 @@ public class ParticipationBridge {
                 }
                 break;
             }
-            publishWithRetry(campaignId, message);
+            publishAsync(campaignId, message);
         }
     }
 
@@ -105,35 +107,43 @@ public class ParticipationBridge {
         return 2_000;
     }
 
-    private void publishWithRetry(Long campaignId, String message) {
+    private void publishAsync(Long campaignId, String message) {
         String partitionKey = extractUserIdKey(message, campaignId);
-        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
-            try {
-                kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
-                publishedCounters.computeIfAbsent(campaignId, id ->
-                        Counter.builder("bridge.messages.published")
-                                .description("Kafka messages published by bridge")
-                                .tag("campaignId", String.valueOf(id))
-                                .register(meterRegistry)
-                ).increment();
-                return;
-            } catch (Exception e) {
-                log.warn("Kafka publish failed. attempt={}/{}, campaignId={}", attempt, MAX_RETRY, campaignId, e);
-                if (attempt < MAX_RETRY) {
-                    long backoffMs = (long) Math.pow(2, attempt) * 100L;
-                    try {
-                        Thread.sleep(backoffMs);
-                    } catch (InterruptedException interruptedException) {
-                        Thread.currentThread().interrupt();
-                        sendToDlqWithSlack(campaignId, partitionKey, message,
-                                "THREAD_INTERRUPTED", interruptedException.getMessage());
-                        return;
-                    }
-                }
-            }
-        }
+        try {
+            kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            Throwable failure = unwrapCompletionException(ex);
+                            log.warn("Kafka publish completed with failure. campaignId={}", campaignId, failure);
+                            sendToDlqWithSlack(
+                                    campaignId,
+                                    partitionKey,
+                                    message,
+                                    ASYNC_SEND_FAILED,
+                                    failure.getMessage()
+                            );
+                            return;
+                        }
 
-        sendToDlqWithSlack(campaignId, partitionKey, message, "MAX_RETRY_EXCEEDED", null);
+                        publishedCounters.computeIfAbsent(campaignId, id ->
+                                Counter.builder("bridge.messages.published")
+                                        .description("Kafka messages published by bridge")
+                                        .tag("campaignId", String.valueOf(id))
+                                        .register(meterRegistry)
+                        ).increment();
+                    });
+        } catch (Exception e) {
+            log.warn("Kafka publish failed before enqueue. campaignId={}", campaignId, e);
+            sendToDlqWithSlack(campaignId, partitionKey, message, IMMEDIATE_SEND_FAILED, e.getMessage());
+        }
+    }
+
+    private Throwable unwrapCompletionException(Throwable throwable) {
+        if (throwable instanceof CompletionException completionException
+                && completionException.getCause() != null) {
+            return completionException.getCause();
+        }
+        return throwable;
     }
 
     private String extractUserIdKey(String message, Long campaignId) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -113,10 +113,6 @@ public class ParticipationEventConsumer {
         log.info("batch processed. polled={}, parsed={}, success={}, latency_ms={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        // ④ 결과 캐시 적재 (DB 커밋 후)
-        if (!successEvents.isEmpty()) {
-            writeResultCache(successEvents);
-        }
 
         // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -1,6 +1,8 @@
 package io.eventdriven.campaign.application.consumer;
 
+import io.eventdriven.campaign.application.event.DlqEventPayload;
 import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.application.service.DlqMessageService;
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -14,7 +16,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
@@ -22,35 +23,24 @@ import tools.jackson.databind.json.JsonMapper;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-/**
- * 선착순 참여 이벤트 Consumer (v3)
- *
- * v3 역할: API에서 Redis DECR만 하고 DB 미접촉 → Consumer가 DB INSERT SUCCESS 직접 처리
- * - API: RateLimit → DECR → LPUSH → 202 (DB 없음)
- * - Consumer: (campaignId, userId, sequence) → INSERT SUCCESS
- * - 멱등성: UNIQUE(campaign_id, user_id) 제약 → DataIntegrityViolationException 무시
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ParticipationEventConsumer {
 
+    private static final String RESULT_CACHE_PREFIX = "participation:result:";
+    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
+
     private final JsonMapper jsonMapper;
     private final ParticipationHistoryRepository participationHistoryRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final KafkaTemplate<String, String> kafkaTemplate;
     private final RedisTemplate<String, String> redisTemplate;
     private final SlackNotificationService slackNotificationService;
+    private final DlqMessageService dlqMessageService;
     private final MeterRegistry meterRegistry;
-
-    private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
-    private static final String RESULT_CACHE_PREFIX = "participation:result:";
-    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
 
     @KafkaListener(
             topics = "campaign-participation-topic",
@@ -58,67 +48,67 @@ public class ParticipationEventConsumer {
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeParticipationEvent(List<ConsumerRecord<String, String>> records, Acknowledgment acknowledgment) {
-
-        // ① 메시지 파싱 — sequence 없는 메시지는 Poison Pill로 DLQ
         List<ParticipationEvent> events = parseRecords(records);
-
         if (events.isEmpty()) {
             acknowledgment.acknowledge();
             return;
         }
 
-        // ② DB INSERT SUCCESS 직접 처리 (배치 INSERT → 단건 폴백)
         LocalDateTime batchStart = LocalDateTime.now();
         List<ParticipationEvent> successEvents = new ArrayList<>();
 
         try {
-            // 배치 INSERT IGNORE — 한 번의 JDBC 왕복으로 전체 처리
             List<Object[]> batchArgs = new ArrayList<>(events.size());
             for (ParticipationEvent event : events) {
                 batchArgs.add(new Object[]{event.getCampaignId(), event.getUserId(), event.getSequence()});
             }
             jdbcTemplate.batchUpdate(
-                    "INSERT IGNORE INTO participation_history (campaign_id, user_id, sequence, status, created_at) VALUES (?, ?, ?, 'SUCCESS', NOW())",
+                    "INSERT IGNORE INTO participation_history "
+                            + "(campaign_id, user_id, sequence, status, created_at) "
+                            + "VALUES (?, ?, ?, 'SUCCESS', NOW())",
                     batchArgs
             );
             successEvents.addAll(events);
-
-        } catch (Exception batchEx) {
-            // 배치 실패 시 단건 폴백 (어떤 레코드가 문제인지 파악 + DLQ 전송)
-            log.warn("배치 INSERT 실패 → 단건 폴백. {}건", events.size(), batchEx);
+        } catch (Exception batchException) {
+            log.warn("Batch insert failed. Falling back to row-by-row insert. count={}", events.size(), batchException);
             for (ParticipationEvent event : events) {
                 try {
                     participationHistoryRepository.insertSuccess(
-                            event.getCampaignId(), event.getUserId(), event.getSequence());
+                            event.getCampaignId(),
+                            event.getUserId(),
+                            event.getSequence()
+                    );
                     successEvents.add(event);
                 } catch (DataIntegrityViolationException e) {
-                    log.warn("중복 INSERT 무시 (멱등). campaignId={}, userId={}, sequence={}",
+                    log.warn("Duplicate success ignored. campaignId={}, userId={}, sequence={}",
                             event.getCampaignId(), event.getUserId(), event.getSequence());
                     successEvents.add(event);
                 } catch (Exception e) {
-                    log.error("INSERT 실패 → DLQ. campaignId={}, userId={}, sequence={}",
+                    log.error("Insert failed. campaignId={}, userId={}, sequence={}",
                             event.getCampaignId(), event.getUserId(), event.getSequence(), e);
-                    sendToDlqWithSlack(buildMessageStr(event), "INSERT_FAILED", e);
+                    sendToDlqWithSlack(
+                            String.valueOf(event.getUserId()),
+                            serializeEvent(event),
+                            "INSERT_FAILED",
+                            e
+                    );
                 }
             }
         }
 
-        // ③ 지연시간 측정 (API LPUSH ~ Consumer INSERT 완료)
         long latencyMs = Duration.between(batchStart, LocalDateTime.now()).toMillis();
         Timer.builder("consumer.pending_to_success.latency")
-                .description("API LPUSH ~ Consumer INSERT SUCCESS 지연시간")
+                .description("Time from consumer batch start to DB success insert")
                 .register(meterRegistry)
                 .record(latencyMs, TimeUnit.MILLISECONDS);
 
-        log.info("batch processed. polled={}, parsed={}, success={}, latency_ms={}",
+        log.info("Consumer batch processed. polled={}, parsed={}, success={}, latencyMs={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        // ④ 결과 캐시 적재 (DB 커밋 후)
         if (!successEvents.isEmpty()) {
             writeResultCache(successEvents);
         }
 
-        // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
     }
 
@@ -136,9 +126,8 @@ public class ParticipationEventConsumer {
                     return null;
                 }
             });
-            log.debug("결과 캐시 적재 완료. {}건", events.size());
         } catch (Exception e) {
-            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
+            log.error("Failed to write result cache. count={}", events.size(), e);
         }
     }
 
@@ -148,36 +137,47 @@ public class ParticipationEventConsumer {
             try {
                 ParticipationEvent event = jsonMapper.readValue(record.value(), ParticipationEvent.class);
                 if (event.getSequence() == null) {
-                    log.warn("sequence 없는 메시지 (Poison Pill) - DLQ 전송: {}", record.value());
-                    sendToDlqWithSlack(record.value(), "MISSING_SEQUENCE", null);
+                    log.warn("Missing sequence. Sending to DLQ. payload={}", record.value());
+                    sendToDlqWithSlack(record.key(), record.value(), "MISSING_SEQUENCE", null);
                     continue;
                 }
                 events.add(event);
             } catch (Exception e) {
-                log.error("JSON 파싱 실패 - DLQ 전송: {}", record.value(), e);
-                sendToDlqWithSlack(record.value(), "JSON_PARSE_ERROR", e);
+                log.error("Failed to parse consumer payload. payload={}", record.value(), e);
+                sendToDlqWithSlack(record.key(), record.value(), "JSON_PARSE_ERROR", e);
             }
         }
         return events;
     }
 
-    private void sendToDlqWithSlack(String originalMessage, String errorReason, Exception exception) {
+    private void sendToDlqWithSlack(
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            Exception exception
+    ) {
         try {
-            Map<String, Object> dlqMessage = new HashMap<>();
-            dlqMessage.put("originalMessage", originalMessage);
-            dlqMessage.put("errorReason", errorReason);
-            dlqMessage.put("errorMessage", exception != null ? exception.getMessage() : null);
-            dlqMessage.put("timestamp", LocalDateTime.now().toString());
-            kafkaTemplate.send(DLQ_TOPIC, jsonMapper.writeValueAsString(dlqMessage));
-            log.info("DLQ 전송 완료 - 사유: {}", errorReason);
+            DlqEventPayload payload = dlqMessageService.createConsumerPayload(
+                    originalKey,
+                    originalMessage,
+                    errorReason,
+                    exception != null ? exception.getMessage() : null
+            );
+            dlqMessageService.publishAndStore(payload);
         } catch (Exception e) {
-            log.error("CRITICAL: DLQ 전송 실패! 원본: {}", originalMessage, e);
+            log.error("Failed to publish consumer DLQ payload. reason={}", errorReason, e);
         }
+
         slackNotificationService.sendDlqAlert("Consumer " + errorReason, originalMessage);
     }
 
-    private String buildMessageStr(ParticipationEvent event) {
-        return String.format("{campaignId:%d, userId:%d, sequence:%d}",
-                event.getCampaignId(), event.getUserId(), event.getSequence());
+    private String serializeEvent(ParticipationEvent event) {
+        try {
+            return jsonMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            return "{\"campaignId\":" + event.getCampaignId()
+                    + ",\"userId\":" + event.getUserId()
+                    + ",\"sequence\":" + event.getSequence() + "}";
+        }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -96,6 +96,7 @@ public class ParticipationEventConsumer {
             }
         }
 
+        // ③ 지연시간 측정 (API LPUSH ~ Consumer INSERT 완료)
         long latencyMs = Duration.between(batchStart, LocalDateTime.now()).toMillis();
         Timer.builder("consumer.pending_to_success.latency")
                 .description("Time from consumer batch start to DB success insert")
@@ -105,10 +106,8 @@ public class ParticipationEventConsumer {
         log.info("Consumer batch processed. polled={}, parsed={}, success={}, latencyMs={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        if (!successEvents.isEmpty()) {
-            writeResultCache(successEvents);
-        }
 
+        // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
     }
 
@@ -126,8 +125,9 @@ public class ParticipationEventConsumer {
                     return null;
                 }
             });
+            log.debug("결과 캐시 적재 완료. {}건", events.size());
         } catch (Exception e) {
-            log.error("Failed to write result cache. count={}", events.size(), e);
+            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
         }
     }
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -11,9 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -31,13 +28,9 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class ParticipationEventConsumer {
 
-    private static final String RESULT_CACHE_PREFIX = "participation:result:";
-    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
-
     private final JsonMapper jsonMapper;
     private final ParticipationHistoryRepository participationHistoryRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final RedisTemplate<String, String> redisTemplate;
     private final SlackNotificationService slackNotificationService;
     private final DlqMessageService dlqMessageService;
     private final MeterRegistry meterRegistry;
@@ -109,26 +102,6 @@ public class ParticipationEventConsumer {
 
         // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
-    }
-
-    @SuppressWarnings("unchecked")
-    private void writeResultCache(List<ParticipationEvent> events) {
-        try {
-            redisTemplate.executePipelined(new SessionCallback<Object>() {
-                @Override
-                public <K, V> Object execute(RedisOperations<K, V> operations) {
-                    RedisOperations<String, String> ops = (RedisOperations<String, String>) operations;
-                    for (ParticipationEvent event : events) {
-                        String key = RESULT_CACHE_PREFIX + event.getUserId() + ":" + event.getCampaignId();
-                        ops.opsForValue().set(key, "SUCCESS", RESULT_CACHE_TTL);
-                    }
-                    return null;
-                }
-            });
-            log.debug("결과 캐시 적재 완료. {}건", events.size());
-        } catch (Exception e) {
-            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
-        }
     }
 
     private List<ParticipationEvent> parseRecords(List<ConsumerRecord<String, String>> records) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/DlqEventPayload.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/DlqEventPayload.java
@@ -1,0 +1,108 @@
+package io.eventdriven.campaign.application.event;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.DlqSourceType;
+
+import java.time.LocalDateTime;
+
+public class DlqEventPayload {
+    private DlqSourceType sourceType;
+    private String originalTopic;
+    private String originalKey;
+    private String originalMessage;
+    private String errorReason;
+    private String errorMessage;
+    private Long campaignId;
+    private Long userId;
+    private Long sequence;
+    private DlqReplayClassification replayClassification;
+    private LocalDateTime occurredAt;
+
+    public DlqSourceType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(DlqSourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public String getOriginalTopic() {
+        return originalTopic;
+    }
+
+    public void setOriginalTopic(String originalTopic) {
+        this.originalTopic = originalTopic;
+    }
+
+    public String getOriginalKey() {
+        return originalKey;
+    }
+
+    public void setOriginalKey(String originalKey) {
+        this.originalKey = originalKey;
+    }
+
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    public void setOriginalMessage(String originalMessage) {
+        this.originalMessage = originalMessage;
+    }
+
+    public String getErrorReason() {
+        return errorReason;
+    }
+
+    public void setErrorReason(String errorReason) {
+        this.errorReason = errorReason;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Long getCampaignId() {
+        return campaignId;
+    }
+
+    public void setCampaignId(Long campaignId) {
+        this.campaignId = campaignId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(Long sequence) {
+        this.sequence = sequence;
+    }
+
+    public DlqReplayClassification getReplayClassification() {
+        return replayClassification;
+    }
+
+    public void setReplayClassification(DlqReplayClassification replayClassification) {
+        this.replayClassification = replayClassification;
+    }
+
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(LocalDateTime occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
@@ -1,0 +1,416 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.config.BatchProperties;
+import io.eventdriven.campaign.domain.entity.*;
+import io.eventdriven.campaign.domain.repository.CampaignRepository;
+import io.eventdriven.campaign.domain.repository.ConsistencyRecoveryExecutionRepository;
+import io.eventdriven.campaign.domain.repository.ConsistencyRecoveryResultRepository;
+import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ConsistencyRecoveryService {
+
+    private final CampaignRepository campaignRepository;
+    private final ParticipationHistoryRepository participationHistoryRepository;
+    private final ConsistencyRecoveryExecutionRepository executionRepository;
+    private final ConsistencyRecoveryResultRepository resultRepository;
+    private final RedisStockService redisStockService;
+    private final RedisQueueService redisQueueService;
+    private final BatchProperties batchProperties;
+    private final MeterRegistry meterRegistry;
+
+    @Transactional
+    public ConsistencyRecoveryExecution createExecution(
+            String requestedBy,
+            Boolean dryRun,
+            Boolean autoFix,
+            Long campaignId,
+            Integer maxCampaigns
+    ) {
+        int effectiveMaxCampaigns = maxCampaigns != null && maxCampaigns > 0
+                ? maxCampaigns
+                : batchProperties.getConsistency().getDefaultMaxCampaigns();
+        long targetCount = resolveTargetCount(campaignId, effectiveMaxCampaigns);
+        return executionRepository.save(new ConsistencyRecoveryExecution(
+                normalize(requestedBy),
+                Boolean.TRUE.equals(dryRun),
+                Boolean.TRUE.equals(autoFix),
+                campaignId,
+                effectiveMaxCampaigns,
+                targetCount
+        ));
+    }
+
+    @Transactional
+    public void markRunning(Long executionId) {
+        getExecutionEntity(executionId).markRunning(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void markCompleted(Long executionId) {
+        ConsistencyRecoveryExecution execution = getExecutionEntity(executionId);
+        if (execution.getStatus() != ConsistencyRecoveryExecutionStatus.FAILED) {
+            execution.markCompleted(LocalDateTime.now());
+        }
+    }
+
+    @Transactional
+    public void markFailed(Long executionId) {
+        getExecutionEntity(executionId).markFailed(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void processExecution(Long executionId) {
+        ConsistencyRecoveryExecution execution = getExecutionEntity(executionId);
+        List<Campaign> campaigns = loadTargetCampaigns(execution);
+
+        for (Campaign campaign : campaigns) {
+            inspectCampaign(execution, campaign);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public ConsistencyRecoveryExecution getExecution(Long executionId) {
+        return getExecutionEntity(executionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsistencyRecoveryResult> getExecutionResults(Long executionId) {
+        return resultRepository.findByExecutionIdOrderByIdAsc(executionId, PageRequest.of(0, 200));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsistencyRecoveryExecution> getExecutions(int size) {
+        return executionRepository.findByOrderByIdDesc(PageRequest.of(0, Math.max(1, size)));
+    }
+
+    public Map<String, Object> toExecutionResponse(
+            ConsistencyRecoveryExecution execution,
+            List<ConsistencyRecoveryResult> results
+    ) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("execution", execution);
+        data.put("results", results);
+        return data;
+    }
+
+    private void inspectCampaign(ConsistencyRecoveryExecution execution, Campaign campaign) {
+        long successCount = nvl(participationHistoryRepository.countByCampaignIdAndStatus(
+                campaign.getId(), ParticipationStatus.SUCCESS));
+        long pendingCount = nvl(participationHistoryRepository.countByCampaignIdAndStatus(
+                campaign.getId(), ParticipationStatus.PENDING));
+        Long redisRemainingStock = redisStockService.getStock(campaign.getId());
+        Long redisTotalStock = redisStockService.getTotal(campaign.getId());
+        long queueSize = nvl(redisQueueService.size(campaign.getId()));
+        boolean activeFlagPresent = redisStockService.isActive(campaign.getId());
+        boolean activeSetPresent = redisStockService.isRegisteredInActiveCampaigns(campaign.getId());
+
+        CampaignRuntimeSnapshot snapshot = new CampaignRuntimeSnapshot(
+                campaign,
+                successCount,
+                pendingCount,
+                redisRemainingStock,
+                redisTotalStock,
+                queueSize,
+                activeFlagPresent,
+                activeSetPresent
+        );
+
+        List<AnomalyDecision> decisions = detectAnomalies(snapshot);
+        for (AnomalyDecision decision : decisions) {
+            handleDecision(execution, snapshot, decision);
+        }
+    }
+
+    private List<AnomalyDecision> detectAnomalies(CampaignRuntimeSnapshot snapshot) {
+        List<AnomalyDecision> decisions = new ArrayList<>();
+        long derivedRemaining = snapshot.derivedRemainingStock();
+
+        if (snapshot.successCount() + snapshot.pendingCount() > snapshot.campaign().getTotalStock()) {
+            decisions.add(new AnomalyDecision(
+                    ConsistencyAnomalyType.SUCCESS_PENDING_EXCEEDS_TOTAL,
+                    ConsistencySeverity.CRITICAL,
+                    ConsistencyRecoveryAction.REPORT_ONLY,
+                    false,
+                    "success + pending exceeds totalStock"
+            ));
+        }
+
+        if (snapshot.redisRemainingStock() != null && snapshot.redisRemainingStock() < 0) {
+            decisions.add(new AnomalyDecision(
+                    ConsistencyAnomalyType.NEGATIVE_REDIS_STOCK,
+                    ConsistencySeverity.CRITICAL,
+                    ConsistencyRecoveryAction.REPORT_ONLY,
+                    false,
+                    "Redis remaining stock is negative"
+            ));
+        }
+
+        if (snapshot.campaign().getStatus() == CampaignStatus.OPEN) {
+            boolean safeRestore = snapshot.successCount() + snapshot.pendingCount() <= snapshot.campaign().getTotalStock();
+
+            if (snapshot.redisRemainingStock() == null) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.MISSING_REDIS_STOCK,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.RESTORE_REDIS_STATE,
+                        safeRestore,
+                        "Redis stock key is missing"
+                ));
+            }
+
+            if (snapshot.redisTotalStock() == null) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.MISSING_REDIS_TOTAL,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.RESTORE_REDIS_STATE,
+                        safeRestore,
+                        "Redis total key is missing"
+                ));
+            }
+
+            if (snapshot.redisRemainingStock() != null
+                    && safeRestore
+                    && snapshot.redisRemainingStock() != derivedRemaining) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.REDIS_REMAINING_MISMATCH,
+                        ConsistencySeverity.CRITICAL,
+                        ConsistencyRecoveryAction.REPORT_ONLY,
+                        false,
+                        "Redis remaining stock does not match DB-derived remaining stock"
+                ));
+            }
+
+            boolean shouldBeActive = derivedRemaining > 0 || snapshot.queueSize() > 0;
+            if (shouldBeActive && (!snapshot.activeFlagPresent() || !snapshot.activeSetPresent())) {
+                decisions.add(new AnomalyDecision(
+                        snapshot.queueSize() > 0
+                                ? ConsistencyAnomalyType.QUEUE_WITHOUT_ACTIVE_STATE
+                                : ConsistencyAnomalyType.MISSING_ACTIVE_STATE,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.ACTIVATE_CAMPAIGN,
+                        true,
+                        "Open campaign is not fully active in Redis"
+                ));
+            }
+        }
+
+        if (snapshot.campaign().getStatus() == CampaignStatus.CLOSED) {
+            boolean hasRedisResidue = snapshot.redisRemainingStock() != null
+                    || snapshot.redisTotalStock() != null
+                    || snapshot.activeFlagPresent()
+                    || snapshot.activeSetPresent();
+
+            if (hasRedisResidue) {
+                boolean safeCleanup = snapshot.queueSize() == 0;
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.CLOSED_REDIS_RESIDUE,
+                        safeCleanup ? ConsistencySeverity.WARNING : ConsistencySeverity.CRITICAL,
+                        safeCleanup ? ConsistencyRecoveryAction.CLEANUP_REDIS_STATE : ConsistencyRecoveryAction.REPORT_ONLY,
+                        safeCleanup,
+                        safeCleanup
+                                ? "Closed campaign still has Redis runtime state"
+                                : "Closed campaign has Redis runtime state and queued messages"
+                ));
+            }
+        }
+
+        return decisions;
+    }
+
+    private void handleDecision(
+            ConsistencyRecoveryExecution execution,
+            CampaignRuntimeSnapshot snapshot,
+            AnomalyDecision decision
+    ) {
+        boolean fixed = false;
+        ConsistencyRecoveryAction actionTaken = decision.action();
+        String detailMessage = decision.detail();
+
+        if (execution.isDryRun()) {
+            actionTaken = decision.action() == ConsistencyRecoveryAction.NONE
+                    ? ConsistencyRecoveryAction.NONE
+                    : ConsistencyRecoveryAction.REPORT_ONLY;
+            detailMessage = "Dry run: " + detailMessage;
+        } else if (!execution.isAutoFix() || !decision.fixable()) {
+            if (decision.action() != ConsistencyRecoveryAction.REPORT_ONLY
+                    && decision.action() != ConsistencyRecoveryAction.NONE) {
+                actionTaken = ConsistencyRecoveryAction.REPORT_ONLY;
+                detailMessage = detailMessage + " (auto-fix not applied)";
+            }
+        } else {
+            fixed = applyFix(snapshot, decision.action());
+            if (!fixed && decision.action() != ConsistencyRecoveryAction.REPORT_ONLY) {
+                actionTaken = ConsistencyRecoveryAction.REPORT_ONLY;
+                detailMessage = detailMessage + " (auto-fix failed)";
+            }
+        }
+
+        execution.incrementAnomalyCount();
+        if (fixed) {
+            execution.incrementFixedCount();
+            fixedCounter(decision.anomalyType()).increment();
+        } else {
+            execution.incrementReportOnlyCount();
+            anomalyCounter(decision.anomalyType()).increment();
+        }
+
+        resultRepository.save(new ConsistencyRecoveryResult(
+                execution,
+                snapshot.campaign().getId(),
+                snapshot.campaign().getStatus(),
+                snapshot.campaign().getTotalStock(),
+                snapshot.successCount(),
+                snapshot.pendingCount(),
+                snapshot.redisRemainingStock(),
+                snapshot.redisTotalStock(),
+                snapshot.queueSize(),
+                snapshot.activeFlagPresent(),
+                snapshot.activeSetPresent(),
+                decision.anomalyType(),
+                decision.severity(),
+                actionTaken,
+                fixed,
+                detailMessage,
+                LocalDateTime.now()
+        ));
+    }
+
+    private boolean applyFix(CampaignRuntimeSnapshot snapshot, ConsistencyRecoveryAction action) {
+        try {
+            return switch (action) {
+                case RESTORE_REDIS_STATE -> restoreRedisState(snapshot);
+                case ACTIVATE_CAMPAIGN -> activateCampaign(snapshot);
+                case CLEANUP_REDIS_STATE -> cleanupRedisState(snapshot);
+                case REPORT_ONLY, NONE -> false;
+            };
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean restoreRedisState(CampaignRuntimeSnapshot snapshot) {
+        long remaining = snapshot.derivedRemainingStock();
+        redisStockService.initializeStock(snapshot.campaign().getId(), remaining);
+        redisStockService.initializeTotal(snapshot.campaign().getId(), snapshot.campaign().getTotalStock());
+        if (remaining > 0 || snapshot.queueSize() > 0) {
+            redisStockService.activateCampaign(snapshot.campaign().getId());
+        }
+        return true;
+    }
+
+    private boolean activateCampaign(CampaignRuntimeSnapshot snapshot) {
+        redisStockService.activateCampaign(snapshot.campaign().getId());
+        return true;
+    }
+
+    private boolean cleanupRedisState(CampaignRuntimeSnapshot snapshot) {
+        redisStockService.clearRuntimeState(snapshot.campaign().getId());
+        return true;
+    }
+
+    private List<Campaign> loadTargetCampaigns(ConsistencyRecoveryExecution execution) {
+        if (execution.getFilterCampaignId() != null) {
+            return campaignRepository.findById(execution.getFilterCampaignId())
+                    .map(List::of)
+                    .orElseGet(List::of);
+        }
+
+        int remaining = execution.getMaxCampaigns();
+        int pageSize = Math.max(1, batchProperties.getConsistency().getPageSize());
+        int page = 0;
+        List<Campaign> campaigns = new ArrayList<>();
+
+        while (remaining > 0) {
+            Page<Campaign> result = campaignRepository.findAll(PageRequest.of(
+                    page,
+                    Math.min(pageSize, remaining),
+                    Sort.by(Sort.Direction.ASC, "id")
+            ));
+            if (result.isEmpty()) {
+                break;
+            }
+            campaigns.addAll(result.getContent());
+            remaining = execution.getMaxCampaigns() - campaigns.size();
+            page++;
+        }
+
+        return campaigns;
+    }
+
+    private long resolveTargetCount(Long campaignId, int maxCampaigns) {
+        if (campaignId != null) {
+            return campaignRepository.existsById(campaignId) ? 1L : 0L;
+        }
+        return Math.min(campaignRepository.count(), maxCampaigns);
+    }
+
+    private ConsistencyRecoveryExecution getExecutionEntity(Long executionId) {
+        return executionRepository.findById(executionId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Consistency recovery execution not found: " + executionId
+                ));
+    }
+
+    private long nvl(Long value) {
+        return value == null ? 0L : value;
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    private Counter anomalyCounter(ConsistencyAnomalyType anomalyType) {
+        return Counter.builder("batch.consistency_recovery.anomaly")
+                .tag("type", anomalyType.name())
+                .register(meterRegistry);
+    }
+
+    private Counter fixedCounter(ConsistencyAnomalyType anomalyType) {
+        return Counter.builder("batch.consistency_recovery.fixed")
+                .tag("type", anomalyType.name())
+                .register(meterRegistry);
+    }
+
+    private record CampaignRuntimeSnapshot(
+            Campaign campaign,
+            long successCount,
+            long pendingCount,
+            Long redisRemainingStock,
+            Long redisTotalStock,
+            long queueSize,
+            boolean activeFlagPresent,
+            boolean activeSetPresent
+    ) {
+        private long derivedRemainingStock() {
+            return Math.max(campaign.getTotalStock() - successCount - pendingCount, 0L);
+        }
+    }
+
+    private record AnomalyDecision(
+            ConsistencyAnomalyType anomalyType,
+            ConsistencySeverity severity,
+            ConsistencyRecoveryAction action,
+            boolean fixable,
+            String detail
+    ) {
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
@@ -9,6 +9,7 @@ import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -21,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConsistencyRecoveryService {
@@ -238,6 +240,7 @@ public class ConsistencyRecoveryService {
             CampaignRuntimeSnapshot snapshot,
             AnomalyDecision decision
     ) {
+        Map<String, Object> beforeState = snapshotState(snapshot);
         boolean fixed = false;
         ConsistencyRecoveryAction actionTaken = decision.action();
         String detailMessage = decision.detail();
@@ -261,6 +264,10 @@ public class ConsistencyRecoveryService {
             }
         }
 
+        Map<String, Object> afterState = fixed
+                ? refreshRuntimeState(snapshot.campaign().getId(), snapshot)
+                : beforeState;
+
         execution.incrementAnomalyCount();
         if (fixed) {
             execution.incrementFixedCount();
@@ -269,6 +276,19 @@ public class ConsistencyRecoveryService {
             execution.incrementReportOnlyCount();
             anomalyCounter(decision.anomalyType()).increment();
         }
+
+        log.info(
+                "Consistency recovery decision. executionId={}, campaignId={}, anomalyType={}, requestedAction={}, actionTaken={}, fixed={}, before={}, after={}, detail={}",
+                execution.getId(),
+                snapshot.campaign().getId(),
+                decision.anomalyType(),
+                decision.action(),
+                actionTaken,
+                fixed,
+                beforeState,
+                afterState,
+                detailMessage
+        );
 
         resultRepository.save(new ConsistencyRecoveryResult(
                 execution,
@@ -388,6 +408,36 @@ public class ConsistencyRecoveryService {
         return Counter.builder("batch.consistency_recovery.fixed")
                 .tag("type", anomalyType.name())
                 .register(meterRegistry);
+    }
+
+    private Map<String, Object> snapshotState(CampaignRuntimeSnapshot snapshot) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("campaignStatus", snapshot.campaign().getStatus());
+        state.put("totalStock", snapshot.campaign().getTotalStock());
+        state.put("successCount", snapshot.successCount());
+        state.put("pendingCount", snapshot.pendingCount());
+        state.put("derivedRemainingStock", snapshot.derivedRemainingStock());
+        state.put("redisRemainingStock", snapshot.redisRemainingStock());
+        state.put("redisTotalStock", snapshot.redisTotalStock());
+        state.put("queueSize", snapshot.queueSize());
+        state.put("activeFlagPresent", snapshot.activeFlagPresent());
+        state.put("activeSetPresent", snapshot.activeSetPresent());
+        return state;
+    }
+
+    private Map<String, Object> refreshRuntimeState(Long campaignId, CampaignRuntimeSnapshot snapshot) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("campaignStatus", snapshot.campaign().getStatus());
+        state.put("totalStock", snapshot.campaign().getTotalStock());
+        state.put("successCount", snapshot.successCount());
+        state.put("pendingCount", snapshot.pendingCount());
+        state.put("derivedRemainingStock", snapshot.derivedRemainingStock());
+        state.put("redisRemainingStock", redisStockService.getStock(campaignId));
+        state.put("redisTotalStock", redisStockService.getTotal(campaignId));
+        state.put("queueSize", nvl(redisQueueService.size(campaignId)));
+        state.put("activeFlagPresent", redisStockService.isActive(campaignId));
+        state.put("activeSetPresent", redisStockService.isRegisteredInActiveCampaigns(campaignId));
+        return state;
     }
 
     private record CampaignRuntimeSnapshot(

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqMessageService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqMessageService.java
@@ -1,0 +1,134 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.application.event.DlqEventPayload;
+import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.config.KafkaConfig;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.DlqSourceType;
+import io.eventdriven.campaign.domain.repository.DlqMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DlqMessageService {
+
+    public static final String DLQ_TOPIC = KafkaConfig.TOPIC_NAME + ".dlq";
+
+    private final DlqMessageRepository dlqMessageRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final tools.jackson.databind.json.JsonMapper jsonMapper;
+
+    public DlqEventPayload createBridgePayload(
+            Long fallbackCampaignId,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
+        ParticipationEvent event = tryParseParticipationEvent(originalMessage);
+        DlqEventPayload payload = new DlqEventPayload();
+        payload.setSourceType(DlqSourceType.BRIDGE);
+        payload.setOriginalTopic(KafkaConfig.TOPIC_NAME);
+        payload.setOriginalKey(originalKey);
+        payload.setOriginalMessage(originalMessage);
+        payload.setErrorReason(errorReason);
+        payload.setErrorMessage(errorMessage);
+        payload.setCampaignId(event != null && event.getCampaignId() != null ? event.getCampaignId() : fallbackCampaignId);
+        payload.setUserId(event != null ? event.getUserId() : null);
+        payload.setSequence(event != null ? event.getSequence() : null);
+        payload.setReplayClassification(resolveBridgeClassification(event));
+        payload.setOccurredAt(LocalDateTime.now());
+        return payload;
+    }
+
+    public DlqEventPayload createConsumerPayload(
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
+        ParticipationEvent event = tryParseParticipationEvent(originalMessage);
+        DlqEventPayload payload = new DlqEventPayload();
+        payload.setSourceType(DlqSourceType.CONSUMER);
+        payload.setOriginalTopic(KafkaConfig.TOPIC_NAME);
+        payload.setOriginalKey(originalKey);
+        payload.setOriginalMessage(originalMessage);
+        payload.setErrorReason(errorReason);
+        payload.setErrorMessage(errorMessage);
+        payload.setCampaignId(event != null ? event.getCampaignId() : null);
+        payload.setUserId(event != null ? event.getUserId() : null);
+        payload.setSequence(event != null ? event.getSequence() : null);
+        payload.setReplayClassification(resolveConsumerClassification(errorReason, event));
+        payload.setOccurredAt(LocalDateTime.now());
+        return payload;
+    }
+
+    @Transactional
+    public void publishAndStore(DlqEventPayload payload) {
+        saveDlqMessage(payload);
+        publishDlqEvent(payload);
+    }
+
+    private DlqReplayClassification resolveBridgeClassification(ParticipationEvent event) {
+        if (event == null || event.getCampaignId() == null || event.getUserId() == null || event.getSequence() == null) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        return DlqReplayClassification.REPLAYABLE;
+    }
+
+    private DlqReplayClassification resolveConsumerClassification(String errorReason, ParticipationEvent event) {
+        if ("JSON_PARSE_ERROR".equals(errorReason) || "MISSING_SEQUENCE".equals(errorReason)) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        if (event == null || event.getCampaignId() == null || event.getUserId() == null || event.getSequence() == null) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        return DlqReplayClassification.CONDITIONALLY_REPLAYABLE;
+    }
+
+    private ParticipationEvent tryParseParticipationEvent(String originalMessage) {
+        try {
+            return jsonMapper.readValue(originalMessage, ParticipationEvent.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void saveDlqMessage(DlqEventPayload payload) {
+        try {
+            dlqMessageRepository.save(new DlqMessageRecord(
+                    payload.getSourceType(),
+                    payload.getOriginalTopic(),
+                    payload.getOriginalKey(),
+                    payload.getOriginalMessage(),
+                    payload.getErrorReason(),
+                    payload.getErrorMessage(),
+                    payload.getCampaignId(),
+                    payload.getUserId(),
+                    payload.getSequence(),
+                    payload.getReplayClassification()
+            ));
+        } catch (Exception e) {
+            log.error("Failed to persist DLQ message. sourceType={}, reason={}",
+                    payload.getSourceType(), payload.getErrorReason(), e);
+        }
+    }
+
+    private void publishDlqEvent(DlqEventPayload payload) {
+        try {
+            String message = jsonMapper.writeValueAsString(payload);
+            kafkaTemplate.send(DLQ_TOPIC, payload.getOriginalKey(), message);
+        } catch (Exception e) {
+            log.error("Failed to publish DLQ event. sourceType={}, reason={}",
+                    payload.getSourceType(), payload.getErrorReason(), e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayPolicyService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayPolicyService.java
@@ -1,0 +1,71 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayAction;
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.ParticipationStatus;
+import io.eventdriven.campaign.domain.repository.CampaignRepository;
+import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DlqReplayPolicyService {
+
+    private final CampaignRepository campaignRepository;
+    private final ParticipationHistoryRepository participationHistoryRepository;
+    private final tools.jackson.databind.json.JsonMapper jsonMapper;
+
+    public DlqReplayDecision decide(DlqMessageRecord message) {
+        if (message.getReplayClassification() == DlqReplayClassification.NON_REPLAYABLE) {
+            return DlqReplayDecision.finalFail("NON_REPLAYABLE", "Payload is not safe to replay");
+        }
+
+        Long campaignId = message.getCampaignId();
+        Long userId = message.getUserId();
+        Long sequence = message.getSequence();
+
+        if (campaignId == null || userId == null || sequence == null) {
+            return DlqReplayDecision.finalFail("MISSING_REQUIRED_FIELDS", "campaignId/userId/sequence must exist");
+        }
+
+        if (campaignRepository.findById(campaignId).isEmpty()) {
+            return DlqReplayDecision.finalFail("CAMPAIGN_NOT_FOUND", "Campaign does not exist");
+        }
+
+        if (participationHistoryRepository.existsSuccessHistory(
+                campaignId, userId, ParticipationStatus.SUCCESS)) {
+            return DlqReplayDecision.skip("ALREADY_SUCCESS", "Participation already succeeded");
+        }
+
+        try {
+            String replayPayload = jsonMapper.writeValueAsString(new ParticipationEvent(campaignId, userId, sequence));
+            return DlqReplayDecision.replay(String.valueOf(userId), replayPayload,
+                    "REPLAYABLE", "Replay to main participation topic");
+        } catch (Exception e) {
+            return DlqReplayDecision.finalFail("SERIALIZATION_FAILED", e.getMessage());
+        }
+    }
+
+    public record DlqReplayDecision(
+            DlqReplayAction action,
+            String reason,
+            String detail,
+            String replayKey,
+            String replayPayload
+    ) {
+        public static DlqReplayDecision replay(String replayKey, String replayPayload, String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.REPLAY, reason, detail, replayKey, replayPayload);
+        }
+
+        public static DlqReplayDecision skip(String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.SKIP, reason, detail, null, null);
+        }
+
+        public static DlqReplayDecision finalFail(String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.FINAL_FAIL, reason, detail, null, null);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
@@ -15,6 +15,7 @@ import io.eventdriven.campaign.domain.repository.DlqReplayExecutionRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DlqReplayService {
@@ -169,11 +171,33 @@ public class DlqReplayService {
         DlqReplayPolicyService.DlqReplayDecision decision = dlqReplayPolicyService.decide(message);
         LocalDateTime now = LocalDateTime.now();
 
+        log.info(
+                "DLQ replay decision. executionId={}, messageId={}, classification={}, action={}, publishKey={}, reason={}, detail={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                decision.reason(),
+                decision.detail()
+        );
+
         if (execution.isDryRun()) {
             recordItem(execution, message, decision, DlqReplayItemResult.DRY_RUN,
                     "Dry run only: " + decision.detail());
             incrementExecutionCounter(execution, decision.action());
             counterFor(decision.action(), true).increment();
+            log.info(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.DRY_RUN,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount()
+            );
             return;
         }
 
@@ -205,6 +229,17 @@ public class DlqReplayService {
                     now
             ));
             counterFor(DlqReplayAction.REPLAY, false).increment();
+            log.info(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.SUCCESS,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount()
+            );
         } catch (Exception e) {
             message.incrementReplayAttempt();
             execution.incrementPublishFailed();
@@ -218,6 +253,18 @@ public class DlqReplayService {
                     now
             ));
             counterForFailure().increment();
+            log.warn(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}, error={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.FAILED,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount(),
+                    e.getMessage()
+            );
         }
     }
 
@@ -231,6 +278,17 @@ public class DlqReplayService {
         execution.incrementSkipped();
         recordItem(execution, message, decision, DlqReplayItemResult.SKIPPED, decision.detail());
         counterFor(DlqReplayAction.SKIP, false).increment();
+        log.info(
+                "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                DlqReplayItemResult.SKIPPED,
+                message.getProcessingStatus(),
+                message.getReplayAttemptCount()
+        );
     }
 
     private void finalFail(
@@ -243,6 +301,17 @@ public class DlqReplayService {
         execution.incrementFinalFailed();
         recordItem(execution, message, decision, DlqReplayItemResult.FINAL_FAILED, decision.detail());
         counterFor(DlqReplayAction.FINAL_FAIL, false).increment();
+        log.info(
+                "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                DlqReplayItemResult.FINAL_FAILED,
+                message.getProcessingStatus(),
+                message.getReplayAttemptCount()
+        );
     }
 
     private void recordItem(

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
@@ -1,0 +1,301 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.config.BatchProperties;
+import io.eventdriven.campaign.config.KafkaConfig;
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayAction;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionItem;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionStatus;
+import io.eventdriven.campaign.domain.entity.DlqReplayItemResult;
+import io.eventdriven.campaign.domain.repository.DlqMessageRepository;
+import io.eventdriven.campaign.domain.repository.DlqReplayExecutionItemRepository;
+import io.eventdriven.campaign.domain.repository.DlqReplayExecutionRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class DlqReplayService {
+
+    private final DlqMessageRepository dlqMessageRepository;
+    private final DlqReplayExecutionRepository dlqReplayExecutionRepository;
+    private final DlqReplayExecutionItemRepository dlqReplayExecutionItemRepository;
+    private final DlqReplayPolicyService dlqReplayPolicyService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final BatchProperties batchProperties;
+    private final MeterRegistry meterRegistry;
+
+    @Transactional
+    public DlqReplayExecution createExecution(
+            String requestedBy,
+            Boolean dryRun,
+            Long campaignId,
+            String reason,
+            LocalDateTime fromTime,
+            LocalDateTime toTime,
+            Integer maxItems
+    ) {
+        int effectiveMaxItems = maxItems != null && maxItems > 0
+                ? maxItems
+                : batchProperties.getReplay().getDefaultMaxItems();
+        long targetCount = dlqMessageRepository.countReplayCandidates(
+                DlqMessageProcessingStatus.PENDING,
+                campaignId,
+                normalize(reason),
+                fromTime,
+                toTime
+        );
+        DlqReplayExecution execution = new DlqReplayExecution(
+                normalize(requestedBy),
+                Boolean.TRUE.equals(dryRun),
+                campaignId,
+                normalize(reason),
+                fromTime,
+                toTime,
+                effectiveMaxItems,
+                Math.min(targetCount, effectiveMaxItems)
+        );
+        return dlqReplayExecutionRepository.save(execution);
+    }
+
+    @Transactional
+    public void markRunning(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        execution.markRunning(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void markCompleted(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        if (execution.getStatus() != DlqReplayExecutionStatus.FAILED) {
+            execution.markCompleted(LocalDateTime.now());
+        }
+    }
+
+    @Transactional
+    public void markFailed(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        execution.markFailed(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void processExecution(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        int pageSize = Math.max(1, batchProperties.getReplay().getPageSize());
+        int remaining = execution.getMaxItems();
+        long afterId = 0L;
+        Set<Long> processedIds = new HashSet<>();
+
+        while (remaining > 0) {
+            List<DlqMessageRecord> candidates = dlqMessageRepository.findReplayCandidates(
+                    DlqMessageProcessingStatus.PENDING,
+                    afterId,
+                    execution.getFilterCampaignId(),
+                    execution.getFilterReason(),
+                    execution.getFilterFromTime(),
+                    execution.getFilterToTime(),
+                    PageRequest.of(0, Math.min(pageSize, remaining))
+            );
+
+            if (candidates.isEmpty()) {
+                return;
+            }
+
+            for (DlqMessageRecord candidate : candidates) {
+                afterId = candidate.getId();
+                if (!processedIds.add(candidate.getId())) {
+                    continue;
+                }
+                processSingleMessage(execution, candidate);
+                remaining--;
+                if (remaining == 0) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public DlqReplayExecution getExecution(Long executionId) {
+        return getExecutionEntity(executionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DlqReplayExecutionItem> getExecutionItems(Long executionId) {
+        return dlqReplayExecutionItemRepository.findByExecutionIdOrderByIdAsc(
+                executionId,
+                PageRequest.of(0, 100)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<DlqMessageRecord> searchMessages(
+            DlqMessageProcessingStatus status,
+            Long campaignId,
+            String reason,
+            int size
+    ) {
+        int safeSize = Math.max(1, size);
+        return dlqMessageRepository.searchMessages(
+                status,
+                campaignId,
+                normalize(reason),
+                PageRequest.of(0, safeSize)
+        );
+    }
+
+    public Map<String, Object> toExecutionResponse(DlqReplayExecution execution, List<DlqReplayExecutionItem> items) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("execution", execution);
+        data.put("items", items);
+        return data;
+    }
+
+    private void processSingleMessage(DlqReplayExecution execution, DlqMessageRecord message) {
+        DlqReplayPolicyService.DlqReplayDecision decision = dlqReplayPolicyService.decide(message);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (execution.isDryRun()) {
+            recordItem(execution, message, decision, DlqReplayItemResult.DRY_RUN,
+                    "Dry run only: " + decision.detail());
+            incrementExecutionCounter(execution, decision.action());
+            counterFor(decision.action(), true).increment();
+            return;
+        }
+
+        switch (decision.action()) {
+            case REPLAY -> replay(execution, message, decision, now);
+            case SKIP -> skip(execution, message, decision, now);
+            case FINAL_FAIL -> finalFail(execution, message, decision, now);
+        }
+    }
+
+    private void replay(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        try {
+            kafkaTemplate.send(KafkaConfig.TOPIC_NAME, decision.replayKey(), decision.replayPayload()).get();
+            message.incrementReplayAttempt();
+            message.markReplayed(now);
+            execution.incrementReplayed();
+            dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                    execution,
+                    message,
+                    decision.reason(),
+                    DlqReplayAction.REPLAY,
+                    DlqReplayItemResult.SUCCESS,
+                    decision.detail(),
+                    now
+            ));
+            counterFor(DlqReplayAction.REPLAY, false).increment();
+        } catch (Exception e) {
+            message.incrementReplayAttempt();
+            execution.incrementPublishFailed();
+            dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                    execution,
+                    message,
+                    decision.reason(),
+                    DlqReplayAction.REPLAY,
+                    DlqReplayItemResult.FAILED,
+                    e.getMessage(),
+                    now
+            ));
+            counterForFailure().increment();
+        }
+    }
+
+    private void skip(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        message.markSkipped(decision.reason());
+        execution.incrementSkipped();
+        recordItem(execution, message, decision, DlqReplayItemResult.SKIPPED, decision.detail());
+        counterFor(DlqReplayAction.SKIP, false).increment();
+    }
+
+    private void finalFail(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        message.markFinalFailed(decision.reason());
+        execution.incrementFinalFailed();
+        recordItem(execution, message, decision, DlqReplayItemResult.FINAL_FAILED, decision.detail());
+        counterFor(DlqReplayAction.FINAL_FAIL, false).increment();
+    }
+
+    private void recordItem(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            DlqReplayItemResult result,
+            String detail
+    ) {
+        dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                execution,
+                message,
+                decision.reason(),
+                decision.action(),
+                result,
+                detail,
+                LocalDateTime.now()
+        ));
+    }
+
+    private void incrementExecutionCounter(DlqReplayExecution execution, DlqReplayAction action) {
+        switch (action) {
+            case REPLAY -> execution.incrementReplayed();
+            case SKIP -> execution.incrementSkipped();
+            case FINAL_FAIL -> execution.incrementFinalFailed();
+        }
+    }
+
+    private Counter counterFor(DlqReplayAction action, boolean dryRun) {
+        String suffix = switch (action) {
+            case REPLAY -> "replayed";
+            case SKIP -> "skipped";
+            case FINAL_FAIL -> "final_failed";
+        };
+        return Counter.builder("batch.dlq_replay." + suffix)
+                .tag("dryRun", String.valueOf(dryRun))
+                .register(meterRegistry);
+    }
+
+    private Counter counterForFailure() {
+        return Counter.builder("batch.dlq_replay.publish_failed")
+                .register(meterRegistry);
+    }
+
+    private DlqReplayExecution getExecutionEntity(Long executionId) {
+        return dlqReplayExecutionRepository.findById(executionId)
+                .orElseThrow(() -> new IllegalArgumentException("DLQ replay execution not found: " + executionId));
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
@@ -15,7 +15,7 @@ public class RedisQueueService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final long MAX_QUEUE_SIZE = 500_000;
+    private static final long MAX_QUEUE_SIZE = 1_000_000;
     private final DefaultRedisScript<Long> pushQueueScript;
 
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
@@ -87,6 +87,31 @@ public class RedisStockService {
         redisTemplate.opsForValue().set(getTotalKey(campaignId), String.valueOf(totalStock));
     }
 
+    public Long getTotal(Long campaignId) {
+        String total = redisTemplate.opsForValue().get(getTotalKey(campaignId));
+        return total != null ? Long.parseLong(total) : null;
+    }
+
+    public boolean hasTotal(Long campaignId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(getTotalKey(campaignId)));
+    }
+
+    public boolean isRegisteredInActiveCampaigns(Long campaignId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(ACTIVE_CAMPAIGNS_KEY, campaignId.toString())
+        );
+    }
+
+    public void deleteTotal(Long campaignId) {
+        redisTemplate.delete(getTotalKey(campaignId));
+    }
+
+    public void clearRuntimeState(Long campaignId) {
+        deleteStock(campaignId);
+        deleteTotal(campaignId);
+        deactivateCampaign(campaignId);
+    }
+
     private String getTotalKey(Long campaignId) {
         return TOTAL_KEY_PREFIX + campaignId + "}";
     }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -19,10 +20,12 @@ public class SlackNotificationService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    @Async("slackTaskExecutor")
     public void sendDlqAlert(String reason, String detail) {
         sendAlert("[DLQ 알림] " + reason, detail);
     }
 
+    @Async("slackTaskExecutor")
     public void sendBatchAlert(String title, String detail) {
         sendAlert("[Batch 알림] " + title, detail);
     }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
@@ -10,13 +10,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
-/**
- * Slack Incoming Webhook 알림 서비스
- *
- * DLQ 적재 시 Slack 채널로 알림 발송.
- * webhook-url 미설정 시 로그만 남기고 스킵 (로컬/테스트 환경 안전).
- * SSM Parameter Store → 환경변수 SLACK_WEBHOOK_URL → slack.webhook-url 순으로 주입.
- */
 @Slf4j
 @Service
 public class SlackNotificationService {
@@ -26,29 +19,30 @@ public class SlackNotificationService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    /**
-     * DLQ 적재 알림 발송
-     *
-     * @param reason  알림 사유 (예: "Bridge Produce MAX_RETRY 초과")
-     * @param detail  상세 정보 (historyId 또는 campaignId 포함)
-     */
     public void sendDlqAlert(String reason, String detail) {
+        sendAlert("[DLQ 알림] " + reason, detail);
+    }
+
+    public void sendBatchAlert(String title, String detail) {
+        sendAlert("[Batch 알림] " + title, detail);
+    }
+
+    private void sendAlert(String title, String detail) {
         if (webhookUrl == null || webhookUrl.isBlank()) {
-            log.warn("[Slack 미설정] DLQ 알림 스킵. reason={}, detail={}", reason, detail);
+            log.warn("[Slack 미설정] 알림 스킵. title={}, detail={}", title, detail);
             return;
         }
         try {
-            String text = String.format("[DLQ 알림] %s | %s", reason, detail);
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
             restTemplate.postForEntity(
                     webhookUrl,
-                    new HttpEntity<>(Map.of("text", text), headers),
+                    new HttpEntity<>(Map.of("text", title + " | " + detail), headers),
                     String.class
             );
-            log.info("Slack 알림 전송 완료. reason={}", reason);
+            log.info("Slack 알림 전송 완료. title={}", title);
         } catch (Exception e) {
-            log.error("Slack 알림 전송 실패. reason={}", reason, e);
+            log.error("Slack 알림 전송 실패. title={}", title, e);
         }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
@@ -1,0 +1,89 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ConsistencyRecoveryJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+    private final ConsistencyRecoveryJobExecutionListener consistencyRecoveryJobExecutionListener;
+
+    @Bean
+    public Job consistencyRecoveryJob(
+            Step consistencyRecoveryStartStep,
+            Step consistencyRecoveryProcessStep,
+            Step consistencyRecoveryFinishStep
+    ) {
+        return new JobBuilder("consistencyRecoveryJob", jobRepository)
+                .listener(consistencyRecoveryJobExecutionListener)
+                .start(consistencyRecoveryStartStep)
+                .next(consistencyRecoveryProcessStep)
+                .next(consistencyRecoveryFinishStep)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryStartStep() {
+        return new StepBuilder("consistencyRecoveryStartStep", jobRepository)
+                .tasklet(markRunningTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryProcessStep() {
+        return new StepBuilder("consistencyRecoveryProcessStep", jobRepository)
+                .tasklet(processTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryFinishStep() {
+        return new StepBuilder("consistencyRecoveryFinishStep", jobRepository)
+                .tasklet(markCompletedTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet markRunningTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.markRunning(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet processTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.processExecution(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet markCompletedTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.markCompleted(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
@@ -39,26 +39,26 @@ public class ConsistencyRecoveryJobConfig {
     @Bean
     public Step consistencyRecoveryStartStep() {
         return new StepBuilder("consistencyRecoveryStartStep", jobRepository)
-                .tasklet(markRunningTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryMarkRunningTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step consistencyRecoveryProcessStep() {
         return new StepBuilder("consistencyRecoveryProcessStep", jobRepository)
-                .tasklet(processTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryProcessTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step consistencyRecoveryFinishStep() {
         return new StepBuilder("consistencyRecoveryFinishStep", jobRepository)
-                .tasklet(markCompletedTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryMarkCompletedTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
-    public Tasklet markRunningTasklet() {
+    public Tasklet consistencyRecoveryMarkRunningTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");
@@ -68,7 +68,7 @@ public class ConsistencyRecoveryJobConfig {
     }
 
     @Bean
-    public Tasklet processTasklet() {
+    public Tasklet consistencyRecoveryProcessTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");
@@ -78,7 +78,7 @@ public class ConsistencyRecoveryJobConfig {
     }
 
     @Bean
-    public Tasklet markCompletedTasklet() {
+    public Tasklet consistencyRecoveryMarkCompletedTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobExecutionListener.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobExecutionListener.java
@@ -1,0 +1,66 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import io.eventdriven.campaign.application.service.SlackNotificationService;
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConsistencyRecoveryJobExecutionListener implements JobExecutionListener {
+
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+    private final SlackNotificationService slackNotificationService;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (!"consistencyRecoveryJob".equals(jobExecution.getJobInstance().getJobName())) {
+            return;
+        }
+
+        Long executionId = jobExecution.getJobParameters().getLong("consistencyRecoveryExecutionId");
+        if (executionId == null) {
+            return;
+        }
+
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            try {
+                consistencyRecoveryService.markFailed(executionId);
+            } catch (Exception e) {
+                log.error("Failed to mark consistency recovery execution as failed. executionId={}", executionId, e);
+            }
+        }
+
+        sendAlert(executionId, jobExecution.getStatus());
+    }
+
+    private void sendAlert(Long executionId, BatchStatus batchStatus) {
+        try {
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.getExecution(executionId);
+            slackNotificationService.sendBatchAlert(
+                    batchStatus == BatchStatus.FAILED
+                            ? "Consistency Recovery Failed"
+                            : "Consistency Recovery Completed",
+                    String.format(
+                            "executionId=%d, status=%s, dryRun=%s, autoFix=%s, target=%d, anomalies=%d, fixed=%d, reportOnly=%d",
+                            execution.getId(),
+                            execution.getStatus(),
+                            execution.isDryRun(),
+                            execution.isAutoFix(),
+                            execution.getTargetCount(),
+                            execution.getAnomalyCount(),
+                            execution.getFixedCount(),
+                            execution.getReportOnlyCount()
+                    )
+            );
+        } catch (Exception e) {
+            log.error("Failed to send consistency recovery Slack alert. executionId={}", executionId, e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
@@ -39,26 +39,26 @@ public class DlqReplayJobConfig {
     @Bean
     public Step dlqReplayStartStep() {
         return new StepBuilder("dlqReplayStartStep", jobRepository)
-                .tasklet(markRunningTasklet(), transactionManager)
+                .tasklet(dlqReplayMarkRunningTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step dlqReplayProcessStep() {
         return new StepBuilder("dlqReplayProcessStep", jobRepository)
-                .tasklet(processReplayTasklet(), transactionManager)
+                .tasklet(dlqReplayProcessTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step dlqReplayFinishStep() {
         return new StepBuilder("dlqReplayFinishStep", jobRepository)
-                .tasklet(markCompletedTasklet(), transactionManager)
+                .tasklet(dlqReplayMarkCompletedTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
-    public Tasklet markRunningTasklet() {
+    public Tasklet dlqReplayMarkRunningTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.markRunning(executionId);
@@ -67,7 +67,7 @@ public class DlqReplayJobConfig {
     }
 
     @Bean
-    public Tasklet processReplayTasklet() {
+    public Tasklet dlqReplayProcessTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.processExecution(executionId);
@@ -76,7 +76,7 @@ public class DlqReplayJobConfig {
     }
 
     @Bean
-    public Tasklet markCompletedTasklet() {
+    public Tasklet dlqReplayMarkCompletedTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.markCompleted(executionId);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
@@ -1,0 +1,86 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class DlqReplayJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final DlqReplayService dlqReplayService;
+    private final DlqReplayJobExecutionListener dlqReplayJobExecutionListener;
+
+    @Bean
+    public Job dlqReplayJob(
+            Step dlqReplayStartStep,
+            Step dlqReplayProcessStep,
+            Step dlqReplayFinishStep
+    ) {
+        return new JobBuilder("dlqReplayJob", jobRepository)
+                .listener(dlqReplayJobExecutionListener)
+                .start(dlqReplayStartStep)
+                .next(dlqReplayProcessStep)
+                .next(dlqReplayFinishStep)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayStartStep() {
+        return new StepBuilder("dlqReplayStartStep", jobRepository)
+                .tasklet(markRunningTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayProcessStep() {
+        return new StepBuilder("dlqReplayProcessStep", jobRepository)
+                .tasklet(processReplayTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayFinishStep() {
+        return new StepBuilder("dlqReplayFinishStep", jobRepository)
+                .tasklet(markCompletedTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet markRunningTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.markRunning(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet processReplayTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.processExecution(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet markCompletedTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.markCompleted(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobExecutionListener.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobExecutionListener.java
@@ -1,0 +1,65 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.SlackNotificationService;
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DlqReplayJobExecutionListener implements JobExecutionListener {
+
+    private final DlqReplayService dlqReplayService;
+    private final SlackNotificationService slackNotificationService;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (!"dlqReplayJob".equals(jobExecution.getJobInstance().getJobName())) {
+            return;
+        }
+
+        Long replayExecutionId = jobExecution.getJobParameters().getLong("replayExecutionId");
+        if (replayExecutionId == null) {
+            return;
+        }
+
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            try {
+                dlqReplayService.markFailed(replayExecutionId);
+            } catch (Exception e) {
+                log.error("Failed to mark DLQ replay execution as failed. replayExecutionId={}", replayExecutionId, e);
+            }
+        }
+
+        sendReplayAlert(jobExecution.getStatus(), replayExecutionId);
+    }
+
+    private void sendReplayAlert(BatchStatus batchStatus, Long replayExecutionId) {
+        try {
+            DlqReplayExecution execution = dlqReplayService.getExecution(replayExecutionId);
+            String title = batchStatus == BatchStatus.FAILED
+                    ? "DLQ Replay Failed"
+                    : "DLQ Replay Completed";
+            String detail = String.format(
+                    "executionId=%d, status=%s, dryRun=%s, target=%d, replayed=%d, skipped=%d, finalFailed=%d, publishFailed=%d",
+                    execution.getId(),
+                    execution.getStatus(),
+                    execution.isDryRun(),
+                    execution.getTargetCount(),
+                    execution.getReplayedCount(),
+                    execution.getSkippedCount(),
+                    execution.getFinalFailedCount(),
+                    execution.getPublishFailedCount()
+            );
+            slackNotificationService.sendBatchAlert(title, detail);
+        } catch (Exception e) {
+            log.error("Failed to send DLQ replay Slack alert. replayExecutionId={}", replayExecutionId, e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,38 +53,56 @@ public class PendingRecoveryJobConfig {
     @Bean
     public Tasklet pendingRecoveryTasklet() {
         return (contribution, chunkContext) -> {
-            LocalDateTime cutoff = LocalDateTime.now().minusMinutes(5);
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime cutoff = now.minusMinutes(5);
             List<ParticipationHistory> pendingList =
                     participationHistoryRepository.findByStatusAndCreatedAtBefore(
                             ParticipationStatus.PENDING, cutoff);
 
             if (pendingList.isEmpty()) {
+                log.info("Pending recovery completed. candidates=0, republished=0");
                 return RepeatStatus.FINISHED;
             }
 
             int successCount = 0;
             for (ParticipationHistory history : pendingList) {
                 String message = buildMessage(history);
+                Long ageMinutes = history.getCreatedAt() == null
+                        ? null
+                        : Math.max(0L, ChronoUnit.MINUTES.between(history.getCreatedAt(), now));
                 try {
-                    // Redis Queue 대신 Kafka 직접 발행
-                    // 이유: 재고 소진 시 active:campaigns에서 SREM → Bridge가 큐를 드레인하지 않음
-                    //       Batch 복구 대상은 소량이므로 Bridge 우회해도 부하 없음
                     kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(history.getCampaign().getId()), message)
                             .whenComplete((result, ex) -> {
                                 if (ex != null) {
-                                    log.error("PENDING 재발행 실패. historyId={}", history.getId(), ex);
+                                    log.error(
+                                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=false",
+                                            history.getId(),
+                                            history.getCampaign().getId(),
+                                            ageMinutes,
+                                            ex
+                                    );
                                 } else {
-                                    log.info("PENDING 재발행 성공. historyId={}", history.getId());
+                                    log.info(
+                                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=true",
+                                            history.getId(),
+                                            history.getCampaign().getId(),
+                                            ageMinutes
+                                    );
                                 }
                             });
                     successCount++;
                 } catch (Exception e) {
-                    log.warn("PENDING 재발행 실패. historyId={}, campaignId={}",
-                            history.getId(), history.getCampaign().getId(), e);
+                    log.warn(
+                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=false",
+                            history.getId(),
+                            history.getCampaign().getId(),
+                            ageMinutes,
+                            e
+                    );
                 }
             }
 
-            log.info("PENDING 재처리 완료. 전체={}, 재발행={}", pendingList.size(), successCount);
+            log.info("Pending recovery completed. candidates={}, republished={}", pendingList.size(), successCount);
 
             return RepeatStatus.FINISHED;
         };
@@ -97,7 +116,7 @@ public class PendingRecoveryJobConfig {
             msg.put("sequence", history.getSequence());
             return jsonMapper.writeValueAsString(msg);
         } catch (Exception e) {
-            throw new RuntimeException("메시지 직렬화 실패. historyId=" + history.getId(), e);
+            throw new RuntimeException("Message serialization failed. historyId=" + history.getId(), e);
         }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchConfig.java
@@ -3,15 +3,20 @@ package io.eventdriven.campaign.config;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Spring Batch 설정
  * - 비동기 JobLauncher: 배치 실행 시 API 응답 지연 방지
  */
+@EnableAsync
 @Configuration
 @SuppressWarnings("removal")
 public class BatchConfig {
@@ -36,6 +41,18 @@ public class BatchConfig {
         return executor;
     }
 
+    @Bean(name = "slackTaskExecutor")
+    public ThreadPoolTaskExecutor slackTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("slack-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.initialize();
+        return executor;
+    }
+
     /**
      * 비동기 JobLauncher
      * - 배치 작업을 백그라운드에서 실행
@@ -47,7 +64,7 @@ public class BatchConfig {
     @Bean(name = "asyncJobLauncher")
     public JobLauncher asyncJobLauncher(
             JobRepository jobRepository,
-            ThreadPoolTaskExecutor batchTaskExecutor
+            @Qualifier("batchTaskExecutor") ThreadPoolTaskExecutor batchTaskExecutor
     ) throws Exception {
         TaskExecutorJobLauncher jobLauncher = new TaskExecutorJobLauncher();
         jobLauncher.setJobRepository(jobRepository);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchProperties.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchProperties.java
@@ -5,10 +5,6 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-/**
- * 배치 작업 관련 설정 프로퍼티
- * - application.yml의 batch.* 설정을 주입받음
- */
 @Getter
 @Setter
 @Component
@@ -17,22 +13,32 @@ public class BatchProperties {
 
     private Aggregation aggregation = new Aggregation();
     private Metadata metadata = new Metadata();
+    private Replay replay = new Replay();
+    private Consistency consistency = new Consistency();
 
     @Getter
     @Setter
     public static class Aggregation {
-        /**
-         * 집계 가능한 최대 과거 기간 (년)
-         */
         private int maxPastYears = 1;
     }
 
     @Getter
     @Setter
     public static class Metadata {
-        /**
-         * 배치 메타데이터 보관 기간 (일)
-         */
         private int retentionDays = 90;
+    }
+
+    @Getter
+    @Setter
+    public static class Replay {
+        private int pageSize = 100;
+        private int defaultMaxItems = 100;
+    }
+
+    @Getter
+    @Setter
+    public static class Consistency {
+        private int pageSize = 100;
+        private int defaultMaxCampaigns = 100;
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyAnomalyType.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyAnomalyType.java
@@ -1,0 +1,12 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyAnomalyType {
+    MISSING_REDIS_STOCK,
+    MISSING_REDIS_TOTAL,
+    MISSING_ACTIVE_STATE,
+    CLOSED_REDIS_RESIDUE,
+    QUEUE_WITHOUT_ACTIVE_STATE,
+    SUCCESS_PENDING_EXCEEDS_TOTAL,
+    REDIS_REMAINING_MISMATCH,
+    NEGATIVE_REDIS_STOCK
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryAction.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryAction.java
@@ -1,0 +1,9 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyRecoveryAction {
+    NONE,
+    REPORT_ONLY,
+    RESTORE_REDIS_STATE,
+    ACTIVATE_CAMPAIGN,
+    CLEANUP_REDIS_STATE
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecution.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecution.java
@@ -1,0 +1,101 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "consistency_recovery_execution")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsistencyRecoveryExecution extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requested_by", length = 100)
+    private String requestedBy;
+
+    @Column(name = "dry_run", nullable = false)
+    private boolean dryRun;
+
+    @Column(name = "auto_fix", nullable = false)
+    private boolean autoFix;
+
+    @Column(name = "filter_campaign_id")
+    private Long filterCampaignId;
+
+    @Column(name = "max_campaigns", nullable = false)
+    private int maxCampaigns;
+
+    @Column(name = "target_count", nullable = false)
+    private long targetCount;
+
+    @Column(name = "anomaly_count", nullable = false)
+    private long anomalyCount;
+
+    @Column(name = "fixed_count", nullable = false)
+    private long fixedCount;
+
+    @Column(name = "report_only_count", nullable = false)
+    private long reportOnlyCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private ConsistencyRecoveryExecutionStatus status;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    public ConsistencyRecoveryExecution(
+            String requestedBy,
+            boolean dryRun,
+            boolean autoFix,
+            Long filterCampaignId,
+            int maxCampaigns,
+            long targetCount
+    ) {
+        this.requestedBy = requestedBy;
+        this.dryRun = dryRun;
+        this.autoFix = autoFix;
+        this.filterCampaignId = filterCampaignId;
+        this.maxCampaigns = maxCampaigns;
+        this.targetCount = targetCount;
+        this.status = ConsistencyRecoveryExecutionStatus.REQUESTED;
+    }
+
+    public void markRunning(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.RUNNING;
+        this.startedAt = now;
+        this.endedAt = null;
+    }
+
+    public void incrementAnomalyCount() {
+        this.anomalyCount++;
+    }
+
+    public void incrementFixedCount() {
+        this.fixedCount++;
+    }
+
+    public void incrementReportOnlyCount() {
+        this.reportOnlyCount++;
+    }
+
+    public void markCompleted(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.COMPLETED;
+        this.endedAt = now;
+    }
+
+    public void markFailed(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.FAILED;
+        this.endedAt = now;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecutionStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecutionStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyRecoveryExecutionStatus {
+    REQUESTED,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryResult.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryResult.java
@@ -1,0 +1,113 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "consistency_recovery_result")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsistencyRecoveryResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "execution_id", nullable = false)
+    private ConsistencyRecoveryExecution execution;
+
+    @Column(name = "campaign_id", nullable = false)
+    private Long campaignId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "campaign_status", nullable = false, length = 32)
+    private CampaignStatus campaignStatus;
+
+    @Column(name = "total_stock", nullable = false)
+    private long totalStock;
+
+    @Column(name = "success_count", nullable = false)
+    private long successCount;
+
+    @Column(name = "pending_count", nullable = false)
+    private long pendingCount;
+
+    @Column(name = "redis_remaining_stock")
+    private Long redisRemainingStock;
+
+    @Column(name = "redis_total_stock")
+    private Long redisTotalStock;
+
+    @Column(name = "queue_size", nullable = false)
+    private long queueSize;
+
+    @Column(name = "active_flag_present", nullable = false)
+    private boolean activeFlagPresent;
+
+    @Column(name = "active_set_present", nullable = false)
+    private boolean activeSetPresent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "anomaly_type", nullable = false, length = 64)
+    private ConsistencyAnomalyType anomalyType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false, length = 32)
+    private ConsistencySeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_taken", nullable = false, length = 32)
+    private ConsistencyRecoveryAction actionTaken;
+
+    @Column(name = "fixed", nullable = false)
+    private boolean fixed;
+
+    @Column(name = "detail_message", length = 1000)
+    private String detailMessage;
+
+    @Column(name = "checked_at", nullable = false)
+    private LocalDateTime checkedAt;
+
+    public ConsistencyRecoveryResult(
+            ConsistencyRecoveryExecution execution,
+            Long campaignId,
+            CampaignStatus campaignStatus,
+            long totalStock,
+            long successCount,
+            long pendingCount,
+            Long redisRemainingStock,
+            Long redisTotalStock,
+            long queueSize,
+            boolean activeFlagPresent,
+            boolean activeSetPresent,
+            ConsistencyAnomalyType anomalyType,
+            ConsistencySeverity severity,
+            ConsistencyRecoveryAction actionTaken,
+            boolean fixed,
+            String detailMessage,
+            LocalDateTime checkedAt
+    ) {
+        this.execution = execution;
+        this.campaignId = campaignId;
+        this.campaignStatus = campaignStatus;
+        this.totalStock = totalStock;
+        this.successCount = successCount;
+        this.pendingCount = pendingCount;
+        this.redisRemainingStock = redisRemainingStock;
+        this.redisTotalStock = redisTotalStock;
+        this.queueSize = queueSize;
+        this.activeFlagPresent = activeFlagPresent;
+        this.activeSetPresent = activeSetPresent;
+        this.anomalyType = anomalyType;
+        this.severity = severity;
+        this.actionTaken = actionTaken;
+        this.fixed = fixed;
+        this.detailMessage = detailMessage;
+        this.checkedAt = checkedAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencySeverity.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencySeverity.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencySeverity {
+    INFO,
+    WARNING,
+    CRITICAL
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageProcessingStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageProcessingStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqMessageProcessingStatus {
+    PENDING,
+    REPLAYED,
+    SKIPPED,
+    FINAL_FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -27,8 +29,8 @@ public class DlqMessageRecord extends BaseTimeEntity {
     @Column(name = "original_key")
     private String originalKey;
 
-    @Lob
-    @Column(name = "original_message", nullable = false)
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "original_message", nullable = false, columnDefinition = "TEXT")
     private String originalMessage;
 
     @Column(name = "error_reason", nullable = false, length = 100)

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
@@ -1,0 +1,111 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqMessageRecord extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 32)
+    private DlqSourceType sourceType;
+
+    @Column(name = "original_topic", nullable = false)
+    private String originalTopic;
+
+    @Column(name = "original_key")
+    private String originalKey;
+
+    @Lob
+    @Column(name = "original_message", nullable = false)
+    private String originalMessage;
+
+    @Column(name = "error_reason", nullable = false, length = 100)
+    private String errorReason;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Column(name = "campaign_id")
+    private Long campaignId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "sequence_no")
+    private Long sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "replay_classification", nullable = false, length = 32)
+    private DlqReplayClassification replayClassification;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "processing_status", nullable = false, length = 32)
+    private DlqMessageProcessingStatus processingStatus;
+
+    @Column(name = "replay_attempt_count", nullable = false)
+    private int replayAttemptCount;
+
+    @Column(name = "final_failure_reason", length = 255)
+    private String finalFailureReason;
+
+    @Column(name = "last_replayed_at")
+    private LocalDateTime lastReplayedAt;
+
+    public DlqMessageRecord(
+            DlqSourceType sourceType,
+            String originalTopic,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage,
+            Long campaignId,
+            Long userId,
+            Long sequence,
+            DlqReplayClassification replayClassification
+    ) {
+        this.sourceType = sourceType;
+        this.originalTopic = originalTopic;
+        this.originalKey = originalKey;
+        this.originalMessage = originalMessage;
+        this.errorReason = errorReason;
+        this.errorMessage = errorMessage;
+        this.campaignId = campaignId;
+        this.userId = userId;
+        this.sequence = sequence;
+        this.replayClassification = replayClassification;
+        this.processingStatus = DlqMessageProcessingStatus.PENDING;
+        this.replayAttemptCount = 0;
+    }
+
+    public void incrementReplayAttempt() {
+        this.replayAttemptCount++;
+    }
+
+    public void markReplayed(LocalDateTime replayedAt) {
+        this.processingStatus = DlqMessageProcessingStatus.REPLAYED;
+        this.lastReplayedAt = replayedAt;
+        this.finalFailureReason = null;
+    }
+
+    public void markSkipped(String reason) {
+        this.processingStatus = DlqMessageProcessingStatus.SKIPPED;
+        this.finalFailureReason = reason;
+    }
+
+    public void markFinalFailed(String reason) {
+        this.processingStatus = DlqMessageProcessingStatus.FINAL_FAILED;
+        this.finalFailureReason = reason;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayAction.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayAction.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayAction {
+    REPLAY,
+    SKIP,
+    FINAL_FAIL
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayClassification.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayClassification.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayClassification {
+    REPLAYABLE,
+    CONDITIONALLY_REPLAYABLE,
+    NON_REPLAYABLE
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecution.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecution.java
@@ -1,0 +1,118 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_replay_execution")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqReplayExecution extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requested_by", length = 100)
+    private String requestedBy;
+
+    @Column(name = "dry_run", nullable = false)
+    private boolean dryRun;
+
+    @Column(name = "filter_campaign_id")
+    private Long filterCampaignId;
+
+    @Column(name = "filter_reason", length = 100)
+    private String filterReason;
+
+    @Column(name = "filter_from_time")
+    private LocalDateTime filterFromTime;
+
+    @Column(name = "filter_to_time")
+    private LocalDateTime filterToTime;
+
+    @Column(name = "max_items", nullable = false)
+    private int maxItems;
+
+    @Column(name = "target_count", nullable = false)
+    private long targetCount;
+
+    @Column(name = "replayed_count", nullable = false)
+    private long replayedCount;
+
+    @Column(name = "skipped_count", nullable = false)
+    private long skippedCount;
+
+    @Column(name = "final_failed_count", nullable = false)
+    private long finalFailedCount;
+
+    @Column(name = "publish_failed_count", nullable = false)
+    private long publishFailedCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private DlqReplayExecutionStatus status;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    public DlqReplayExecution(
+            String requestedBy,
+            boolean dryRun,
+            Long filterCampaignId,
+            String filterReason,
+            LocalDateTime filterFromTime,
+            LocalDateTime filterToTime,
+            int maxItems,
+            long targetCount
+    ) {
+        this.requestedBy = requestedBy;
+        this.dryRun = dryRun;
+        this.filterCampaignId = filterCampaignId;
+        this.filterReason = filterReason;
+        this.filterFromTime = filterFromTime;
+        this.filterToTime = filterToTime;
+        this.maxItems = maxItems;
+        this.targetCount = targetCount;
+        this.status = DlqReplayExecutionStatus.REQUESTED;
+    }
+
+    public void markRunning(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.RUNNING;
+        this.startedAt = now;
+        this.endedAt = null;
+    }
+
+    public void incrementReplayed() {
+        this.replayedCount++;
+    }
+
+    public void incrementSkipped() {
+        this.skippedCount++;
+    }
+
+    public void incrementFinalFailed() {
+        this.finalFailedCount++;
+    }
+
+    public void incrementPublishFailed() {
+        this.publishFailedCount++;
+    }
+
+    public void markCompleted(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.COMPLETED;
+        this.endedAt = now;
+    }
+
+    public void markFailed(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.FAILED;
+        this.endedAt = now;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionItem.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionItem.java
@@ -1,0 +1,70 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_replay_execution_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqReplayExecutionItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "execution_id", nullable = false)
+    private DlqReplayExecution execution;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dlq_message_id", nullable = false)
+    private DlqMessageRecord dlqMessage;
+
+    @Column(name = "original_topic", nullable = false)
+    private String originalTopic;
+
+    @Column(name = "original_key")
+    private String originalKey;
+
+    @Column(name = "reason", nullable = false, length = 100)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action", nullable = false, length = 32)
+    private DlqReplayAction action;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result", nullable = false, length = 32)
+    private DlqReplayItemResult result;
+
+    @Column(name = "detail_message", length = 1000)
+    private String detailMessage;
+
+    @Column(name = "processed_at", nullable = false)
+    private LocalDateTime processedAt;
+
+    public DlqReplayExecutionItem(
+            DlqReplayExecution execution,
+            DlqMessageRecord dlqMessage,
+            String reason,
+            DlqReplayAction action,
+            DlqReplayItemResult result,
+            String detailMessage,
+            LocalDateTime processedAt
+    ) {
+        this.execution = execution;
+        this.dlqMessage = dlqMessage;
+        this.originalTopic = dlqMessage.getOriginalTopic();
+        this.originalKey = dlqMessage.getOriginalKey();
+        this.reason = reason;
+        this.action = action;
+        this.result = result;
+        this.detailMessage = detailMessage;
+        this.processedAt = processedAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayExecutionStatus {
+    REQUESTED,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayItemResult.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayItemResult.java
@@ -1,0 +1,9 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayItemResult {
+    SUCCESS,
+    SKIPPED,
+    FINAL_FAILED,
+    FAILED,
+    DRY_RUN
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqSourceType.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqSourceType.java
@@ -1,0 +1,6 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqSourceType {
+    BRIDGE,
+    CONSUMER
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryExecutionRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryExecutionRepository.java
@@ -1,0 +1,12 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConsistencyRecoveryExecutionRepository extends JpaRepository<ConsistencyRecoveryExecution, Long> {
+
+    List<ConsistencyRecoveryExecution> findByOrderByIdDesc(Pageable pageable);
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryResultRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryResultRepository.java
@@ -1,0 +1,23 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryResult;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ConsistencyRecoveryResultRepository extends JpaRepository<ConsistencyRecoveryResult, Long> {
+
+    @Query("""
+        SELECT r
+        FROM ConsistencyRecoveryResult r
+        WHERE r.execution.id = :executionId
+        ORDER BY r.id ASC
+    """)
+    List<ConsistencyRecoveryResult> findByExecutionIdOrderByIdAsc(
+            @Param("executionId") Long executionId,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqMessageRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqMessageRepository.java
@@ -1,0 +1,67 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DlqMessageRepository extends JpaRepository<DlqMessageRecord, Long> {
+
+    @Query("""
+        SELECT COUNT(d)
+        FROM DlqMessageRecord d
+        WHERE d.processingStatus = :status
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+          AND (:fromTime IS NULL OR d.createdAt >= :fromTime)
+          AND (:toTime IS NULL OR d.createdAt <= :toTime)
+    """)
+    long countReplayCandidates(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            @Param("fromTime") LocalDateTime fromTime,
+            @Param("toTime") LocalDateTime toTime
+    );
+
+    @Query("""
+        SELECT d
+        FROM DlqMessageRecord d
+        WHERE d.processingStatus = :status
+          AND d.id > :afterId
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+          AND (:fromTime IS NULL OR d.createdAt >= :fromTime)
+          AND (:toTime IS NULL OR d.createdAt <= :toTime)
+        ORDER BY d.id ASC
+    """)
+    List<DlqMessageRecord> findReplayCandidates(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("afterId") Long afterId,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            @Param("fromTime") LocalDateTime fromTime,
+            @Param("toTime") LocalDateTime toTime,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT d
+        FROM DlqMessageRecord d
+        WHERE (:status IS NULL OR d.processingStatus = :status)
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+        ORDER BY d.id DESC
+    """)
+    List<DlqMessageRecord> searchMessages(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionItemRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionItemRepository.java
@@ -1,0 +1,23 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionItem;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DlqReplayExecutionItemRepository extends JpaRepository<DlqReplayExecutionItem, Long> {
+
+    @Query("""
+        SELECT i
+        FROM DlqReplayExecutionItem i
+        WHERE i.execution.id = :executionId
+        ORDER BY i.id ASC
+    """)
+    List<DlqReplayExecutionItem> findByExecutionIdOrderByIdAsc(
+            @Param("executionId") Long executionId,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionRepository.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DlqReplayExecutionRepository extends JpaRepository<DlqReplayExecution, Long> {
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ParticipationHistoryRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ParticipationHistoryRepository.java
@@ -61,6 +61,19 @@ public interface ParticipationHistoryRepository extends JpaRepository<Participat
      */
     Optional<ParticipationHistory> findByCampaignIdAndUserId(Long campaignId, Long userId);
 
+    @Query("""
+        SELECT COUNT(ph) > 0
+        FROM ParticipationHistory ph
+        WHERE ph.campaign.id = :campaignId
+          AND ph.userId = :userId
+          AND ph.status = :status
+    """)
+    boolean existsSuccessHistory(
+            @Param("campaignId") Long campaignId,
+            @Param("userId") Long userId,
+            @Param("status") ParticipationStatus status
+    );
+
     // 5분 초과 PENDING 재처리 배치용
     List<ParticipationHistory> findByStatusAndCreatedAtBefore(ParticipationStatus status, LocalDateTime cutoff);
 

--- a/app/campaign-core/src/main/resources/db/migration/V5__dlq_replay_schema.sql
+++ b/app/campaign-core/src/main/resources/db/migration/V5__dlq_replay_schema.sql
@@ -1,0 +1,76 @@
+CREATE TABLE dlq_message (
+    id                      BIGINT       NOT NULL AUTO_INCREMENT,
+    source_type             VARCHAR(32)  NOT NULL,
+    original_topic          VARCHAR(255) NOT NULL,
+    original_key            VARCHAR(255),
+    original_message        TEXT         NOT NULL,
+    error_reason            VARCHAR(100) NOT NULL,
+    error_message           VARCHAR(1000),
+    campaign_id             BIGINT,
+    user_id                 BIGINT,
+    sequence_no             BIGINT,
+    replay_classification   VARCHAR(32)  NOT NULL,
+    processing_status       VARCHAR(32)  NOT NULL,
+    replay_attempt_count    INT          NOT NULL DEFAULT 0,
+    final_failure_reason    VARCHAR(255),
+    last_replayed_at        DATETIME(6),
+    created_at              DATETIME(6)  NOT NULL,
+    updated_at              DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dlq_message_status_id
+    ON dlq_message (processing_status, id);
+
+CREATE INDEX idx_dlq_message_campaign_status
+    ON dlq_message (campaign_id, processing_status);
+
+CREATE INDEX idx_dlq_message_reason_status
+    ON dlq_message (error_reason, processing_status);
+
+CREATE TABLE dlq_replay_execution (
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
+    requested_by         VARCHAR(100),
+    dry_run              BIT(1)       NOT NULL,
+    filter_campaign_id   BIGINT,
+    filter_reason        VARCHAR(100),
+    filter_from_time     DATETIME(6),
+    filter_to_time       DATETIME(6),
+    max_items            INT          NOT NULL,
+    target_count         BIGINT       NOT NULL DEFAULT 0,
+    replayed_count       BIGINT       NOT NULL DEFAULT 0,
+    skipped_count        BIGINT       NOT NULL DEFAULT 0,
+    final_failed_count   BIGINT       NOT NULL DEFAULT 0,
+    publish_failed_count BIGINT       NOT NULL DEFAULT 0,
+    status               VARCHAR(32)  NOT NULL,
+    started_at           DATETIME(6),
+    ended_at             DATETIME(6),
+    created_at           DATETIME(6)  NOT NULL,
+    updated_at           DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE dlq_replay_execution_item (
+    id             BIGINT        NOT NULL AUTO_INCREMENT,
+    execution_id   BIGINT        NOT NULL,
+    dlq_message_id BIGINT        NOT NULL,
+    original_topic VARCHAR(255)  NOT NULL,
+    original_key   VARCHAR(255),
+    reason         VARCHAR(100)  NOT NULL,
+    action         VARCHAR(32)   NOT NULL,
+    result         VARCHAR(32)   NOT NULL,
+    detail_message VARCHAR(1000),
+    processed_at   DATETIME(6)   NOT NULL,
+    created_at     DATETIME(6)   NOT NULL,
+    updated_at     DATETIME(6)   NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_dlq_replay_execution_item_execution
+        FOREIGN KEY (execution_id) REFERENCES dlq_replay_execution (id),
+    CONSTRAINT fk_dlq_replay_execution_item_message
+        FOREIGN KEY (dlq_message_id) REFERENCES dlq_message (id),
+    CONSTRAINT uk_dlq_replay_execution_message
+        UNIQUE (execution_id, dlq_message_id)
+);
+
+CREATE INDEX idx_dlq_replay_execution_item_execution
+    ON dlq_replay_execution_item (execution_id);

--- a/app/campaign-core/src/main/resources/db/migration/V6__consistency_recovery_schema.sql
+++ b/app/campaign-core/src/main/resources/db/migration/V6__consistency_recovery_schema.sql
@@ -1,0 +1,47 @@
+CREATE TABLE consistency_recovery_execution (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    requested_by VARCHAR(100) NULL,
+    dry_run BIT NOT NULL,
+    auto_fix BIT NOT NULL,
+    filter_campaign_id BIGINT NULL,
+    max_campaigns INT NOT NULL,
+    target_count BIGINT NOT NULL DEFAULT 0,
+    anomaly_count BIGINT NOT NULL DEFAULT 0,
+    fixed_count BIGINT NOT NULL DEFAULT 0,
+    report_only_count BIGINT NOT NULL DEFAULT 0,
+    status VARCHAR(32) NOT NULL,
+    started_at DATETIME NULL,
+    ended_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    INDEX idx_consistency_execution_status (status),
+    INDEX idx_consistency_execution_campaign (filter_campaign_id)
+);
+
+CREATE TABLE consistency_recovery_result (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id BIGINT NOT NULL,
+    campaign_id BIGINT NOT NULL,
+    campaign_status VARCHAR(32) NOT NULL,
+    total_stock BIGINT NOT NULL,
+    success_count BIGINT NOT NULL,
+    pending_count BIGINT NOT NULL,
+    redis_remaining_stock BIGINT NULL,
+    redis_total_stock BIGINT NULL,
+    queue_size BIGINT NOT NULL,
+    active_flag_present BIT NOT NULL,
+    active_set_present BIT NOT NULL,
+    anomaly_type VARCHAR(64) NOT NULL,
+    severity VARCHAR(32) NOT NULL,
+    action_taken VARCHAR(32) NOT NULL,
+    fixed BIT NOT NULL,
+    detail_message VARCHAR(1000) NULL,
+    checked_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT fk_consistency_result_execution
+        FOREIGN KEY (execution_id) REFERENCES consistency_recovery_execution(id),
+    INDEX idx_consistency_result_execution (execution_id),
+    INDEX idx_consistency_result_campaign (campaign_id),
+    INDEX idx_consistency_result_anomaly (anomaly_type)
+);

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -4,7 +4,7 @@
 resource "aws_launch_template" "app" {
   name          = "batch-kafka-app-lt"
   image_id      = "ami-01c64e7a84a57e681"  # batch-kafka-app-ami (Docker + CodeDeploy 포함)
-  instance_type = "t3.large"
+  instance_type = "t3.small"
 
   iam_instance_profile {
     name = aws_iam_instance_profile.batch_kafka_app.name

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -4,7 +4,7 @@
 resource "aws_launch_template" "app" {
   name          = "batch-kafka-app-lt"
   image_id      = "ami-01c64e7a84a57e681"  # batch-kafka-app-ami (Docker + CodeDeploy 포함)
-  instance_type = "t3.small"
+  instance_type = "t3.large"
 
   iam_instance_profile {
     name = aws_iam_instance_profile.batch_kafka_app.name

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -53,7 +53,7 @@ resource "aws_autoscaling_group" "app" {
   }
 
   lifecycle {
-    ignore_changes = [desired_capacity]  # 수동 스케일 조정 보호
+    ignore_changes = [desired_capacity, min_size, max_size]  # 수동 스케일 조정 보호
   }
 }
 

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -239,7 +239,7 @@ resource "aws_instance" "kafka_3" {
 # terraform-mcp EC2 인스턴스
 resource "aws_instance" "terraform_mcp" {
   ami                    = "ami-0ecfdfd1c8ae01aec" # Amazon Linux 2023 ap-northeast-2 (2026-03-27)
-  instance_type          = "t3.small"
+  instance_type          = "t3.large"
   subnet_id              = aws_subnet.public_2a.id
   vpc_security_group_ids = [aws_security_group.terraform_mcp.id]
   iam_instance_profile   = aws_iam_instance_profile.terraform_mcp.name


### PR DESCRIPTION
## 개요

이번 PR은 운영 복구를 위한 두 개의 배치 기능을 포함합니다.

1. `DLQ replay batch`
  - Bridge / Consumer 단계에서 DLQ로 이동한 메시지를 조회하고 재처리합니다.
  - 중복 성공 건은 skip 하고, malformed payload 는 final fail 로 종료합니다.
2. `Consistency recovery batch`
  - Redis / DB / campaign 상태 불일치를 탐지합니다.
  - 안전하게 자동 복구 가능한 항목은 복구하고, 위험한 항목은 report-only 로 남깁니다.

추가 포함 사항:

- 운영 API 추가
- Slack batch alert 연동
- Docker 기반 full integration test 보강
- 로컬 Docker 기준 실제 admin API 검증

## 구현 범위

### 1. DLQ Replay

추가된 주요 요소:

- DLQ 메시지 저장 테이블
- replay execution / execution item 테이블
- replay 정책 서비스
- Spring Batch `dlqReplayJob`
- 운영 API
  - `POST /api/admin/dlq-replay`
  - `GET /api/admin/dlq-replay/executions/{executionId}`
  - `GET /api/admin/dlq-replay/messages`
- Slack batch summary alert

현재 정책:

- `(campaignId, userId)`가 이미 `SUCCESS`이면 `SKIP`
- malformed payload / 필수 필드 누락이면 `FINAL_FAIL`
- replay 가능 건은 메인 Kafka 토픽으로 재발행
- `dryRun=true`면 preview 만 수행하고 원본 DLQ 상태는 변경하지 않음

### 2. Consistency Recovery

추가된 주요 요소:

- consistency recovery execution / result 테이블
- anomaly 탐지 및 복구 서비스
- Spring Batch `consistencyRecoveryJob`
- 운영 API
  - `POST /api/admin/consistency-recovery`
  - `GET /api/admin/consistency-recovery/executions`
  - `GET /api/admin/consistency-recovery/executions/{executionId}`
- Slack batch summary alert

현재 anomaly 범위:

- `MISSING_REDIS_STOCK`
- `MISSING_REDIS_TOTAL`
- `MISSING_ACTIVE_STATE`
- `QUEUE_WITHOUT_ACTIVE_STATE`
- `CLOSED_REDIS_RESIDUE`
- `SUCCESS_PENDING_EXCEEDS_TOTAL`
- `REDIS_REMAINING_MISMATCH`
- `NEGATIVE_REDIS_STOCK`

현재 정책:

- auto-fix 대상
  - `MISSING_REDIS_STOCK`
  - `MISSING_REDIS_TOTAL`
  - `MISSING_ACTIVE_STATE`
  - `CLOSED_REDIS_RESIDUE`
- report-only 대상
  - `SUCCESS_PENDING_EXCEEDS_TOTAL`
  - `REDIS_REMAINING_MISMATCH`
  - 자동 수정이 위험한 기타 케이스
- `dryRun=true`면 결과만 기록하고 Redis 값은 변경하지 않음

### 3. 공통 보강

- `BatchProperties`에 replay / consistency 설정 추가
- `RedisStockService`에 total 조회, active set 조회, runtime state cleanup 유틸 추가
- `SlackNotificationService` 추가 — `@Async("slackTaskExecutor")` 비동기 처리
- `BatchConfig`에 `@EnableAsync` 및 Slack 전용 스레드 풀 추가
- 배치 완료/실패 summary Slack listener 추가
- Docker 기반 `fullIntegrationTest` 실행 경로 정리
- Kafka 테스트 consumer 관찰 race 완화

## Slack 비동기 처리 설계 결정

### 문제

초기 `SlackNotificationService`는 `RestTemplate`을 사용한 동기 호출 구조였습니다.

```java
// 변경 전 — 호출 스레드가 Slack HTTP 응답을 기다리는 동안 블로킹
private void sendAlert(String title, String detail) {
    restTemplate.postForEntity(webhookUrl, ..., String.class);
}
```

Slack webhook 응답 시간은 통상 200~500ms입니다.

이 구조에서 운영 장애 시나리오별로 다음 문제가 발생합니다.

**Bridge — MAX_RETRY_EXCEEDED**

`ParticipationBridge`는 `@Scheduled(fixedDelay = 100)`으로 동작합니다. 즉 이전 사이클이 끝나야 다음 사이클이 시작됩니다.

Kafka publish가 3회 재시도 후 실패하면 `sendToDlqWithSlack`이 호출됩니다. 이 시점에 Slack 동기 호출이 발생하면 Bridge 사이클이 Slack 응답 대기 시간만큼 지연됩니다.

```
Bridge 사이클 시작
  → Kafka publish 3회 재시도 (약 600ms 소비)
  → sendToDlqWithSlack()
      → slackNotificationService.sendDlqAlert()  ← 여기서 추가 200~500ms 블로킹
  → 사이클 종료 후 100ms 뒤 다음 사이클 시작
```

Kafka 장애 상황에서 Redis Queue 드레인이 늦어지는 복합 장애로 이어질 수 있습니다.

**Consumer — INSERT_FAILED**

DB 장애 시 배치 INSERT 실패 → row-by-row 폴백 진입 → 여러 건 연속 실패 시 건당 Slack 동기 호출이 발생합니다.

```java
// ConsumerRecord 파싱 루프 안에서 호출
sendToDlqWithSlack(..., "INSERT_FAILED", e);  // 건당 Slack 블로킹
```

Slack 응답을 기다리는 동안 `acknowledgment.acknowledge()`도 지연됩니다. Kafka 오프셋 커밋이 늦어지면 consumer lag이 폭증합니다.

### 해결

`@EnableAsync` + Slack 전용 스레드 풀을 도입해 Slack 호출을 호출 스레드에서 분리했습니다.

**`BatchConfig.java`**

```java
@EnableAsync
@Configuration
public class BatchConfig {

    @Bean(name = "slackTaskExecutor")
    public ThreadPoolTaskExecutor slackTaskExecutor() {
        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
        executor.setCorePoolSize(2);
        executor.setMaxPoolSize(4);
        executor.setQueueCapacity(50);
        executor.setThreadNamePrefix("slack-");
        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
        executor.initialize();
        return executor;
    }
}
```

**`SlackNotificationService.java`**

```java
@Async("slackTaskExecutor")
public void sendDlqAlert(String reason, String detail) {
    sendAlert("[DLQ 알림] " + reason, detail);
}

@Async("slackTaskExecutor")
public void sendBatchAlert(String title, String detail) {
    sendAlert("[Batch 알림] " + title, detail);
}
```

### 설계 선택 이유

| 항목 | 선택 | 이유 |
|------|------|------|
| `DiscardPolicy` | 큐 초과 시 알림 버림 | Slack 알림은 유실돼도 메인 로직에 영향 없음. 알림 재시도보다 호출 스레드 보호가 우선 |
| `queueCapacity=50` | 대기 큐 50개 | 에러 폭발 시 일시적 버퍼 확보. 초과분은 버림 |
| `maxPoolSize=4` | 최대 4개 스레드 | Slack 호출 빈도가 낮아 소형 풀로 충분. 리소스 낭비 방지 |
| 기존 `batchTaskExecutor` 미재사용 | 전용 풀 분리 | 배치 작업 스레드와 경합 방지 |

### 기존 로직 영향 없음

`@EnableAsync`는 `@Async`가 붙은 메서드에만 적용됩니다. 기존 동기 메서드, 배치 스레드 풀, Kafka consumer, Bridge 스케줄러는 변경 없습니다.

## 테스트 및 검증

## 1. 자동 검증

완료:

- `./gradlew compileJava`
- Docker 기반 `fullIntegrationTest` green

관련 통합 테스트:

- `DlqReplayIntegrationTest`
- `ConsistencyRecoveryIntegrationTest`
- `PendingRecoveryIntegrationTest`

관련 서비스/리스너 테스트:

- `DlqReplayServiceTest`
- `ConsistencyRecoveryServiceTest`
- `DlqReplayJobExecutionListenerTest`
- `ConsistencyRecoveryJobExecutionListenerTest`

## 2. 통합 테스트에서 확인한 범위

### DLQ Replay Integration

검증한 시나리오:

- replay 가능한 DLQ 메시지 -> Kafka 재발행 성공
- 이미 `SUCCESS`인 `(campaignId, userId)` -> `SKIP`
- malformed payload -> `FINAL_FAIL`

검증 포인트:

- execution 카운트
- execution item 결과
- DLQ 원본 row 상태 변경

### Consistency Recovery Integration

검증한 시나리오:

- `MISSING_REDIS_STOCK` -> fixed
- `MISSING_REDIS_TOTAL` -> fixed
- `MISSING_ACTIVE_STATE` -> fixed
- `CLOSED_REDIS_RESIDUE` -> cleanup
- `REDIS_REMAINING_MISMATCH` -> report-only
- `SUCCESS_PENDING_EXCEEDS_TOTAL` -> report-only

검증 포인트:

- execution 카운트
- result row anomaly / action / fixed 여부
- Redis 값 복구/삭제 여부

### Pending Recovery Integration

검증한 시나리오:

- no pending
- old pending only
- mixed age

검증 포인트:

- 재발행 건수
- old pending 만 재발행되는지
- republish key가 `campaignId` 기준인지

## 3. 로컬 Docker 실제 API 검증

이번 작업에서는 통합 테스트뿐 아니라 로컬 Docker 환경에서 실제 admin API 를 호출해 운영 경로를 검증했습니다.


### 3-1. Flyway 검증

확인 내용:

- `flyway_schema_history`에서 `V5`, `V6` 성공
- 아래 테이블 생성 확인
  - `dlq_message`
  - `dlq_replay_execution`
  - `dlq_replay_execution_item`
  - `consistency_recovery_execution`
  - `consistency_recovery_result`
- `GET /actuator/health` -> `UP`

결론:

- 마이그레이션 적용 경로 정상
- 앱 부팅과 schema validation 도 정상

### 3-2. DLQ replay 실제 검증

직접 넣은 데이터:

- 정상 replay 대상 DLQ row 1건
- 이미 성공 처리된 사용자에 대한 중복 DLQ row 1건
- malformed payload DLQ row 1건

실행:

- `POST /api/admin/dlq-replay`

확인 결과:

- execution `#1`
  - `targetCount=2`
  - `replayedCount=1`
  - `skippedCount=1`
  - `publishFailedCount=0`
- execution `#2`
  - `finalFailedCount=1`

원본 상태:

- 정상 row -> `REPLAYED`
- 중복 row -> `SKIPPED`
- malformed row -> `FINAL_FAILED`

execution item:

- `REPLAY`
- `SKIP`
- `FINAL_FAIL`

결론:

- 정상 재처리
- 중복 방지
- malformed 최종 실패 처리

### 3-3. DLQ replay dry-run 검증

직접 넣은 데이터:

- replay 가능한 DLQ row 1건 추가

실행:

- `POST /api/admin/dlq-replay` with `dryRun=true`

확인 결과:

- execution item -> `action=REPLAY`, `result=DRY_RUN`
- 원본 DLQ row 상태 유지
  - `processing_status=PENDING`
  - `replay_attempt_count=0`
  - `last_replayed_at=NULL`

결론:

- 미리보기만 수행하고 실제 상태는 변경하지 않음

### 3-4. Consistency recovery 실제 검증

직접 만든 상태 1:

- `CLOSED` campaign 인데 Redis runtime state 가 남아 있는 상태

실행:

- `POST /api/admin/consistency-recovery`

확인 결과:

- `anomalyType=CLOSED_REDIS_RESIDUE`
- `actionTaken=CLEANUP_REDIS_STATE`
- `fixed=true`
- Redis stock / total / active flag / active set membership 제거 확인

직접 만든 상태 2:

- DB 계산값과 Redis remaining stock 이 다르도록 강제한 상태

실행:

- `POST /api/admin/consistency-recovery`

확인 결과:

- `anomalyType=REDIS_REMAINING_MISMATCH`
- `actionTaken=REPORT_ONLY`
- `fixed=false`
- Redis stock 값은 그대로 유지

결론:

- 자동 복구 가능한 건 실제 복구
- 위험한 건 수정하지 않고 보고만 수행

### 3-5. Consistency recovery dry-run 검증

직접 만든 상태:

- 동일한 mismatch 상태 유지

실행:

- `POST /api/admin/consistency-recovery` with `dryRun=true`

확인 결과:

- result row 기록
- `reportOnlyCount=1`
- Redis stock 값은 실행 전후 동일

결론:

- dry-run은 anomaly 를 보여주지만 실제 Redis 상태는 변경하지 않음

## 4. Slack 알림 검증

Slack 알림은 `실제 앱 경로 확인`과 `direct webhook 확인`으로 나눠 검증했습니다.

### 4-1. 실제 앱 경로로 확인한 알림
<img width="1049" height="301" alt="image" src="https://github.com/user-attachments/assets/d20a8fc1-b363-4a2b-b58a-07aa41a52343" />


로컬 app 컨테이너에 webhook 환경변수를 주입한 뒤 실제 배치/API 흐름을 실행했습니다.

확인한 알림:

- `DLQ Replay Completed`
  - `dlq-replay dry-run` 실행 후 앱 로그에서 `Slack 알림 전송 완료` 확인
- `Consistency Recovery Completed`
  - `consistency-recovery dry-run` 실행 후 앱 로그에서 `Slack 알림 전송 완료` 확인
- `Consumer JSON_PARSE_ERROR`
  - 메인 Kafka 토픽에 malformed 메시지 투입 후 consumer parse 실패 알림 전송 로그 확인

결론:

- 앱에서 `SlackNotificationService` 호출
- webhook 전송
- 완료 알림과 consumer DLQ 알림

위 경로는 실제 앱 실행 흐름으로 확인 완료

### 4-2. Direct webhook 으로 채널 도달 확인

아래 제목은 로컬에서 실패 상황 자체를 짧게 재현하기 까다로워 direct webhook 으로 채널 도달을 확인했습니다.

- `DLQ Replay Failed`
- `Consistency Recovery Failed`
- `Bridge MAX_RETRY_EXCEEDED`

확인 결과:

- Slack webhook 응답 `ok`
- 채널 메시지 수신 확인

### 4-3. 왜 direct webhook 확인도 포함했는가

실패 알림 기능이 구현되지 않았다는 의미는 아닙니다.

로컬에서는 아래 두 상황을 짧고 안정적으로 재현하기가 어려웠습니다.

- `Bridge MAX_RETRY_EXCEEDED`
  - `ParticipationBridge`의 Kafka publish 가 비동기 send 기반이라 짧은 테스트에서 즉시 실패 분기로 떨어뜨리기 어려움
- 배치 `FAILED`
  - Redis/Kafka 를 강제로 끊으면 즉시 `FAILED`보다 재시도/타임아웃 상태가 길어질 수 있음

따라서 결론은:

- 구현/연결 문제보다는 로컬에서 실패 상황 재현 난이도가 높았음
- 배치 실패 제목과 Bridge 실패 제목 자체는 direct webhook 으로 채널 도달 확인 완료
- 관련 코드 경로와 리스너 테스트도 이미 존재

## 5. Slack 알림 포맷 정리

알림은 "이상 발생" 신호 용도이며, 세부 내역은 `executionId` 기반 API 조회로 확인합니다.

### 5-1. 알림 종류 및 발화 시점

| 알림 제목 | 채널 prefix | 발화 시점 |
|-----------|-------------|-----------|
| `DLQ Replay Completed` | `[Batch 알림]` | `dlqReplayJob` 정상 완료 |
| `DLQ Replay Failed` | `[Batch 알림]` | `dlqReplayJob` 실행 중 예외 발생 |
| `Consistency Recovery Completed` | `[Batch 알림]` | `consistencyRecoveryJob` 정상 완료 |
| `Consistency Recovery Failed` | `[Batch 알림]` | `consistencyRecoveryJob` 실행 중 예외 발생 |
| `Consumer JSON_PARSE_ERROR` | `[DLQ 알림]` | Kafka consumer 메시지 파싱 실패 → DLQ 이동 시 |
| `Bridge MAX_RETRY_EXCEEDED` | `[DLQ 알림]` | `ParticipationBridge` Kafka publish 최대 재시도 초과 시 |

### 5-2. 포맷 및 필드 설명

**DLQ Replay Completed / Failed**

```
[Batch 알림] DLQ Replay Completed | executionId=4, status=COMPLETED, dryRun=true, target=1, replayed=1, skipped=0, finalFailed=0, publishFailed=0
[Batch 알림] DLQ Replay Failed    | executionId=5, status=FAILED, dryRun=false, target=3, replayed=0, skipped=0, finalFailed=0, publishFailed=0
```

| 필드 | 설명 |
|------|------|
| `executionId` | 조회 키 — `GET /api/admin/dlq-replay/executions/{executionId}` |
| `status` | `COMPLETED` / `FAILED` |
| `dryRun` | `true`면 미리보기만 수행, 실제 Kafka 발행 없음 |
| `target` | 처리 대상 DLQ 메시지 수 |
| `replayed` | Kafka 재발행 성공 건수 (dryRun=true면 대상으로 분류된 건수) |
| `skipped` | 이미 `SUCCESS`인 `(campaignId, userId)` — 중복 skip 건수 |
| `finalFailed` | malformed payload 또는 필수 필드 누락으로 최종 실패 건수 |
| `publishFailed` | Kafka publish 자체 실패 건수 |

**Consistency Recovery Completed / Failed**

```
[Batch 알림] Consistency Recovery Completed | executionId=4, status=COMPLETED, dryRun=true, autoFix=true, target=1, anomalies=1, fixed=0, reportOnly=1
[Batch 알림] Consistency Recovery Failed    | executionId=5, status=FAILED, dryRun=true, autoFix=true, target=1, anomalies=0, fixed=0, reportOnly=0
```

| 필드 | 설명 |
|------|------|
| `executionId` | 조회 키 — `GET /api/admin/consistency-recovery/executions/{executionId}` |
| `status` | `COMPLETED` / `FAILED` |
| `dryRun` | `true`면 anomaly 탐지만 수행, Redis 값 변경 없음 |
| `autoFix` | `true`면 auto-fix 대상 anomaly 자동 복구 활성화 |
| `target` | 스캔한 캠페인 수 |
| `anomalies` | 탐지된 이상 건수 |
| `fixed` | 실제 복구 완료 건수 (dryRun=true면 항상 0) |
| `reportOnly` | 자동 복구 불가로 보고만 한 건수 |

**Consumer JSON_PARSE_ERROR**

```
[DLQ 알림] Consumer JSON_PARSE_ERROR | {raw payload}
```

| 필드 | 설명 |
|------|------|
| raw payload | 파싱 실패한 원본 메시지 내용 — 원인 파악용 |

발화 조건: Kafka consumer가 메시지 역직렬화 중 `JsonProcessingException` 발생 시.
정상 운영에서는 발생하지 않아야 하는 알림이므로 수신 즉시 원인 확인 필요.

**Bridge MAX_RETRY_EXCEEDED**

```
[DLQ 알림] Bridge MAX_RETRY_EXCEEDED | campaignId={id}, messageCount={n}
```

| 필드 | 설명 |
|------|------|
| `campaignId` | 재시도 초과가 발생한 캠페인 ID |
| `messageCount` | 해당 사이클에서 재시도 초과된 메시지 수 |

발화 조건: `ParticipationBridge`가 Kafka publish 최대 재시도 횟수를 초과했을 때.

### 5-3. 알림 수신 후 행동 기준

| 알림 | 즉시 행동 |
|------|-----------|
| `Completed` (dryRun=true) | 수치 확인 후 actual run 여부 판단 |
| `Completed` (dryRun=false, fixed>0) | 정상 복구 완료 — 추가 확인 불필요 |
| `Completed` (reportOnly>0) | `executionId`로 result 조회 → anomalyType 확인 후 수동 판단 |
| `Failed` | 앱 로그에서 `executionId` 시점 스택트레이스 확인 — 인프라 문제 의심 |
| `JSON_PARSE_ERROR` | payload 확인 → 코드 버그 또는 외부 잘못된 데이터 주입 여부 판단 |
| `MAX_RETRY_EXCEEDED` | Kafka 브로커 상태 및 Bridge 로그 즉시 확인 |

## 쉽게 설명하면

이번 검증은 단순히 `API가 200 응답하는지`만 본 것이 아닙니다.

우리가 실제로 한 것은:

1. 테스트 데이터를 직접 넣음
2. 배치/API를 실제로 실행함
3. DB와 Redis 결과가 기대한 후처리로 바뀌는지 확인함
4. Slack 알림이 실제로 오는지도 확인함

즉 확인한 것은:

- 중복 처리가 되는지
- 실패 건이 final fail 로 정리되는지
- 복구 가능한 정합성 문제를 실제로 고치는지
- 위험한 정합성 문제는 report-only 로 남기는지
- dry-run이 진짜로 상태를 안 바꾸는지
- 배치 완료 알림과 주요 실패성 알림이 Slack 으로 전달되는지

## 현재 상태

현재 상태는 다음과 같습니다.

- 구현 완료
- 자동 테스트 완료
- Docker full integration test 완료
- 로컬 Docker 실제 API 검증 완료
- dry-run / actual run 검증 완료
- Slack 알림 경로 검증 완료

즉 `기능 검증 완료` 상태입니다.

남은 것은 운영 반영 전 점검입니다.

- SSM 파라미터 확인
- 운영 권한 / 연결 확인
- `slack.webhook-url` 설정 확인
- 배포 후 health / 로그 확인

## 남은 운영 체크

- `/batch-kafka/prod/SPRING_PROFILES_ACTIVE`
- `/batch-kafka/prod/SPRING_DATASOURCE_URL`
- `/batch-kafka/prod/SPRING_DATASOURCE_USERNAME`
- `/batch-kafka/prod/SPRING_DATASOURCE_PASSWORD`
- `/batch-kafka/prod/SPRING_KAFKA_BOOTSTRAP_SERVERS`
- `/batch-kafka/prod/SPRING_DATA_REDIS_CLUSTER_NODES`
- `/batch-kafka/prod/SLACK_WEBHOOK_URL`
- `/batch-kafka/prod/ECR_IMAGE`

운영 배포 경로 기준으로는 SSM -> `.env.prod` -> `application-prod.yml` -> Spring property 연결이 이미 되어 있습니다.


### 추가 수정 사항

  ParticipationBridge의 Kafka publish 처리 방식을 수정했습니다.

  기존 구현은 kafkaTemplate.send() 호출 직후 예외가 없으면 즉시 성공으로 간주하고 publish 카운터를 증가시켰습니다. 하지만 send()는 비동기 호출이기 때문에, 이 시점에 보장되는 것은
  producer 내부 접수 성공뿐이며 실제 브로커 전송 성공은 아직 확정되지 않습니다. 따라서 버퍼 적재 이후 브로커 전송이 최종 실패하는 경우에도 애플리케이션 레벨에서는 성공으로 처리될
  수 있는 문제가 있었습니다.

  또한 기존 코드에는 애플리케이션 레벨 3회 재시도 + Thread.sleep()이 포함되어 있었는데, Kafka producer가 이미 내부적으로 대기 및 재시도 정책을 수행하는 구조에서 동일한 레벨의 재 
  시도를 한 번 더 수행하고 있었습니다. 이 방식은 실질적인 복구 효과보다 @Scheduled(fixedDelay = 100) 드레인 스레드를 블로킹하는 부작용이 더 컸습니다.                             
                                                                                                                                                                                  
  이번 수정에서는 다음과 같이 정리했습니다.                                                                                                                                       
                                                                                                                                                                                  
  - 애플리케이션 레벨 재시도 루프 제거                                                                                                                                            
  - Thread.sleep() 제거                                                                                                                                                           
  - send() 호출 시점 즉시 예외는 즉시 DLQ 처리                                                                                                                                    
  - send() 반환 future의 whenComplete에서 최종 성공/실패를 판정                                                                                                                   
  - publish 카운터는 future 성공 완료 시점에만 증가하도록 변경                                                                                                                    
  - future 실패 시 DLQ 및 Slack 알림 처리 추가                                                                                                                                    
                                                                                                                                                                                  
  이 변경으로 인해 ParticipationBridge는 더 이상 단일 메시지 publish 실패 때문에 드레인 루프를 멈추지 않으며, send() 접수 성공과 실제 Kafka 전송 성공을 구분해서 처리하게 됩니다. 
  결과적으로 성공 집계 정확도와 DLQ 처리 정확도가 함께 개선됩니다.   

## 체크리스트

- [x] 기능 구현 완료
- [x] 단위 / 서비스 테스트 완료
- [x] Docker full integration test 완료
- [x] 로컬 Docker 실제 API 검증 완료
- [x] dry-run / actual run 검증 완료
- [x] Flyway `V5`, `V6` 로컬 검증 완료
- [x] Slack 알림 검증 완료
- [x] Slack 비동기 처리 (`@Async` + 전용 스레드 풀) 적용 완료
- [x] 운영 runbook 작성 완료
- [x] 운영 SSM 변수 확인
- [x] 운영 권한 / 연결 확인
- [x] 최종 배포 판단
- [x] `DO NOT MERGE` 해제 판단

