### PR TITLE
feat: Grafana 수동 감시 자동화 - MCP 서버 + Prometheus/CloudWatch 알림 (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ infra/terraform.tfstate
 infra/terraform.tfstate.backup
 infra/*.tfvars
 
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+
 # 환경변수 (민감정보)
 .env
 app/campaign-core/.env

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -808,19 +808,62 @@ bash ~/1milion-campaign-orchestration-system/stress-test/run-test.sh prod
 
 ---
 
-### Phase C — API 엔드포인트 정리 (v3 기준 재정비)
+### Phase C — API 엔드포인트 정리 + 프론트 운영 콘솔화
 
-v1/v2 잔재 엔드포인트를 v3 아키텍처 기준으로 정리합니다.
+v1/v2 잔재 제거 + 프론트를 "성능 실험실"에서 "운영 콘솔"로 재편합니다.
 
-**주요 작업:**
+#### 백엔드 API 분류
 
-| 작업 | 내용 |
-|------|------|
-| 불필요한 컨트롤러 제거 | v1 LoadTestController, TestController, KafkaManagementController 등 정리 |
-| 폴링 API 개선 | `GET /api/campaigns/{id}/participation/{userId}/result` — Redis 캐시 우선, DB fallback |
-| 캠페인 상태 조회 API | 재고/상태 Redis 우선 조회 (DB 미접촉) |
-| Admin API 정리 | 캠페인 생성 시 Redis 초기화 (stock, total, active flag) 흐름 명확화 |
-| API 문서화 | Swagger/OpenAPI 또는 README에 엔드포인트 명세 정리 |
+| 분류 | API | 조치 |
+|------|-----|------|
+| A. 핵심 유지 | `POST /api/campaigns/{id}/participation` | 유지 |
+| A. 핵심 유지 | `GET /api/campaigns/{id}/participation/{userId}/result` | 유지 |
+| A. 핵심 유지 | `GET/POST /api/admin/campaigns` | 유지 |
+| A. 핵심 유지 | `GET /api/admin/stats/daily` | 유지 |
+| A. 핵심 유지 | `GET /api/admin/stats/campaign/{id}` | 유지 |
+| A. 핵심 유지 | `POST/GET /api/admin/batch/*` | 유지 |
+| B. 보조 | `GET /api/campaigns/{id}/status` | 유지 (운영 요약 목적으로 제한) |
+| B. 보조 | `POST /api/admin/kafka/reload-consumers` | 내부 운영용으로만 |
+| C. 실험용 | `LoadTestController` 전체 | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/raw` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/order-analysis/{id}` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `GET /api/admin/stats/order-violations/{id}` | 비노출 + @deprecated 표기 |
+| C. 실험용 | `AdminLogController` 전체 | 비노출 + @deprecated 표기 |
+| C. 실험용 | `POST /api/admin/test/participate-bulk` | 비노출 + @deprecated 표기 |
+| v2 잔재 | `POST /api/campaigns/{id}/participation-sync` | 제거 대상 |
+| 불필요 | `AdminViewController` | React SPA라면 제거 |
+
+> 이번 단계는 **삭제가 아니라 비노출 + @deprecated 표기**. 실제 미사용 확인 후 최종 삭제.
+
+#### 프론트 목표 구조
+
+```
+사용자 영역
+  /               랜딩 + 진행 중 캠페인 요약
+  /campaigns      캠페인 목록 + 참여 + 결과 확인
+
+관리자 영역
+  /admin/campaigns    캠페인 생성/조회/상태/재고
+  /admin/stats        일별 통계 + 캠페인별 통계
+  /admin/operations   배치 실행/이력 + DLQ 재처리 + 정합성 점검/복구
+  /admin/system       운영 링크 포털 (Grafana/CloudWatch/Kafka UI 링크)
+```
+
+제거 대상 라우트: `/admin/performance`, `/admin/load-test`, `/admin/monitoring`
+
+> Grafana/CloudWatch가 하는 모니터링을 프론트에서 재구현하지 않는다.
+> `/admin/system`은 직접 차트를 그리는 게 아니라 운영 링크 포털 역할만 수행.
+
+#### 단계별 실행
+
+```
+1단계. App.tsx/Layout.tsx 라우트 + 메뉴 재구성
+2단계. 실험용 페이지 라우트 제거 (파일은 유지)
+3단계. 실험용 API에 @deprecated 주석 추가
+4단계. StatsDashboard + CampaignDetailStats → /admin/stats 통합
+5단계. BatchManagement → /admin/operations 재구성 (시뮬레이션 제거)
+6단계. /admin/system 신설 (Grafana/CloudWatch/Kafka UI 링크 카드)
+```
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # 1Million Campaign Orchestration System — 아키텍처 문서
 
-> 작성일: 2026-04-27
-> v1(10만 트래픽) → v3 Redis-first(100만 트래픽 목표) 전체 설계 및 구현 정리
-> 현재 상태: Phase A(ASG) 완료, Phase B(100만 테스트) 진행 예정
+> 작성일: 2026-04-27  최종 업데이트: 2026-04-28
+> v1(10만 트래픽) → v3 Redis-first(100만 트래픽) 전체 설계 및 구현 정리
+> 현재 상태: Phase B(100만 테스트) 완료 ✅ — TPS ~2,442/s, 정합성 1,000,000건
 
 ---
 
@@ -81,8 +81,8 @@
     v
 [ParticipationEventConsumer — concurrency=10]
     |
-    |-- INSERT IGNORE INTO participation_history (멱등성 보장)
-    |-- Redis 결과 캐시 적재  participation:result:{userId}:{campaignId}
+    |-- jdbcTemplate.batchUpdate() INSERT IGNORE (배치, DB 왕복 N→1)
+    |-- (Redis 결과 캐시 제거 — CME pipeline 병목 원인이었음)
     |
     v
 [MySQL RDS — batch-kafka-db]
@@ -174,8 +174,9 @@ redis.call('LPUSH', KEYS[1], ARGV[2])
 return 1
 ```
 
-- MAX_QUEUE_SIZE = 100,000 (시스템 과부하 방지)
+- MAX_QUEUE_SIZE = 1,000,000 (100만 트래픽 기준, 데이터 유실 방지)
 - LLEN + LPUSH 원자적 실행으로 race condition 없음
+- Queue 상한 초과 시 push() false 반환 → DECR 이미 완료된 상태로 유실 위험 → 상한을 충분히 크게 유지
 
 ---
 
@@ -374,7 +375,7 @@ kafka:
 
 ## 7. ParticipationEventConsumer — DB 최종 기록
 
-v3에서 Consumer의 역할은 단순합니다: **Kafka 메시지를 받아 DB에 INSERT SUCCESS**
+v3에서 Consumer의 역할은 단순합니다: **Kafka 메시지를 받아 DB에 배치 INSERT SUCCESS**
 
 ```java
 @KafkaListener(
@@ -389,19 +390,22 @@ public void consumeParticipationEvent(
     // 1. 메시지 파싱 (sequence 없으면 DLQ)
     List<ParticipationEvent> events = parseRecords(records);
 
-    // 2. DB INSERT IGNORE (멱등성 — UNIQUE(campaign_id, user_id) 제약)
-    for (ParticipationEvent event : events) {
-        participationHistoryRepository.insertSuccess(
-                event.getCampaignId(), event.getUserId(), event.getSequence());
-        // DataIntegrityViolationException → 중복으로 무시 (at-least-once 보장)
-    }
+    // 2. 배치 INSERT IGNORE (DB 왕복 N→1, rewriteBatchedStatements=true)
+    List<Object[]> batchArgs = events.stream()
+        .map(e -> new Object[]{e.getCampaignId(), e.getUserId(), e.getSequence()})
+        .toList();
+    jdbcTemplate.batchUpdate(
+        "INSERT IGNORE INTO participation_history (campaign_id, user_id, sequence, status, created_at) VALUES (?, ?, ?, 'SUCCESS', NOW())",
+        batchArgs
+    );
+    // 배치 실패 시 단건 폴백 + DLQ
 
-    // 3. Redis 결과 캐시 적재 (파이프라인으로 배치 처리)
-    writeResultCache(successEvents);
-
-    // 4. Kafka 오프셋 수동 커밋 (처리 완료 후)
+    // 3. Kafka 오프셋 수동 커밋
     acknowledgment.acknowledge();
 }
+// Redis 결과 캐시(writeResultCache) 제거 — ElastiCache CME pipeline 병목 원인
+// 제거 전: Kafka lag 9K 누적, Consumer 지연 200ms+
+// 제거 후: lag 거의 0, Consumer 지연 7.5~15ms
 ```
 
 ### 멱등성 보장 메커니즘
@@ -648,6 +652,9 @@ SSH를 완전히 차단하고 SSM Session Manager로만 접속합니다. 민감 
 | 6차 | 파티션 3개 (userId 키) | 550/s | 3.12s | 거의 0 | ✅ |
 | 7차 | 3브로커 + 파티션 10개, 12만 | ~1,150/s | - | 거의 0 | ✅ |
 | 8차 | 3브로커 + 파티션 10개, 50만 | ~1,220/s | 2.81s | 거의 0 | ✅ |
+| 9차 | **ASG 2대**, 50만 | ~2,014/s | - | 거의 0 | ✅ |
+| 10차 | **writeResultCache 제거 + 배치 INSERT**, 100만 | ~2,613/s | 2.22s | 거의 0 | ❌ 574,888 (Queue 오버플로우) |
+| **11차** | **MAX_QUEUE_SIZE 1M**, 100만 | **~2,442/s** | **2.74s** | **거의 0** | **✅ 1,000,000** |
 
 ### 병목 분석 및 해결
 
@@ -899,15 +906,18 @@ ItemWriter:    LPUSH 재적재 → Bridge → Kafka → Consumer INSERT
 [완료] Kafka 3-broker KRaft 클러스터
 [완료] ElastiCache CME 3샤드
 [완료] 8차 테스트 (50만, TPS ~1,220/s, 정합성 완벽)
+[완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, min=2/max=3, CPU 60% Target Tracking)
+[완료] Phase B — 100만 트래픽 테스트 ✅
+              - 9차: ASG 2대, TPS ~2,014/s
+              - writeResultCache 제거 (CME pipeline 병목)
+              - Consumer jdbcTemplate.batchUpdate() + rewriteBatchedStatements=true
+              - MAX_QUEUE_SIZE 500K → 1M (데이터 유실 방지)
+              - terraform-mcp t3.large (k6 OOM 방지)
+              - 11차 최종: TPS ~2,442/s, 정합성 1,000,000 ✅
 
-[진행 중] Phase A — ASG Terraform 구성
-              codedeploy.tf + asg.tf + user-data-app.sh
-              기존 단일 EC2 제거 + Prometheus EC2 SD 전환
-
-[예정] Phase B — 9차 테스트 (100만, TPS ~2,400/s 기대)
 [예정] Phase C — API 엔드포인트 v3 기준 정리
 [예정] Phase D — Spring Batch 안전망 (재고 정합성 검증 + 유실 복구)
 [예정] Phase E — MCP 서버 (AI 자율 운영)
 ```
 
-**최종 목표**: 100만 트래픽 처리 + AI가 자율적으로 운영 판단하는 시스템
+**최종 목표**: 100만 트래픽 처리 ✅ + AI가 자율적으로 운영 판단하는 시스템

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ POST /api/campaigns/{id}/participation
      remaining < 0  → 보상 INCR + 400
      remaining == 0 → DB CLOSED + active flag DEL
   3. sequence = total - remaining (선착순 확정)
-  4. RedisQueueService    LPUSH queue:campaign:{id}  (MAX_QUEUE_SIZE=500K)
+  4. RedisQueueService    LPUSH queue:campaign:{id}  (MAX_QUEUE_SIZE=1M)
   5. 202 반환 (DB 미접촉)
 
 ParticipationBridge (@Scheduled 100ms)
@@ -45,7 +45,7 @@ ParticipationBridge (@Scheduled 100ms)
 Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
   → jdbcTemplate.batchUpdate() INSERT IGNORE 배치 처리 (멱등성)
   → 배치 실패 시 단건 폴백 + DLQ
-  → Redis 결과 캐시
+  (Redis 결과 캐시 제거 — CME pipeline 병목 원인이었음)
 ```
 
 ---
@@ -63,24 +63,21 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | 7차 | 3브로커+파티션 10개, 12만 | ~1,150/s | **앱 CPU 90%** |
 | 8차 | 3브로커+파티션 10개, 50만 | ~1,220/s | **앱 CPU 80%** |
 | 9차 | **ASG 2대**, 50만 | ~2,014/s | 앱 CPU 80% (인스턴스당) |
+| 10차 | **writeResultCache 제거 + 배치 INSERT**, 100만 | ~2,613/s | Queue 500K 상한 도달 → 데이터 유실 |
+| **11차** | **MAX_QUEUE_SIZE 1M**, 100만 | **~2,442/s** | **정합성 1,000,000 완벽 ✅** |
 
-### 9차 테스트 상세 (ASG 2대, 50만)
-- 조건: TOTAL_REQUESTS=600,000, 재고=500,000, MAX_VUS=2,000, DURATION=1,200s
-- TPS ~2,014/s (+65%) / avg 988ms (-39%) / 5xx: 0 ✅ / HikariCP pending 거의 0 ✅
-- Redis Queue 100K 상한 도달 → MAX_QUEUE_SIZE 500K로 상향 완료
-- **수평 확장 효과 확인: TPS 2배, avg 절반. 인스턴스당 CPU는 동일 수준 유지**
-
-### 100만 테스트 시도 (9차 이후, 미완료)
+### 11차 테스트 상세 (100만, 최종 성공) ✅
 - 조건: TOTAL_REQUESTS=1,200,000, 재고=1,000,000, MAX_VUS=2,000
-- 78만 근처에서 k6 응답시간 폭발 → 테스트 중단
-- **원인: Redis Queue 적체 (유입 속도 > Consumer 배출 속도)**
-  - Consumer가 Kafka 메시지를 1건씩 DB INSERT → Consumer 처리 병목
-  - Kafka lag 누적 → Bridge 배출 속도 제한 → Queue 500K 상한 도달 → 신규 요청 적재 실패
-  - RDS CPU는 41%로 여유 있었음 — DB 용량 문제 아닌 순수 패턴 문제
-- **조치 완료 (develop 브랜치, 머지 대기 중)**:
-  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1) ✅
-  - SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료 ✅
-  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체 ✅
+- TPS ~2,442/s / avg 816ms / p95 2.74s / 5xx: 0 ✅
+- DB COUNT = **1,000,000** (정합성 완벽) ✅
+- Redis Queue 최대 700K (1M 상한 여유 있음) ✅
+- Consumer 지연 7.5~15ms (배치 INSERT 효과) ✅
+- Kafka lag 거의 0 (rebalancing 순간 700 스파이크 → 즉시 해소) ✅
+- HikariCP pending 거의 0 ✅ / RDS CPU 최대 47% ✅
+
+### 10차 → 11차 개선 포인트
+- 10차: writeResultCache(CME pipeline) 제거 → Kafka lag 9K→거의 0, TPS 2,613/s 달성했으나 Queue 500K 상한으로 **데이터 425K 유실**
+- 11차: MAX_QUEUE_SIZE 1M으로 상향 → Queue 700K까지만 차서 유실 0건
 
 ---
 
@@ -99,23 +96,17 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 ---
 
-## 다음 작업 — Phase B: 100만 트래픽 테스트
+## 전체 로드맵
 
-**목표**: Consumer 배치 INSERT 적용 후 100만 트래픽 처리 검증.
-
-### 배포 전 필수 작업 (모두 완료 ✅)
-- SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료
-- develop 브랜치 배치 INSERT 코드 작성 완료
-- **남은 것: develop → main 머지 → CI/CD 자동 배포**
-
-### 전체 로드맵
 ```
 [완료] v3 Redis-first, Kafka 3-broker, ElastiCache CME, 8차 테스트 (50만 TPS ~1,220/s)
 [완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, EC2 SD, min=2 운영 중)
 [완료] 9차 테스트 (ASG 2대, 50만 TPS ~2,014/s)
-[진행] Phase B — develop→main 머지 후 10만 검증 → 100만 테스트
-       → 10만 검증: batch processed 로그에서 polled= 분포 확인
-       → 통과 시 100만 테스트
+[완료] Phase B — 100만 트래픽 테스트 성공 (11차, TPS ~2,442/s, 정합성 1,000,000 ✅)
+       - writeResultCache 제거 (CME pipeline 병목)
+       - Consumer jdbcTemplate.batchUpdate() 배치 INSERT
+       - MAX_QUEUE_SIZE 500K → 1M (데이터 유실 방지)
+       - terraform-mcp t3.large (k6 OOM 방지)
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
 [예정] Phase E — MCP 서버 (AI 자율 운영)
@@ -132,7 +123,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
 | ASG (앱) | batch-kafka-app-asg (t3.small, min=2/max=3, private_app_2a+2b) |
 | EC2 (Kafka) | kafka-1/2/3 (t3.small, public 2a/2b/2c) |
-| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana+redis-exporter 실행 중) |
+| EC2 (MCP) | terraform-mcp (t3.large, public_2a, Prometheus+Grafana+redis-exporter+kafka-exporter 실행 중) |
 | RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro) |
 | ALB | alb-batch-kafka-api → tg-api-8080 |
 | ElastiCache | CME 3샤드 (Valkey 7.2, cache.t3.micro × 6) |
@@ -201,16 +192,14 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 2. kafka-1/2/3 중지
 3. terraform-mcp 중지
 4. RDS 중지
+5. (장기 미사용 시) 로컬에서:
+   terraform destroy -target=aws_elasticache_replication_group.redis
+   terraform destroy -target=aws_ssm_parameter.redis_cluster_nodes
+   terraform destroy -target=aws_ssm_parameter.redis_exporter_addr
 ```
 
-### 비용 절감 (장기 미사용)
-```bash
-terraform destroy -target=aws_elasticache_replication_group.redis \
-  -target=aws_ssm_parameter.redis_cluster_nodes \
-  -target=aws_ssm_parameter.redis_exporter_addr
-```
-
-> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES, REDIS_EXPORTER_ADDR)은 자동 갱신됨
+> ASG 인스턴스는 콘솔에서 직접 중지 금지 → desired=0으로만
+> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES) 자동 갱신
 > ASG min/max는 ignore_changes로 보호 — terraform apply가 용량을 건드리지 않음
 
 ---
@@ -241,10 +230,14 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 
 ## 면접 핵심 멘트
 
-**프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트"
+**프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트. 최종적으로 100만 트래픽, 정합성 1,000,000건, 5xx 0건 달성"
 
-**CI/CD**: "OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, Blue-Green 무중단 배포"
+**CI/CD**: "OIDC 기반 키 없는 AWS 인증, SSH 차단 + SSM Session Manager, CodeDeploy OneAtATime 무중단 배포"
 
-**한계 인지**: "단일 인스턴스 CPU 한계 → ASG 수평 확장, 데이터로 근거 제시"
+**한계 인지**: "단일 인스턴스 CPU 한계 → ASG 수평 확장, 데이터로 근거 제시. TPS 1,220→2,014/s (+65%) 확인"
 
-**Consumer 병목 개선**: "Kafka batch listener로 받아도 DB INSERT가 1건씩이면 소용없다는 걸 로그로 확인 후, JdbcTemplate.batchUpdate + rewriteBatchedStatements=true로 DB 왕복 N→1로 줄임"
+**Consumer 병목 개선**: "Kafka batch listener로 받아도 DB INSERT가 1건씩이면 소용없다는 걸 로그로 확인 후, JdbcTemplate.batchUpdate + rewriteBatchedStatements=true로 DB 왕복 N→1로 줄임. Consumer 지연 200ms → 7.5ms"
+
+**데이터 유실 발견 및 해결**: "10차 테스트에서 DB 정합성 검증 중 574,888건만 INSERT된 것 발견. Redis Queue 500K 상한 초과 시 LPUSH 실패해도 202 반환하는 구조적 문제. MAX_QUEUE_SIZE 1M으로 상향해 11차에서 정합성 완벽 달성"
+
+**모니터링**: "Prometheus + Grafana 커스텀 메트릭 4종(Bridge 드레인 속도/사이클, Consumer 지연, Redis Queue 적재량). Docker monitoring 네트워크로 컨테이너 이름 기반 DNS — IP 관리 불필요"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 ```
 app/campaign-core/     ← Spring Boot 앱 (v3 Redis-first)
 infra/                 ← Terraform IaC
-mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase E, 미작성)
+mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase E, 구현 완료 — 배포 대기)
 stress-test/           ← k6 부하 테스트 스크립트
 .github/workflows/     ← deploy.yml
 ```
@@ -93,6 +93,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | #7 ASG 수평 확장 | ✅ 완료 (2026-04-27, ASG 2대 운영 중) |
 | Spring Batch PENDING 재처리 | 미작성 |
 | 모니터링 #22~#25 | ✅ 완료 (Grafana 13패널, 커스텀 메트릭 4종) |
+| Phase E MCP 서버 (#62~#66) | ✅ 코드 완료 — terraform-mcp 수동 배포 필요 |
 
 ---
 
@@ -109,7 +110,11 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
        - terraform-mcp t3.large (k6 OOM 방지)
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
-[예정] Phase E — MCP 서버 (AI 자율 운영)
+[진행중] Phase E — MCP 서버 (AI 자율 운영)
+       - 코드 완료 (feat/mcp-server 브랜치)
+       - terraform apply -target=aws_iam_role_policy.terraform_mcp_cloudwatch_read 필요
+       - terraform-mcp EC2에서 수동 docker build & run으로 배포
+       - CI/CD 파이프라인 미구성 (mcp-server/** 트리거 없음, 수동 배포)
 ```
 
 ---
@@ -137,7 +142,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 ## 모니터링 구성 (terraform-mcp)
 
-- Prometheus + Grafana + redis-exporter + kafka-exporter 모두 Docker 컨테이너
+- Prometheus + Grafana + redis-exporter + kafka-exporter + **mcp-server** 모두 Docker 컨테이너
 - **Docker monitoring 네트워크**: 컨테이너 이름 기반 통신 (IP 변경 무관)
   ```bash
   # 컨테이너 재생성 시 네트워크 연결 필수
@@ -183,7 +188,8 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 1. RDS 시작
 2. kafka-1/2/3 시작
 3. terraform-mcp 시작 (--restart unless-stopped로 컨테이너 자동 복구)
-4. ASG 콘솔에서 desired=2, min=2, max=3
+4. mcp-server 컨테이너 확인: `sudo docker ps | grep mcp-server` (미실행 시 아래 mcp-server 배포 섹션 참고)
+5. ASG 콘솔에서 desired=2, min=2, max=3
 ```
 
 ### 끌 때
@@ -228,6 +234,42 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 
 ---
 
+## mcp-server 배포 (terraform-mcp에서 수동)
+
+```bash
+# 최초 배포 또는 코드 업데이트 시
+cd ~/1milion-campaign-orchestration-system
+git pull
+
+sudo docker build -t mcp-server:latest ./mcp-server
+
+sudo docker run -d \
+  --name mcp-server \
+  --restart unless-stopped \
+  --network monitoring \
+  -p 8000:8000 \
+  -e SLACK_WEBHOOK_URL="$(aws ssm get-parameter --name /batch-kafka/prod/SLACK_WEBHOOK_URL \
+    --with-decryption --query Parameter.Value --output text)" \
+  -e BATCH_API_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com" \
+  -e BATCH_CAMPAIGN_ID="<캠페인ID>" \
+  mcp-server:latest
+
+# 검증
+curl http://localhost:8000/health
+sudo docker logs mcp-server --follow
+```
+
+MCP 도구 7개 (Claude에서 호출 가능):
+- `get_monitor_status` — cooldown 상태 조회
+- `run_check` — P1/P2/P3 수동 실행
+- `query_prometheus` — PromQL instant 쿼리
+- `query_prometheus_range` — 구간 메트릭 조회 (테스트 후 분석용)
+- `get_test_report` — 테스트 구간 핵심 메트릭 요약
+- `reset_cooldown` — 쿨다운 초기화
+- `trigger_consistency_check` — 정합성 검사 즉시 실행
+
+---
+
 ## 면접 핵심 멘트
 
 **프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트. 최종적으로 100만 트래픽, 정합성 1,000,000건, 5xx 0건 달성"
@@ -241,3 +283,5 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 **데이터 유실 발견 및 해결**: "10차 테스트에서 DB 정합성 검증 중 574,888건만 INSERT된 것 발견. Redis Queue 500K 상한 초과 시 LPUSH 실패해도 202 반환하는 구조적 문제. MAX_QUEUE_SIZE 1M으로 상향해 11차에서 정합성 완벽 달성"
 
 **모니터링**: "Prometheus + Grafana 커스텀 메트릭 4종(Bridge 드레인 속도/사이클, Consumer 지연, Redis Queue 적재량). Docker monitoring 네트워크로 컨테이너 이름 기반 DNS — IP 관리 불필요"
+
+**MCP 서버 (Phase E)**: "Grafana 대시보드를 사람이 직접 보던 수동 감시를 자동화. Prometheus/CloudWatch 30초 폴링 → P1/P2/P3 임계값 비교 → Slack 알림. Claude MCP 도구 7개로 운영 중 즉시 쿼리 가능. AI는 탐지와 설명만, 실행은 사람이 판단하는 구조로 설계"

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -113,10 +113,6 @@ public class ParticipationEventConsumer {
         log.info("batch processed. polled={}, parsed={}, success={}, latency_ms={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        // ④ 결과 캐시 적재 (DB 커밋 후)
-        if (!successEvents.isEmpty()) {
-            writeResultCache(successEvents);
-        }
 
         // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
@@ -15,7 +15,7 @@ public class RedisQueueService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final long MAX_QUEUE_SIZE = 500_000;
+    private static final long MAX_QUEUE_SIZE = 1_000_000;
     private final DefaultRedisScript<Long> pushQueueScript;
 
 

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -4,7 +4,7 @@
 resource "aws_launch_template" "app" {
   name          = "batch-kafka-app-lt"
   image_id      = "ami-01c64e7a84a57e681"  # batch-kafka-app-ami (Docker + CodeDeploy 포함)
-  instance_type = "t3.large"
+  instance_type = "t3.small"
 
   iam_instance_profile {
     name = aws_iam_instance_profile.batch_kafka_app.name

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -4,7 +4,7 @@
 resource "aws_launch_template" "app" {
   name          = "batch-kafka-app-lt"
   image_id      = "ami-01c64e7a84a57e681"  # batch-kafka-app-ami (Docker + CodeDeploy 포함)
-  instance_type = "t3.small"
+  instance_type = "t3.large"
 
   iam_instance_profile {
     name = aws_iam_instance_profile.batch_kafka_app.name

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -239,7 +239,7 @@ resource "aws_instance" "kafka_3" {
 # terraform-mcp EC2 인스턴스
 resource "aws_instance" "terraform_mcp" {
   ami                    = "ami-0ecfdfd1c8ae01aec" # Amazon Linux 2023 ap-northeast-2 (2026-03-27)
-  instance_type          = "t3.small"
+  instance_type          = "t3.large"
   subnet_id              = aws_subnet.public_2a.id
   vpc_security_group_ids = [aws_security_group.terraform_mcp.id]
   iam_instance_profile   = aws_iam_instance_profile.terraform_mcp.name

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -37,6 +37,24 @@ resource "aws_iam_role_policy" "terraform_mcp_ec2_describe" {
   })
 }
 
+# MCP 모니터링 서버용 — CloudWatch 읽기 (ASG CPU, RDS CPU)
+resource "aws_iam_role_policy" "terraform_mcp_cloudwatch_read" {
+  name = "CloudWatchRead-for-mcp"
+  role = aws_iam_role.terraform_mcp.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
 # terraform-mcp 보안 그룹
 resource "aws_security_group" "terraform_mcp" {
   name        = "terraform-mcp-sg"

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+CMD ["python", "main.py"]

--- a/mcp-server/MCP_SERVER.md
+++ b/mcp-server/MCP_SERVER.md
@@ -1,0 +1,606 @@
+# MCP Monitor Server — 상세 설명서
+
+## 목차
+
+1. [이게 뭔가 / 왜 만들었나](#1-이게-뭔가--왜-만들었나)
+2. [전체 파일 구조](#2-전체-파일-구조)
+3. [파일별 상세 설명](#3-파일별-상세-설명)
+4. [전체 동작 메커니즘](#4-전체-동작-메커니즘)
+5. [인프라 적용 방법](#5-인프라-적용-방법)
+6. [Claude (AI) 연동](#6-claude-ai-연동)
+7. [생각보다 금방 끝난 이유](#7-생각보다-금방-끝난-이유)
+
+---
+
+## 1. 이게 뭔가 / 왜 만들었나
+
+### 한 줄 요약
+
+> Prometheus / CloudWatch를 30초마다 폴링해서 이상 감지하면 Slack으로 알림 보내는 AI 운영 서버.
+> Claude가 도구를 직접 호출해서 운영 상황을 묻고 분석할 수 있게 MCP 프로토콜로 도구를 노출한다.
+
+### 배경
+
+100만 트래픽 캠페인 시스템(Phase B)을 구축했는데, 운영하면서 사람이 Grafana를 24시간 보고 있을 수는 없다.
+Phase E 목표: **AI가 이상을 탐지하고 설명한다. 실행(인프라 변경)은 사람이 한다.**
+
+AWS 쓰기 권한 없음 — 읽기 전용으로만 동작한다.
+
+### 감지 범위
+
+| 우선순위 | 항목 | 임계값 |
+|----------|------|--------|
+| P1 (즉시 대응) | 5xx 에러 발생 | 1건 이상 |
+| P1 | Redis Queue CRITICAL | 850,000건 (85%) |
+| P1 | 데이터 정합성 불일치 | Redis ≠ DB |
+| P2 (성능 경고) | 앱 CPU CRITICAL | 90% |
+| P2 | 앱 CPU WARNING | 80% |
+| P2 | Kafka consumer lag CRITICAL | 1,000 |
+| P2 | Kafka consumer lag WARNING | 500 |
+| P2 | Consumer 처리 지연 CRITICAL | 200ms |
+| P2 | Consumer 처리 지연 WARNING | 50ms |
+| P2 | HikariCP 커넥션 대기 | 1개 이상 |
+| P3 (인프라 모니터링) | RDS CPU WARNING | 60% |
+| P3 | Bridge 드레인 사이클 지연 | 60초 초과 |
+
+---
+
+## 2. 전체 파일 구조
+
+```
+mcp-server/
+├── main.py                # FastAPI 앱 진입점 + APScheduler 등록 + MCP 마운트
+├── monitor.py             # 폴링 루프 — 각 detector 호출 조율
+├── config.py              # 임계값 + 환경변수 단일 관리 포인트
+├── state.py               # 중복 알림 방지 cooldown 관리 (인메모리)
+├── slack.py               # Slack Webhook 전송 + 메시지 포맷
+├── tools.py               # MCP 도구 5개 노출 (Claude용)
+├── requirements.txt       # Python 의존성
+├── Dockerfile
+└── detectors/
+    ├── __init__.py
+    ├── p1_detector.py     # 5xx 에러 / Redis Queue / 데이터 정합성
+    ├── p2_detector.py     # 앱 CPU / Kafka lag / Consumer 지연 / HikariCP
+    └── p3_detector.py     # RDS CPU / Bridge 드레인 사이클
+```
+
+---
+
+## 3. 파일별 상세 설명
+
+---
+
+### `config.py` — 설정 단일 관리 포인트
+
+모든 임계값과 환경변수를 **이 파일에서만** 관리한다.
+detector 파일들이 각자 숫자를 하드코딩하지 않고 `import config` 하나로 참조한다.
+임계값을 바꾸고 싶으면 이 파일만 수정하면 된다.
+
+```python
+SLACK_WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]  # 필수 — 없으면 기동 즉시 에러
+PROMETHEUS_URL    = os.environ.get("PROMETHEUS_URL", "http://prometheus:9090")
+AWS_REGION        = os.environ.get("AWS_REGION", "ap-northeast-2")
+ASG_NAME          = os.environ.get("ASG_NAME", "batch-kafka-app-asg")
+RDS_ID            = os.environ.get("RDS_ID", "batch-kafka-db")
+BATCH_API_URL     = os.environ.get("BATCH_API_URL", "http://alb-...")
+BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
+```
+
+`SLACK_WEBHOOK_URL`만 필수값.
+나머지는 기본값이 있어서 환경변수 주입 없이도 로컬 테스트 가능.
+
+---
+
+### `state.py` — 중복 알림 방지
+
+30초마다 폴링하는데 CPU가 10분 동안 90%면 Slack 알림이 20번 울린다.
+이걸 막는 역할. 쿨다운(기본 5분) 동안은 같은 알림을 보내지 않는다.
+
+```python
+_alert_state: dict[str, float] = {}  # {"cpu_critical": 1714900000.0}
+
+can_alert(key, cooldown)   # 쿨다운이 지났으면 True → 알림 보내도 됨
+record_alert(key)          # 알림 보낸 시각 기록 → 쿨다운 시작
+reset_alert(key)           # 이상 상태 해소 시 상태 삭제 → 다음 이상 시 즉시 알림
+```
+
+**쿨다운 동작 흐름**
+
+```
+이상 감지 → can_alert() True → 알림 발송 → record_alert() → 5분 쿨다운 시작
+30초 후   → can_alert() False (4분 30초 남음) → 스킵
+5분 후    → can_alert() True → 다시 알림
+이상 해소 → reset_alert() → 상태 초기화 → 다음 이상 시 즉시 알림 가능
+```
+
+인메모리 dict라서 컨테이너 재시작 시 초기화된다.
+이건 의도적 설계 — 재시작 후 이전 상태 오염 없이 깨끗하게 시작.
+
+---
+
+### `slack.py` — Slack 메시지 전송
+
+모든 detector가 공통으로 쓰는 Slack 전송 창구.
+`send_alert(level, title, body)` 하나만 노출.
+
+```python
+LEVEL_EMOJI = {
+    "P1": ":red_circle:",          # 🔴
+    "P2": ":large_yellow_circle:", # 🟡
+    "P3": ":large_blue_circle:",   # 🔵
+    "OK": ":white_check_mark:",    # ✅
+}
+```
+
+실제 Slack에 오는 메시지 예시:
+```
+🔴 *[P1] Redis Queue CRITICAL*
+Queue 적재량 870,000 (임계값 850,000 / 85%)
+데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박
+```
+
+`try/except`로 전송 실패를 삼킨다.
+Slack이 다운돼도 모니터링 서버가 죽으면 안 되기 때문.
+
+---
+
+### `monitor.py` — 폴링 루프 조율자
+
+`main.py`에서 스케줄러가 직접 부르는 함수 2개를 제공한다.
+
+```python
+def run_monitor() -> None:          # 30초마다
+    for check in [check_p1, check_p2, check_p3]:
+        try:
+            check()
+        except Exception as e:
+            logger.error(...)       # 에러 로그만, 다음 detector는 계속 실행
+
+def run_consistency_check() -> None:  # 1시간마다
+    check_consistency()
+```
+
+**핵심 설계**: 각 detector를 개별 `try/except`로 감쌈.
+p1이 Prometheus 연결 실패로 터져도 p2, p3는 정상 실행된다.
+
+---
+
+### `detectors/p1_detector.py` — P1 (가장 심각)
+
+#### 5xx 에러 감지
+
+```python
+promql = 'sum(increase(http_server_requests_seconds_count{status=~"5.."}[30s]))'
+```
+
+`increase(...[30s])`는 Prometheus가 **최근 30초 증가량을 직접 계산해서 반환**한다.
+별도 delta 계산 없이 이 값 자체를 사용.
+1건이라도 발생하면 P1 알림 (`HTTP_5XX_THRESHOLD=0`).
+
+#### Redis Queue 적재량 감지
+
+```python
+promql = "campaign_redis_queue_size"
+```
+
+2단계 임계값:
+- `>= 700,000` (70%) → P2 WARNING "Consumer 확인 권장"
+- `>= 850,000` (85%) → P1 CRITICAL "데이터 유실 위험"
+
+CRITICAL 발생 시 WARNING 쿨다운은 리셋 — CRITICAL 알림이 오면 WARNING 중복 방지.
+
+#### 데이터 정합성 검사 (1시간 주기)
+
+```python
+GET /api/admin/campaigns/{id}/consistency
+→ {"redisCount": 1000000, "dbCount": 1000000}
+```
+
+Redis 확정 건수 vs DB INSERT 건수 비교.
+차이 > 0 이면 P1 (유실 또는 중복 의심).
+일치하면 OK 알림 (1시간마다 "정상 확인" 메시지).
+
+`BATCH_CAMPAIGN_ID=0`이면 검사 스킵 — 환경변수 미설정 안전 처리.
+
+---
+
+### `detectors/p2_detector.py` — P2 (성능 경고)
+
+#### 앱 CPU (CloudWatch)
+
+Prometheus가 아닌 **CloudWatch** 사용 이유:
+Prometheus는 앱 자체 JVM 메트릭만 노출한다.
+EC2 인스턴스 레벨 CPU는 CloudWatch ASG 디멘션으로 조회해야 정확하다.
+
+```python
+Namespace="AWS/EC2"
+Dimensions=[{"Name": "AutoScalingGroupName", "Value": "batch-kafka-app-asg"}]
+Statistics=["Average"]
+```
+
+최근 2분 데이터포인트 중 **최고값** 기준 (최근 1분이 CloudWatch 집계 지연으로 비어있을 수 있음).
+
+#### Kafka lag
+
+```python
+promql = "sum(kafka_consumergroup_lag_sum)"
+```
+
+파티션 10개 × Consumer group 전체 합산.
+11차 테스트 때 rebalancing 순간 700 스파이크 경험 → WARNING=500, CRITICAL=1,000으로 설정.
+
+#### Consumer 처리 지연
+
+```python
+promql = "campaign_consumer_latency_ms"
+```
+
+11차 테스트 정상 범위: 7.5~15ms.
+50ms부터 이상 신호, 200ms는 DB 병목 또는 rebalancing 의심.
+
+#### HikariCP pending
+
+```python
+promql = "max(hikaricp_pending_threads)"
+```
+
+`avg()`가 아닌 `max()` — ASG 2대 중 **한 대라도** pending 있으면 알림.
+avg()면 한 대가 100이어도 다른 한 대 0이면 50으로 희석된다.
+
+---
+
+### `detectors/p3_detector.py` — P3 (인프라 모니터링)
+
+#### RDS CPU (CloudWatch)
+
+```python
+Namespace="AWS/RDS"
+Dimensions=[{"Name": "DBInstanceIdentifier", "Value": "batch-kafka-db"}]
+```
+
+11차 테스트 최대치 47% → **60%부터 이상**으로 판단.
+알림 메시지에 "11차 테스트 최대치 47%" 기준을 명시 — 운영자가 맥락 없이도 판단 가능.
+
+#### Bridge 드레인 사이클
+
+```python
+promql = "campaign_bridge_cycle_seconds"
+```
+
+`ParticipationBridge`는 `@Scheduled(fixedDelay=100ms)`.
+정상이면 사이클이 수백ms 이내.
+60초 초과 → Bridge가 멈췄거나 Kafka 연결 문제로 블로킹된 것.
+알림에 Redis Queue 적재량 연계 확인 힌트 포함.
+
+---
+
+### `tools.py` — MCP 도구 5개
+
+Claude가 SSE로 연결해서 직접 호출할 수 있는 도구들.
+**이 파일이 "MCP 서버"의 핵심 — Claude가 운영 상황을 직접 물어볼 수 있는 인터페이스.**
+
+| 도구 | 하는 일 | 예시 사용 상황 |
+|------|---------|--------------|
+| `get_monitor_status` | 현재 cooldown 상태 조회 | "지금 어떤 알림이 쿨다운 중이야?" |
+| `run_check` | p1/p2/p3/all 수동 즉시 실행 | "지금 당장 P1 검사 돌려봐" |
+| `query_prometheus` | PromQL 현재 값 조회 | "Redis Queue 지금 몇 건이야?" |
+| `query_prometheus_range` | 특정 구간 메트릭 시계열 조회 | "40분 전~20분 전 Kafka lag 봐줘" |
+| `get_test_report` | 테스트 구간 전체 핵심 메트릭 요약 | "방금 끝난 테스트 어디서 문제였어?" |
+| `reset_cooldown` | 특정 alert 쿨다운 리셋 | "cpu_critical 쿨다운 풀어줘" |
+| `trigger_consistency_check` | 정합성 검사 즉시 트리거 | "지금 정합성 검사 돌려봐" |
+
+MCP 엔드포인트: `GET /mcp/sse` (Claude 연결점)
+
+---
+
+### `main.py` — 진입점
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler.add_job(run_monitor, "interval", seconds=30, id="monitor")
+    scheduler.add_job(run_consistency_check, "interval", hours=1, id="consistency")
+    scheduler.start()
+    send_alert("OK", "모니터링 시작", "MCP 모니터링 서버가 정상 기동되었습니다.")
+    yield                          # ← 여기서 앱 실행 중
+    scheduler.shutdown(wait=False) # ← 종료 시 실행
+
+app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan)
+```
+
+FastAPI가 HTTP 서버 역할, APScheduler가 백그라운드 스케줄러 역할.
+둘이 같은 프로세스 안에서 동작.
+`@app.on_event`는 FastAPI 0.93+에서 deprecated — `lifespan` 컨텍스트 매니저 패턴 사용.
+
+`GET /health` → `{"status": "ok"}` — Docker HEALTHCHECK용.
+
+---
+
+### `Dockerfile`
+
+```dockerfile
+FROM python:3.11-slim          # 가벼운 베이스 이미지
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt   # 의존성 레이어 캐싱
+COPY . .
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+CMD ["python", "main.py"]
+```
+
+HEALTHCHECK가 `/health`를 30초마다 찌름. 3번 실패 시 컨테이너 `unhealthy` 상태 표시.
+`python:3.11-slim`에는 curl이 없어서 표준 라이브러리 `urllib.request`로 대체.
+
+---
+
+## 4. 전체 동작 메커니즘
+
+```
+docker run 실행
+        │
+        ▼
+    main.py 기동
+        │
+        ├── FastAPI 앱 시작 (port 8000)
+        │       ├── GET /health       ← Docker HEALTHCHECK
+        │       └── GET /mcp/sse      ← Claude 연결 진입점
+        │
+        ├── APScheduler 시작
+        │       │
+        │       ├── [30초마다] run_monitor()
+        │       │       │
+        │       │       ├── check_p1()
+        │       │       │     ├── Prometheus 쿼리 (5xx 건수)
+        │       │       │     └── Prometheus 쿼리 (Redis Queue 크기)
+        │       │       │
+        │       │       ├── check_p2()
+        │       │       │     ├── CloudWatch 조회 (ASG CPU)
+        │       │       │     ├── Prometheus 쿼리 (Kafka lag)
+        │       │       │     ├── Prometheus 쿼리 (Consumer 지연)
+        │       │       │     └── Prometheus 쿼리 (HikariCP pending)
+        │       │       │
+        │       │       └── check_p3()
+        │       │             ├── CloudWatch 조회 (RDS CPU)
+        │       │             └── Prometheus 쿼리 (Bridge 사이클)
+        │       │
+        │       └── [1시간마다] run_consistency_check()
+        │               └── GET /api/admin/campaigns/{id}/consistency
+        │
+        └── Slack "모니터링 시작" 전송
+```
+
+**이상 감지 시 상세 흐름 예시 (CPU)**
+
+```
+[T+0s]   check_p2() 실행
+         → CloudWatch: ASG CPU = 91%
+         → 91% >= CPU_CRITICAL_PERCENT(90%) 조건 충족
+         → can_alert("cpu_critical") == True  ← 쿨다운 없음
+         → send_alert("P2", "앱 CPU CRITICAL", "ASG CPU 91%...")
+         → record_alert("cpu_critical")  ← 5분 쿨다운 시작
+         → Slack에 🟡 [P2] 메시지 수신
+
+[T+30s]  check_p2() 실행
+         → CloudWatch: ASG CPU = 93%
+         → can_alert("cpu_critical") == False  ← 쿨다운 중 (4분 30초 남음)
+         → 스킵 (Slack 발송 없음)
+
+[T+300s] check_p2() 실행
+         → CloudWatch: ASG CPU = 88%
+         → 88% < CPU_CRITICAL_PERCENT(90%)
+         → 88% >= CPU_WARNING_PERCENT(80%)
+         → can_alert("cpu_warning") == True
+         → send_alert("P2", "앱 CPU WARNING", "ASG CPU 88%...")
+         → record_alert("cpu_warning")
+         → reset_alert("cpu_critical")  ← CRITICAL 상태 초기화
+
+[T+600s] check_p2() 실행
+         → CloudWatch: ASG CPU = 72%
+         → 72% < CPU_WARNING_PERCENT(80%)
+         → reset_alert("cpu_critical"), reset_alert("cpu_warning")
+         → 정상 (Slack 발송 없음)
+```
+
+---
+
+## 5. 인프라 적용 방법
+
+### 실행 환경
+
+`terraform-mcp` EC2 인스턴스에서 Docker 컨테이너로 실행.
+기존 `monitoring` Docker 네트워크에 합류 — Prometheus, redis-exporter와 컨테이너 이름 기반 통신.
+
+```
+monitoring 네트워크
+├── prometheus       ← mcp-monitor가 http://prometheus:9090 으로 접근
+├── redis-exporter
+├── kafka-exporter
+└── mcp-monitor      ← 신규 추가
+```
+
+### 빌드 및 실행
+
+```bash
+# terraform-mcp EC2에서 실행
+
+# 1. 레포 클론 (또는 pull)
+cd ~/1milion-campaign-orchestration-system
+
+# 2. 이미지 빌드
+sudo docker build -t mcp-monitor ./mcp-server
+
+# 3. 컨테이너 실행
+sudo docker run -d \
+  --name mcp-monitor \
+  --restart unless-stopped \
+  --network monitoring \
+  -p 8000:8000 \
+  -e SLACK_WEBHOOK_URL="https://hooks.slack.com/services/xxx/yyy/zzz" \
+  -e PROMETHEUS_URL="http://prometheus:9090" \
+  -e AWS_REGION="ap-northeast-2" \
+  -e ASG_NAME="batch-kafka-app-asg" \
+  -e RDS_ID="batch-kafka-db" \
+  -e BATCH_API_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com" \
+  -e BATCH_CAMPAIGN_ID="1" \
+  mcp-monitor
+
+# 4. monitoring 네트워크 연결 (run 시 --network로 이미 연결됨, 확인용)
+sudo docker network inspect monitoring | grep mcp-monitor
+
+# 5. 기동 확인
+curl http://localhost:8000/health
+# → {"status": "ok"}
+
+# 6. 로그 확인
+sudo docker logs mcp-monitor --follow
+```
+
+### AWS IAM 권한 설정
+
+CloudWatch 조회(ASG CPU, RDS CPU)를 위해 `terraform-mcp` EC2 인스턴스 역할에 아래 권한 필요:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "cloudwatch:GetMetricStatistics",
+    "cloudwatch:ListMetrics"
+  ],
+  "Resource": "*"
+}
+```
+
+boto3는 EC2 인스턴스 역할(Instance Profile)에서 자동으로 자격증명을 가져온다.
+별도 AWS_ACCESS_KEY 주입 불필요.
+
+### 컨테이너 재시작 후 복구
+
+`--restart unless-stopped` 옵션으로 EC2 재시작 시 자동 복구됨.
+단, monitoring 네트워크는 별도로 재연결 필요 없음 — run 시 `--network monitoring` 지정으로 고정.
+
+### Slack Incoming Webhook 발급
+
+1. Slack 워크스페이스 → Apps → Incoming Webhooks
+2. 채널 선택 → Webhook URL 복사
+3. `SLACK_WEBHOOK_URL` 환경변수에 주입
+
+---
+
+## 6. Claude (AI) 연동
+
+### MCP가 뭔가
+
+**MCP (Model Context Protocol)** — Anthropic이 만든 AI 도구 연동 표준 프로토콜.
+쉽게 말하면: Claude가 외부 시스템의 도구를 직접 호출할 수 있게 해주는 규격.
+
+이 서버에서 `tools.py`가 MCP 서버 역할을 한다.
+Claude가 `/mcp/sse`로 SSE 연결하면 어떤 도구가 있는지 목록을 받고, 도구를 직접 호출한다.
+
+### 어떤 AI가 쓰이는가
+
+**Claude** (Anthropic).
+Claude Desktop 또는 Claude Code가 이 MCP 서버에 연결해서 운영 도구를 사용한다.
+
+### 연결 방법 — Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS 기준):
+
+```json
+{
+  "mcpServers": {
+    "campaign-monitor": {
+      "url": "http://<terraform-mcp-public-ip>:8000/mcp/sse"
+    }
+  }
+}
+```
+
+Claude Desktop을 재시작하면 좌측 도구 목록에 `campaign-monitor`가 뜬다.
+
+### 실제 사용 시나리오
+
+Claude Desktop에서 대화:
+
+```
+사용자: 지금 Redis Queue 상태 어때?
+
+Claude: query_prometheus 도구를 사용해서 확인할게요.
+        [도구 호출: query_prometheus("campaign_redis_queue_size")]
+        → 현재 342,000건입니다. 임계값(700,000)의 34% 수준으로 정상입니다.
+
+사용자: Kafka lag은?
+
+Claude: [도구 호출: query_prometheus("sum(kafka_consumergroup_lag_sum)")]
+        → 현재 lag은 12입니다. 정상 범위입니다 (CRITICAL 임계값: 1,000).
+
+사용자: 아까 cpu_critical 알림 왔는데 지금은 어때?
+
+Claude: [도구 호출: get_monitor_status()]
+        → cpu_critical: 마지막 알림 240초 전, 쿨다운 잔여 60초
+        [도구 호출: query_prometheus("(ASG CPU PromQL)")]
+        → 현재 CPU 추이도 함께 설명...
+```
+
+### AI의 역할 범위
+
+| 할 수 있는 것 | 할 수 없는 것 |
+|--------------|--------------|
+| 메트릭 조회 및 분석 | 인스턴스 재시작 |
+| 이상 원인 설명 | ASG 스케일 조정 |
+| 수동 감지 트리거 | 코드 배포 |
+| 정합성 검사 실행 | DB 데이터 수정 |
+| 쿨다운 리셋 | 인프라 변경 |
+
+**설계 원칙: AI는 탐지와 설명만, 실행은 사람이 한다.**
+
+---
+
+## 7. 생각보다 금방 끝난 이유
+
+맞다. 상대적으로 빠르게 완성됐다. 이유가 있다.
+
+### 1단계 설계를 미리 잘 잡았다
+
+뼈대를 먼저 잡았기 때문에 2~5단계는 **패턴을 채워넣는 작업**이었다.
+모든 detector가 구조적으로 동일하다:
+
+```
+메트릭 조회 (Prometheus or CloudWatch)
+    → 임계값 비교
+    → can_alert() 확인
+    → send_alert()
+    → record_alert()
+```
+
+p1 작성하고 나면 p2, p3는 쿼리와 임계값만 바꾸면 됐다.
+
+### 실제 복잡도가 낮은 구간
+
+- `state.py`: dict 3개 함수, 10줄
+- `slack.py`: HTTP POST 하나, 25줄
+- `monitor.py`: for loop + try/except, 20줄
+- `tools.py`: 도구 정의 + 핸들러, 실제 로직은 기존 함수 호출뿐
+
+### 복잡도가 숨어있는 곳
+
+이 서버 자체보다 **연동하는 시스템이 이미 완성돼 있었다**:
+
+- Prometheus에 커스텀 메트릭 4종이 이미 수집 중 (Phase B에서 구축)
+- CloudWatch에 ASG/RDS 메트릭이 자동 수집 중
+- Slack Webhook은 기존 규격 그대로 사용
+- MCP 프로토콜은 라이브러리가 핵심 처리를 담당
+
+이 서버는 기존 인프라를 **연결하는 레이어**다.
+핵심 복잡도(부하 분산, Kafka 파티셔닝, Redis 원자 처리)는 이미 Phase A/B에서 해결됐다.
+
+### 남은 복잡도
+
+실제로 EC2에 올려서 돌리면 생길 이슈들:
+
+- Prometheus 메트릭 이름이 실제와 다를 경우 쿼리 조정
+- CloudWatch API 레이트리밋 (30초마다 폴링 × 2개 메트릭)
+- `check_consistency` API가 Spring Boot에 아직 구현 안 됐을 가능성
+- MCP SSE 연결 안정성 (네트워크 끊김 시 재연결)
+
+이런 부분은 실제 배포 후 로그 보면서 조정한다.

--- a/mcp-server/config.py
+++ b/mcp-server/config.py
@@ -12,7 +12,7 @@ BATCH_API_URL     = os.environ.get(
 BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
 
 # P1
-HTTP_5XX_THRESHOLD           = 0
+HTTP_5XX_THRESHOLD           = 1
 REDIS_QUEUE_WARNING          = 700_000   # 70%
 REDIS_QUEUE_CRITICAL         = 850_000   # 85%
 

--- a/mcp-server/config.py
+++ b/mcp-server/config.py
@@ -1,0 +1,33 @@
+import os
+
+SLACK_WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+PROMETHEUS_URL    = os.environ.get("PROMETHEUS_URL", "http://prometheus:9090")
+AWS_REGION        = os.environ.get("AWS_REGION", "ap-northeast-2")
+ASG_NAME          = os.environ.get("ASG_NAME", "batch-kafka-app-asg")
+RDS_ID            = os.environ.get("RDS_ID", "batch-kafka-db")
+BATCH_API_URL     = os.environ.get(
+    "BATCH_API_URL",
+    "http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com",
+)
+BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
+
+# P1
+HTTP_5XX_THRESHOLD           = 0
+REDIS_QUEUE_WARNING          = 700_000   # 70%
+REDIS_QUEUE_CRITICAL         = 850_000   # 85%
+
+# P2
+CPU_WARNING_PERCENT          = 80.0
+CPU_CRITICAL_PERCENT         = 90.0
+KAFKA_LAG_WARNING            = 500
+KAFKA_LAG_CRITICAL           = 1_000
+CONSUMER_LATENCY_WARNING_MS  = 50
+CONSUMER_LATENCY_CRITICAL_MS = 200
+HIKARI_PENDING_THRESHOLD     = 1
+
+# P3
+RDS_CPU_WARNING_PERCENT      = 60.0
+BRIDGE_CYCLE_WARNING_SECONDS = 60
+
+# Cooldown
+COOLDOWN_SECONDS = 300  # 5분

--- a/mcp-server/detectors/p1_detector.py
+++ b/mcp-server/detectors/p1_detector.py
@@ -5,7 +5,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -45,14 +45,13 @@ def _check_5xx() -> None:
 
     if delta > config.HTTP_5XX_THRESHOLD:
         key = "5xx_error"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "5xx 에러 발생",
                 f"최근 30초간 5xx 에러 *{delta:.0f}건* 감지\n"
                 f"Prometheus: `{promql}`",
             )
-            record_alert(key)
             logger.warning("P1 5xx=%.0f", delta)
     else:
         reset_alert("5xx_error")
@@ -72,27 +71,25 @@ def _check_redis_queue() -> None:
 
     if queue_size >= config.REDIS_QUEUE_CRITICAL:
         key = "redis_queue_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "Redis Queue CRITICAL",
                 f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_CRITICAL:,} / 85%)\n"
                 f"데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박",
             )
-            record_alert(key)
             logger.warning("P1 redis_queue CRITICAL size=%d", queue_size)
         reset_alert("redis_queue_warning")
 
     elif queue_size >= config.REDIS_QUEUE_WARNING:
         key = "redis_queue_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Redis Queue WARNING",
                 f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_WARNING:,} / 70%)\n"
                 f"Consumer 처리 속도 확인 권장",
             )
-            record_alert(key)
             logger.warning("P1 redis_queue WARNING size=%d", queue_size)
 
     else:
@@ -127,7 +124,7 @@ def check_consistency() -> None:
 
     if diff > 0:
         key = "consistency_mismatch"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "데이터 정합성 불일치",
@@ -135,7 +132,6 @@ def check_consistency() -> None:
                 f"DB INSERT 건수: *{db_count:,}*\n"
                 f"차이: *{diff:,}건* — 유실 또는 중복 가능성",
             )
-            record_alert(key)
     else:
         reset_alert("consistency_mismatch")
         send_alert(

--- a/mcp-server/detectors/p1_detector.py
+++ b/mcp-server/detectors/p1_detector.py
@@ -1,0 +1,154 @@
+"""P1 감지 — 5xx 에러 / Redis Queue 적재량 / 데이터 정합성."""
+import logging
+
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    """Prometheus instant query. 결과 없으면 None 반환."""
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 5xx 에러 감지
+# ---------------------------------------------------------------------------
+
+def _check_5xx() -> None:
+    # increase()가 이미 "최근 30초 증가량"을 반환 — 별도 delta 계산 불필요
+    promql = 'sum(increase(http_server_requests_seconds_count{status=~"5.."}[30s]))'
+    delta = _query_prometheus(promql)
+    if delta is None:
+        return
+
+    if delta > config.HTTP_5XX_THRESHOLD:
+        key = "5xx_error"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "5xx 에러 발생",
+                f"최근 30초간 5xx 에러 *{delta:.0f}건* 감지\n"
+                f"Prometheus: `{promql}`",
+            )
+            record_alert(key)
+            logger.warning("P1 5xx=%.0f", delta)
+    else:
+        reset_alert("5xx_error")
+
+
+# ---------------------------------------------------------------------------
+# Redis Queue 적재량 감지
+# ---------------------------------------------------------------------------
+
+def _check_redis_queue() -> None:
+    promql = "campaign_redis_queue_size"
+    value = _query_prometheus(promql)
+    if value is None:
+        return
+
+    queue_size = int(value)
+
+    if queue_size >= config.REDIS_QUEUE_CRITICAL:
+        key = "redis_queue_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "Redis Queue CRITICAL",
+                f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_CRITICAL:,} / 85%)\n"
+                f"데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박",
+            )
+            record_alert(key)
+            logger.warning("P1 redis_queue CRITICAL size=%d", queue_size)
+        reset_alert("redis_queue_warning")
+
+    elif queue_size >= config.REDIS_QUEUE_WARNING:
+        key = "redis_queue_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Redis Queue WARNING",
+                f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_WARNING:,} / 70%)\n"
+                f"Consumer 처리 속도 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P1 redis_queue WARNING size=%d", queue_size)
+
+    else:
+        reset_alert("redis_queue_critical")
+        reset_alert("redis_queue_warning")
+
+
+# ---------------------------------------------------------------------------
+# 데이터 정합성 검사 (1시간 폴링)
+# ---------------------------------------------------------------------------
+
+def check_consistency() -> None:
+    """Redis 재고 카운터 vs DB INSERT 건수 정합성 확인."""
+    if config.BATCH_CAMPAIGN_ID == 0:
+        logger.info("BATCH_CAMPAIGN_ID 미설정 — 정합성 검사 스킵")
+        return
+
+    url = f"{config.BATCH_API_URL}/api/admin/campaigns/{config.BATCH_CAMPAIGN_ID}/consistency"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.error("정합성 API 호출 실패: %s", e)
+        return
+
+    redis_count = data.get("redisCount", 0)
+    db_count    = data.get("dbCount", 0)
+    diff        = abs(redis_count - db_count)
+
+    logger.info("정합성 검사 — redis=%d db=%d diff=%d", redis_count, db_count, diff)
+
+    if diff > 0:
+        key = "consistency_mismatch"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "데이터 정합성 불일치",
+                f"Redis 확정 건수: *{redis_count:,}*\n"
+                f"DB INSERT 건수: *{db_count:,}*\n"
+                f"차이: *{diff:,}건* — 유실 또는 중복 가능성",
+            )
+            record_alert(key)
+    else:
+        reset_alert("consistency_mismatch")
+        send_alert(
+            "OK",
+            "정합성 검사 통과",
+            f"Redis = DB = *{db_count:,}건* 일치",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p1() -> None:
+    _check_5xx()
+    _check_redis_queue()

--- a/mcp-server/detectors/p2_detector.py
+++ b/mcp-server/detectors/p2_detector.py
@@ -1,0 +1,230 @@
+"""P2 감지 — 앱 CPU / Kafka lag / Consumer 지연 / HikariCP pending."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+_cw = boto3.client("cloudwatch", region_name=config.AWS_REGION)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+def _query_cloudwatch_asg_cpu() -> float | None:
+    """ASG 전체 인스턴스 평균 CPU (최근 1분)."""
+    now = datetime.now(timezone.utc)
+    try:
+        resp = _cw.get_metric_statistics(
+            Namespace="AWS/EC2",
+            MetricName="CPUUtilization",
+            Dimensions=[{"Name": "AutoScalingGroupName", "Value": config.ASG_NAME}],
+            StartTime=now - timedelta(minutes=2),
+            EndTime=now,
+            Period=60,
+            Statistics=["Average"],
+        )
+        datapoints = resp.get("Datapoints", [])
+        if not datapoints:
+            return None
+        return max(dp["Average"] for dp in datapoints)
+    except Exception as e:
+        logger.error("CloudWatch CPU 조회 실패: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 앱 CPU 감지
+# ---------------------------------------------------------------------------
+
+def _check_cpu() -> None:
+    cpu = _query_cloudwatch_asg_cpu()
+    if cpu is None:
+        return
+
+    logger.info("ASG CPU=%.1f%%", cpu)
+
+    if cpu >= config.CPU_CRITICAL_PERCENT:
+        key = "cpu_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "앱 CPU CRITICAL",
+                f"ASG `{config.ASG_NAME}` 평균 CPU *{cpu:.1f}%* "
+                f"(임계값 {config.CPU_CRITICAL_PERCENT}%)\n"
+                f"ASG Scale-out 또는 인스턴스 타입 확인 필요",
+            )
+            record_alert(key)
+            logger.warning("P2 CPU CRITICAL=%.1f%%", cpu)
+        reset_alert("cpu_warning")
+
+    elif cpu >= config.CPU_WARNING_PERCENT:
+        key = "cpu_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "앱 CPU WARNING",
+                f"ASG `{config.ASG_NAME}` 평균 CPU *{cpu:.1f}%* "
+                f"(임계값 {config.CPU_WARNING_PERCENT}%)\n"
+                f"트래픽 추이 모니터링 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 CPU WARNING=%.1f%%", cpu)
+
+    else:
+        reset_alert("cpu_critical")
+        reset_alert("cpu_warning")
+
+
+# ---------------------------------------------------------------------------
+# Kafka lag 감지
+# ---------------------------------------------------------------------------
+
+def _check_kafka_lag() -> None:
+    promql = "sum(kafka_consumergroup_lag_sum)"
+    lag = _query_prometheus(promql)
+    if lag is None:
+        return
+
+    lag = int(lag)
+    logger.info("Kafka lag=%d", lag)
+
+    if lag >= config.KAFKA_LAG_CRITICAL:
+        key = "kafka_lag_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Kafka lag CRITICAL",
+                f"Consumer group lag *{lag:,}* "
+                f"(임계값 {config.KAFKA_LAG_CRITICAL:,})\n"
+                f"Consumer 처리 속도 저하 또는 재균형 발생 가능",
+            )
+            record_alert(key)
+            logger.warning("P2 Kafka lag CRITICAL=%d", lag)
+        reset_alert("kafka_lag_warning")
+
+    elif lag >= config.KAFKA_LAG_WARNING:
+        key = "kafka_lag_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Kafka lag WARNING",
+                f"Consumer group lag *{lag:,}* "
+                f"(임계값 {config.KAFKA_LAG_WARNING:,})\n"
+                f"일시적 스파이크인지 추이 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 Kafka lag WARNING=%d", lag)
+
+    else:
+        reset_alert("kafka_lag_critical")
+        reset_alert("kafka_lag_warning")
+
+
+# ---------------------------------------------------------------------------
+# Consumer 지연 감지
+# ---------------------------------------------------------------------------
+
+def _check_consumer_latency() -> None:
+    promql = "campaign_consumer_latency_ms"
+    latency = _query_prometheus(promql)
+    if latency is None:
+        return
+
+    logger.info("Consumer latency=%.1fms", latency)
+
+    if latency >= config.CONSUMER_LATENCY_CRITICAL_MS:
+        key = "consumer_latency_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Consumer 지연 CRITICAL",
+                f"Consumer 처리 지연 *{latency:.0f}ms* "
+                f"(임계값 {config.CONSUMER_LATENCY_CRITICAL_MS}ms)\n"
+                f"DB INSERT 병목 또는 Kafka rebalancing 의심",
+            )
+            record_alert(key)
+            logger.warning("P2 consumer latency CRITICAL=%.1fms", latency)
+        reset_alert("consumer_latency_warning")
+
+    elif latency >= config.CONSUMER_LATENCY_WARNING_MS:
+        key = "consumer_latency_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Consumer 지연 WARNING",
+                f"Consumer 처리 지연 *{latency:.0f}ms* "
+                f"(임계값 {config.CONSUMER_LATENCY_WARNING_MS}ms)\n"
+                f"HikariCP pending 및 RDS CPU 함께 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 consumer latency WARNING=%.1fms", latency)
+
+    else:
+        reset_alert("consumer_latency_critical")
+        reset_alert("consumer_latency_warning")
+
+
+# ---------------------------------------------------------------------------
+# HikariCP pending 감지
+# ---------------------------------------------------------------------------
+
+def _check_hikari_pending() -> None:
+    # 전체 인스턴스 중 최대값 기준
+    promql = "max(hikaricp_pending_threads)"
+    pending = _query_prometheus(promql)
+    if pending is None:
+        return
+
+    pending = int(pending)
+    logger.info("HikariCP pending=%d", pending)
+
+    if pending >= config.HIKARI_PENDING_THRESHOLD:
+        key = "hikari_pending"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "HikariCP pending 발생",
+                f"DB 커넥션 대기 *{pending}개* "
+                f"(임계값 {config.HIKARI_PENDING_THRESHOLD})\n"
+                f"RDS CPU 및 slow query 확인 필요",
+            )
+            record_alert(key)
+            logger.warning("P2 HikariCP pending=%d", pending)
+    else:
+        reset_alert("hikari_pending")
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p2() -> None:
+    _check_cpu()
+    _check_kafka_lag()
+    _check_consumer_latency()
+    _check_hikari_pending()

--- a/mcp-server/detectors/p2_detector.py
+++ b/mcp-server/detectors/p2_detector.py
@@ -7,7 +7,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def _check_cpu() -> None:
 
     if cpu >= config.CPU_CRITICAL_PERCENT:
         key = "cpu_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "앱 CPU CRITICAL",
@@ -78,13 +78,12 @@ def _check_cpu() -> None:
                 f"(임계값 {config.CPU_CRITICAL_PERCENT}%)\n"
                 f"ASG Scale-out 또는 인스턴스 타입 확인 필요",
             )
-            record_alert(key)
             logger.warning("P2 CPU CRITICAL=%.1f%%", cpu)
         reset_alert("cpu_warning")
 
     elif cpu >= config.CPU_WARNING_PERCENT:
         key = "cpu_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "앱 CPU WARNING",
@@ -92,7 +91,6 @@ def _check_cpu() -> None:
                 f"(임계값 {config.CPU_WARNING_PERCENT}%)\n"
                 f"트래픽 추이 모니터링 권장",
             )
-            record_alert(key)
             logger.warning("P2 CPU WARNING=%.1f%%", cpu)
 
     else:
@@ -115,7 +113,7 @@ def _check_kafka_lag() -> None:
 
     if lag >= config.KAFKA_LAG_CRITICAL:
         key = "kafka_lag_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Kafka lag CRITICAL",
@@ -123,13 +121,12 @@ def _check_kafka_lag() -> None:
                 f"(임계값 {config.KAFKA_LAG_CRITICAL:,})\n"
                 f"Consumer 처리 속도 저하 또는 재균형 발생 가능",
             )
-            record_alert(key)
             logger.warning("P2 Kafka lag CRITICAL=%d", lag)
         reset_alert("kafka_lag_warning")
 
     elif lag >= config.KAFKA_LAG_WARNING:
         key = "kafka_lag_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Kafka lag WARNING",
@@ -137,7 +134,6 @@ def _check_kafka_lag() -> None:
                 f"(임계값 {config.KAFKA_LAG_WARNING:,})\n"
                 f"일시적 스파이크인지 추이 확인 권장",
             )
-            record_alert(key)
             logger.warning("P2 Kafka lag WARNING=%d", lag)
 
     else:
@@ -159,7 +155,7 @@ def _check_consumer_latency() -> None:
 
     if latency >= config.CONSUMER_LATENCY_CRITICAL_MS:
         key = "consumer_latency_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Consumer 지연 CRITICAL",
@@ -167,13 +163,12 @@ def _check_consumer_latency() -> None:
                 f"(임계값 {config.CONSUMER_LATENCY_CRITICAL_MS}ms)\n"
                 f"DB INSERT 병목 또는 Kafka rebalancing 의심",
             )
-            record_alert(key)
             logger.warning("P2 consumer latency CRITICAL=%.1fms", latency)
         reset_alert("consumer_latency_warning")
 
     elif latency >= config.CONSUMER_LATENCY_WARNING_MS:
         key = "consumer_latency_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Consumer 지연 WARNING",
@@ -181,7 +176,6 @@ def _check_consumer_latency() -> None:
                 f"(임계값 {config.CONSUMER_LATENCY_WARNING_MS}ms)\n"
                 f"HikariCP pending 및 RDS CPU 함께 확인 권장",
             )
-            record_alert(key)
             logger.warning("P2 consumer latency WARNING=%.1fms", latency)
 
     else:
@@ -205,7 +199,7 @@ def _check_hikari_pending() -> None:
 
     if pending >= config.HIKARI_PENDING_THRESHOLD:
         key = "hikari_pending"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "HikariCP pending 발생",
@@ -213,7 +207,6 @@ def _check_hikari_pending() -> None:
                 f"(임계값 {config.HIKARI_PENDING_THRESHOLD})\n"
                 f"RDS CPU 및 slow query 확인 필요",
             )
-            record_alert(key)
             logger.warning("P2 HikariCP pending=%d", pending)
     else:
         reset_alert("hikari_pending")

--- a/mcp-server/detectors/p3_detector.py
+++ b/mcp-server/detectors/p3_detector.py
@@ -1,0 +1,124 @@
+"""P3 감지 — RDS CPU / Bridge 드레인 사이클."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+_cw = boto3.client("cloudwatch", region_name=config.AWS_REGION)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+def _query_cloudwatch_rds_cpu() -> float | None:
+    """RDS 인스턴스 CPU 평균 (최근 1분)."""
+    now = datetime.now(timezone.utc)
+    try:
+        resp = _cw.get_metric_statistics(
+            Namespace="AWS/RDS",
+            MetricName="CPUUtilization",
+            Dimensions=[{"Name": "DBInstanceIdentifier", "Value": config.RDS_ID}],
+            StartTime=now - timedelta(minutes=2),
+            EndTime=now,
+            Period=60,
+            Statistics=["Average"],
+        )
+        datapoints = resp.get("Datapoints", [])
+        if not datapoints:
+            return None
+        return max(dp["Average"] for dp in datapoints)
+    except Exception as e:
+        logger.error("CloudWatch RDS CPU 조회 실패: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# RDS CPU 감지
+# ---------------------------------------------------------------------------
+
+def _check_rds_cpu() -> None:
+    cpu = _query_cloudwatch_rds_cpu()
+    if cpu is None:
+        return
+
+    logger.info("RDS CPU=%.1f%%", cpu)
+
+    if cpu >= config.RDS_CPU_WARNING_PERCENT:
+        key = "rds_cpu_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P3",
+                "RDS CPU WARNING",
+                f"DB `{config.RDS_ID}` CPU *{cpu:.1f}%* "
+                f"(임계값 {config.RDS_CPU_WARNING_PERCENT}%)\n"
+                f"slow query 또는 HikariCP pool 크기 확인 권장\n"
+                f"11차 테스트 최대치: 47% — 현재 {cpu:.0f}%는 비정상 수준",
+            )
+            record_alert(key)
+            logger.warning("P3 RDS CPU WARNING=%.1f%%", cpu)
+    else:
+        reset_alert("rds_cpu_warning")
+
+
+# ---------------------------------------------------------------------------
+# Bridge 드레인 사이클 감지
+# ---------------------------------------------------------------------------
+
+def _check_bridge_cycle() -> None:
+    """Bridge 사이클 시간이 임계값 초과 시 Queue 드레인 지연 의심."""
+    promql = "campaign_bridge_cycle_seconds"
+    cycle_sec = _query_prometheus(promql)
+    if cycle_sec is None:
+        return
+
+    logger.info("Bridge cycle=%.2fs", cycle_sec)
+
+    if cycle_sec >= config.BRIDGE_CYCLE_WARNING_SECONDS:
+        key = "bridge_cycle_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P3",
+                "Bridge 드레인 사이클 지연",
+                f"ParticipationBridge 사이클 *{cycle_sec:.1f}초* "
+                f"(임계값 {config.BRIDGE_CYCLE_WARNING_SECONDS}초)\n"
+                f"Queue → Kafka 전송 지연 — Redis Queue 적재량 함께 확인\n"
+                f"정상 범위: 100ms 간격 스케줄, 사이클당 최대 2,000건 배치",
+            )
+            record_alert(key)
+            logger.warning("P3 Bridge cycle WARNING=%.2fs", cycle_sec)
+    else:
+        reset_alert("bridge_cycle_warning")
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p3() -> None:
+    _check_rds_cpu()
+    _check_bridge_cycle()

--- a/mcp-server/detectors/p3_detector.py
+++ b/mcp-server/detectors/p3_detector.py
@@ -7,7 +7,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def _check_rds_cpu() -> None:
 
     if cpu >= config.RDS_CPU_WARNING_PERCENT:
         key = "rds_cpu_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P3",
                 "RDS CPU WARNING",
@@ -79,7 +79,6 @@ def _check_rds_cpu() -> None:
                 f"slow query 또는 HikariCP pool 크기 확인 권장\n"
                 f"11차 테스트 최대치: 47% — 현재 {cpu:.0f}%는 비정상 수준",
             )
-            record_alert(key)
             logger.warning("P3 RDS CPU WARNING=%.1f%%", cpu)
     else:
         reset_alert("rds_cpu_warning")
@@ -100,7 +99,7 @@ def _check_bridge_cycle() -> None:
 
     if cycle_sec >= config.BRIDGE_CYCLE_WARNING_SECONDS:
         key = "bridge_cycle_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P3",
                 "Bridge 드레인 사이클 지연",
@@ -109,7 +108,6 @@ def _check_bridge_cycle() -> None:
                 f"Queue → Kafka 전송 지연 — Redis Queue 적재량 함께 확인\n"
                 f"정상 범위: 100ms 간격 스케줄, 사이클당 최대 2,000건 배치",
             )
-            record_alert(key)
             logger.warning("P3 Bridge cycle WARNING=%.2fs", cycle_sec)
     else:
         reset_alert("bridge_cycle_warning")

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -1,0 +1,42 @@
+import logging
+from contextlib import asynccontextmanager
+
+import uvicorn
+from apscheduler.schedulers.background import BackgroundScheduler
+from fastapi import FastAPI
+
+from monitor import run_consistency_check, run_monitor
+from slack import send_alert
+from tools import mcp_routes
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+scheduler = BackgroundScheduler()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler.add_job(run_monitor, "interval", seconds=30, id="monitor")
+    scheduler.add_job(run_consistency_check, "interval", hours=1, id="consistency")
+    scheduler.start()
+    logger.info("스케줄러 시작 — 30초 폴링, 1시간 정합성 검사")
+    send_alert("OK", "모니터링 시작", "MCP 모니터링 서버가 정상 기동되었습니다.")
+    yield
+    scheduler.shutdown(wait=False)
+    logger.info("스케줄러 종료")
+
+
+app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=False)

--- a/mcp-server/monitor.py
+++ b/mcp-server/monitor.py
@@ -1,0 +1,24 @@
+import logging
+
+from detectors.p1_detector import check_p1
+from detectors.p2_detector import check_p2
+from detectors.p3_detector import check_p3
+
+logger = logging.getLogger(__name__)
+
+
+def run_monitor() -> None:
+    for check in [check_p1, check_p2, check_p3]:
+        try:
+            check()
+        except Exception as e:
+            logger.error("%s 오류: %s", check.__name__, e)
+
+
+def run_consistency_check() -> None:
+    """1시간마다 실행되는 정합성 검사 (p1_detector에서 구현)."""
+    try:
+        from detectors.p1_detector import check_consistency
+        check_consistency()
+    except Exception as e:
+        logger.error("consistency_check 오류: %s", e)

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.6
+uvicorn==0.30.6
+apscheduler==3.10.4
+requests==2.32.3
+boto3==1.35.0
+mcp==1.0.0

--- a/mcp-server/slack.py
+++ b/mcp-server/slack.py
@@ -1,0 +1,28 @@
+import logging
+
+import requests
+
+from config import SLACK_WEBHOOK_URL
+
+logger = logging.getLogger(__name__)
+
+LEVEL_EMOJI = {
+    "P1": ":red_circle:",
+    "P2": ":large_yellow_circle:",
+    "P3": ":large_blue_circle:",
+    "OK": ":white_check_mark:",
+}
+
+
+def send_alert(level: str, title: str, body: str) -> None:
+    emoji = LEVEL_EMOJI.get(level, "")
+    text = f"{emoji} *[{level}] {title}*\n{body}"
+    try:
+        resp = requests.post(
+            SLACK_WEBHOOK_URL,
+            json={"text": text},
+            timeout=5,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.error("Slack 전송 실패: %s", e)

--- a/mcp-server/state.py
+++ b/mcp-server/state.py
@@ -1,0 +1,15 @@
+import time
+
+_alert_state: dict[str, float] = {}
+
+
+def can_alert(key: str, cooldown: int) -> bool:
+    return (time.time() - _alert_state.get(key, 0)) >= cooldown
+
+
+def record_alert(key: str) -> None:
+    _alert_state[key] = time.time()
+
+
+def reset_alert(key: str) -> None:
+    _alert_state.pop(key, None)

--- a/mcp-server/state.py
+++ b/mcp-server/state.py
@@ -1,15 +1,31 @@
+import threading
 import time
 
 _alert_state: dict[str, float] = {}
+_lock = threading.Lock()
 
 
-def can_alert(key: str, cooldown: int) -> bool:
-    return (time.time() - _alert_state.get(key, 0)) >= cooldown
-
-
-def record_alert(key: str) -> None:
-    _alert_state[key] = time.time()
+def check_and_record(key: str, cooldown: int) -> bool:
+    """can_alert + record_alert를 atomic하게 실행. True면 알림 발송 가능."""
+    with _lock:
+        if (time.time() - _alert_state.get(key, 0)) >= cooldown:
+            _alert_state[key] = time.time()
+            return True
+        return False
 
 
 def reset_alert(key: str) -> None:
-    _alert_state.pop(key, None)
+    with _lock:
+        _alert_state.pop(key, None)
+
+
+def list_alerts() -> dict[str, float]:
+    with _lock:
+        return dict(_alert_state)
+
+
+def reset_all() -> list[str]:
+    with _lock:
+        keys = list(_alert_state.keys())
+        _alert_state.clear()
+        return keys

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -1,0 +1,446 @@
+"""MCP 도구 노출 — Claude가 직접 호출할 수 있는 읽기 전용 운영 도구."""
+import logging
+import time
+
+import requests
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+from mcp.types import TextContent, Tool
+from starlette.routing import Route
+
+import config
+import state
+from detectors.p1_detector import check_consistency, check_p1
+from detectors.p2_detector import check_p2
+from detectors.p3_detector import check_p3
+
+logger = logging.getLogger(__name__)
+
+mcp_server = Server("mcp-monitor")
+
+
+# ---------------------------------------------------------------------------
+# 도구 목록 정의
+# ---------------------------------------------------------------------------
+
+@mcp_server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="get_monitor_status",
+            description=(
+                "현재 alert cooldown 상태를 반환합니다. "
+                "어떤 알림이 활성화(쿨다운 중)인지, 마지막 알림 시각이 언제인지 확인합니다."
+            ),
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="run_check",
+            description=(
+                "P1/P2/P3 detector를 수동으로 즉시 실행합니다. "
+                "쿨다운 무시 없이 실제 감지 로직을 실행하며, Slack 알림도 발송됩니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "level": {
+                        "type": "string",
+                        "enum": ["p1", "p2", "p3", "all"],
+                        "description": "실행할 detector (p1/p2/p3/all)",
+                    }
+                },
+                "required": ["level"],
+            },
+        ),
+        Tool(
+            name="query_prometheus",
+            description=(
+                "Prometheus에 PromQL 쿼리를 실행하고 결과를 반환합니다. "
+                "현재 메트릭 값을 직접 확인할 때 사용합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "promql": {
+                        "type": "string",
+                        "description": "실행할 PromQL 쿼리 (예: campaign_redis_queue_size)",
+                    }
+                },
+                "required": ["promql"],
+            },
+        ),
+        Tool(
+            name="reset_cooldown",
+            description=(
+                "특정 alert의 쿨다운을 리셋합니다. "
+                "쿨다운 중인 알림을 즉시 재발송 가능하게 만들 때 사용합니다. "
+                "key를 'all'로 지정하면 모든 쿨다운을 초기화합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": (
+                            "리셋할 alert key "
+                            "(예: 5xx_error / redis_queue_critical / cpu_warning / all)"
+                        ),
+                    }
+                },
+                "required": ["key"],
+            },
+        ),
+        Tool(
+            name="trigger_consistency_check",
+            description=(
+                "Redis 재고 카운터와 DB INSERT 건수 정합성 검사를 즉시 실행합니다. "
+                "1시간 주기를 기다리지 않고 수동으로 트리거합니다."
+            ),
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="query_prometheus_range",
+            description=(
+                "Prometheus에 특정 시간 구간의 메트릭을 조회합니다. "
+                "부하 테스트 종료 후 '아까 어디서 문제였나' 분석에 사용합니다. "
+                "start/end는 Unix timestamp 또는 'now-1h' 같은 상대 표현 사용 가능."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "promql": {
+                        "type": "string",
+                        "description": "실행할 PromQL 쿼리",
+                    },
+                    "start_minutes_ago": {
+                        "type": "integer",
+                        "description": "조회 시작점 (현재로부터 몇 분 전). 예: 60 → 1시간 전부터",
+                    },
+                    "end_minutes_ago": {
+                        "type": "integer",
+                        "description": "조회 종료점 (현재로부터 몇 분 전). 예: 0 → 지금까지",
+                        "default": 0,
+                    },
+                    "step_seconds": {
+                        "type": "integer",
+                        "description": "데이터 포인트 간격(초). 기본 30초",
+                        "default": 30,
+                    },
+                },
+                "required": ["promql", "start_minutes_ago"],
+            },
+        ),
+        Tool(
+            name="get_test_report",
+            description=(
+                "부하 테스트 구간 전체 핵심 메트릭을 한번에 조회해서 요약합니다. "
+                "테스트 종료 후 '어디서 문제가 있었나' 파악할 때 사용합니다. "
+                "각 메트릭의 최대값과 임계값 초과 여부를 함께 반환합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "start_minutes_ago": {
+                        "type": "integer",
+                        "description": "테스트 시작 시각 (현재로부터 몇 분 전). 예: 60",
+                    },
+                    "end_minutes_ago": {
+                        "type": "integer",
+                        "description": "테스트 종료 시각 (현재로부터 몇 분 전). 예: 0 → 지금",
+                        "default": 0,
+                    },
+                },
+                "required": ["start_minutes_ago"],
+            },
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 도구 실행 핸들러
+# ---------------------------------------------------------------------------
+
+@mcp_server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name == "get_monitor_status":
+        return _handle_get_monitor_status()
+
+    if name == "run_check":
+        return _handle_run_check(arguments.get("level", "all"))
+
+    if name == "query_prometheus":
+        return _handle_query_prometheus(arguments.get("promql", ""))
+
+    if name == "reset_cooldown":
+        return _handle_reset_cooldown(arguments.get("key", ""))
+
+    if name == "trigger_consistency_check":
+        return _handle_trigger_consistency_check()
+
+    if name == "query_prometheus_range":
+        return _handle_query_prometheus_range(
+            promql=arguments.get("promql", ""),
+            start_minutes_ago=arguments.get("start_minutes_ago", 60),
+            end_minutes_ago=arguments.get("end_minutes_ago", 0),
+            step_seconds=arguments.get("step_seconds", 30),
+        )
+
+    if name == "get_test_report":
+        return _handle_get_test_report(
+            start_minutes_ago=arguments.get("start_minutes_ago", 60),
+            end_minutes_ago=arguments.get("end_minutes_ago", 0),
+        )
+
+    return [TextContent(type="text", text=f"알 수 없는 도구: {name}")]
+
+
+# ---------------------------------------------------------------------------
+# 핸들러 구현
+# ---------------------------------------------------------------------------
+
+def _handle_get_monitor_status() -> list[TextContent]:
+    now = time.time()
+    alert_state = state._alert_state
+
+    if not alert_state:
+        return [TextContent(type="text", text="현재 활성화된 alert 없음 (모든 쿨다운 초기화 상태)")]
+
+    lines = ["**현재 alert cooldown 상태**\n"]
+    for key, last_time in sorted(alert_state.items()):
+        elapsed = now - last_time
+        remaining = max(0.0, config.COOLDOWN_SECONDS - elapsed)
+        lines.append(
+            f"- `{key}`: 마지막 알림 {elapsed:.0f}초 전 / "
+            f"쿨다운 잔여 {remaining:.0f}초"
+        )
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+def _handle_run_check(level: str) -> list[TextContent]:
+    results = []
+    checks = {
+        "p1": ("P1 (5xx / Redis Queue)", check_p1),
+        "p2": ("P2 (CPU / Kafka lag / Consumer / HikariCP)", check_p2),
+        "p3": ("P3 (RDS CPU / Bridge 사이클)", check_p3),
+    }
+
+    targets = checks.items() if level == "all" else [(level, checks[level])] if level in checks else []
+
+    if not targets:
+        return [TextContent(type="text", text=f"알 수 없는 level: {level}")]
+
+    for key, (label, fn) in targets:
+        try:
+            fn()
+            results.append(f"✓ {label} 실행 완료")
+        except Exception as e:
+            results.append(f"✗ {label} 실행 실패: {e}")
+
+    return [TextContent(type="text", text="\n".join(results))]
+
+
+def _handle_query_prometheus(promql: str) -> list[TextContent]:
+    if not promql:
+        return [TextContent(type="text", text="promql 파라미터가 필요합니다.")]
+
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        result = data.get("data", {}).get("result", [])
+
+        if not result:
+            return [TextContent(type="text", text=f"`{promql}` → 결과 없음 (메트릭 미수집 또는 쿼리 오류)")]
+
+        lines = [f"**Prometheus 쿼리**: `{promql}`\n"]
+        for item in result:
+            metric = item.get("metric", {})
+            value = item["value"][1]
+            label_str = ", ".join(f'{k}="{v}"' for k, v in metric.items()) or "(no labels)"
+            lines.append(f"- {label_str}: **{value}**")
+
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Prometheus 쿼리 실패: {e}")]
+
+
+def _handle_reset_cooldown(key: str) -> list[TextContent]:
+    if not key:
+        return [TextContent(type="text", text="key 파라미터가 필요합니다.")]
+
+    if key == "all":
+        cleared = list(state._alert_state.keys())
+        state._alert_state.clear()
+        return [TextContent(type="text", text=f"전체 쿨다운 초기화 완료: {cleared}")]
+
+    if key in state._alert_state:
+        state.reset_alert(key)
+        return [TextContent(type="text", text=f"`{key}` 쿨다운 리셋 완료")]
+
+    return [TextContent(type="text", text=f"`{key}` 는 현재 쿨다운 상태가 아닙니다.")]
+
+
+def _handle_query_prometheus_range(
+    promql: str,
+    start_minutes_ago: int,
+    end_minutes_ago: int,
+    step_seconds: int,
+) -> list[TextContent]:
+    if not promql:
+        return [TextContent(type="text", text="promql 파라미터가 필요합니다.")]
+
+    now = time.time()
+    start = now - start_minutes_ago * 60
+    end   = now - end_minutes_ago * 60
+
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query_range",
+            params={"query": promql, "start": start, "end": end, "step": step_seconds},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+
+        if not result:
+            return [TextContent(type="text", text=f"`{promql}` → 해당 구간 데이터 없음")]
+
+        lines = [
+            f"**{promql}** ({start_minutes_ago}분 전 ~ {end_minutes_ago}분 전)\n"
+        ]
+        for series in result:
+            values = [float(v[1]) for v in series["value"] if v[1] != "NaN"] if "value" in series else \
+                     [float(v[1]) for v in series.get("values", []) if v[1] != "NaN"]
+            if not values:
+                continue
+            label_str = ", ".join(f'{k}="{v}"' for k, v in series.get("metric", {}).items()) or "(no labels)"
+            lines.append(
+                f"- {label_str}\n"
+                f"  최솟값: {min(values):.2f} / 최대값: {max(values):.2f} / 평균: {sum(values)/len(values):.2f}"
+            )
+
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Prometheus range 쿼리 실패: {e}")]
+
+
+# 테스트 리포트에서 조회할 메트릭 목록 (promql, 레이블, 임계값)
+_REPORT_METRICS = [
+    (
+        'sum(increase(http_server_requests_seconds_count{status=~"5.."}[1m]))',
+        "5xx 에러 (1분 합산)",
+        config.HTTP_5XX_THRESHOLD,
+        "건",
+    ),
+    (
+        "campaign_redis_queue_size",
+        "Redis Queue 적재량",
+        config.REDIS_QUEUE_CRITICAL,
+        "건",
+    ),
+    (
+        "sum(kafka_consumergroup_lag_sum)",
+        "Kafka consumer lag",
+        config.KAFKA_LAG_CRITICAL,
+        "",
+    ),
+    (
+        "campaign_consumer_latency_ms",
+        "Consumer 처리 지연",
+        config.CONSUMER_LATENCY_CRITICAL_MS,
+        "ms",
+    ),
+    (
+        "max(hikaricp_pending_threads)",
+        "HikariCP pending",
+        config.HIKARI_PENDING_THRESHOLD,
+        "개",
+    ),
+    (
+        "campaign_bridge_cycle_seconds",
+        "Bridge 드레인 사이클",
+        config.BRIDGE_CYCLE_WARNING_SECONDS,
+        "초",
+    ),
+]
+
+
+def _handle_get_test_report(start_minutes_ago: int, end_minutes_ago: int) -> list[TextContent]:
+    now   = time.time()
+    start = now - start_minutes_ago * 60
+    end   = now - end_minutes_ago * 60
+    step  = 30  # 30초 해상도
+
+    lines = [
+        f"## 부하 테스트 리포트",
+        f"조회 구간: {start_minutes_ago}분 전 ~ {end_minutes_ago}분 전\n",
+        f"{'메트릭':<30} {'최대값':>12} {'임계값':>12} {'초과':>6}",
+        "-" * 65,
+    ]
+
+    for promql, label, threshold, unit in _REPORT_METRICS:
+        try:
+            resp = requests.get(
+                f"{config.PROMETHEUS_URL}/api/v1/query_range",
+                params={"query": promql, "start": start, "end": end, "step": step},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            result = resp.json().get("data", {}).get("result", [])
+
+            if not result:
+                lines.append(f"{label:<30} {'데이터 없음':>12}")
+                continue
+
+            all_values = []
+            for series in result:
+                all_values += [float(v[1]) for v in series.get("values", []) if v[1] != "NaN"]
+
+            if not all_values:
+                lines.append(f"{label:<30} {'데이터 없음':>12}")
+                continue
+
+            max_val = max(all_values)
+            exceeded = "⚠️ YES" if max_val > threshold else "OK"
+            lines.append(
+                f"{label:<30} {f'{max_val:.1f}{unit}':>12} {f'{threshold}{unit}':>12} {exceeded:>6}"
+            )
+
+        except Exception as e:
+            lines.append(f"{label:<30} 조회 실패: {e}")
+
+    lines.append("\n*CloudWatch 메트릭(앱 CPU, RDS CPU)은 query_prometheus_range로 별도 확인*")
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+def _handle_trigger_consistency_check() -> list[TextContent]:
+    try:
+        check_consistency()
+        return [TextContent(type="text", text="정합성 검사 실행 완료 — Slack 결과 확인")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"정합성 검사 실패: {e}")]
+
+
+# ---------------------------------------------------------------------------
+# FastAPI 마운트용 SSE transport
+# ---------------------------------------------------------------------------
+
+sse = SseServerTransport("/mcp/messages")
+
+
+async def handle_sse(request):
+    async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+        await mcp_server.run(streams[0], streams[1], mcp_server.create_initialization_options())
+
+
+mcp_routes = [
+    Route("/mcp/sse", endpoint=handle_sse),
+    Route("/mcp/messages", endpoint=sse.handle_post_message, methods=["POST"]),
+]

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -200,7 +200,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
 def _handle_get_monitor_status() -> list[TextContent]:
     now = time.time()
-    alert_state = state._alert_state
+    alert_state = state.list_alerts()
 
     if not alert_state:
         return [TextContent(type="text", text="현재 활성화된 alert 없음 (모든 쿨다운 초기화 상태)")]
@@ -275,11 +275,10 @@ def _handle_reset_cooldown(key: str) -> list[TextContent]:
         return [TextContent(type="text", text="key 파라미터가 필요합니다.")]
 
     if key == "all":
-        cleared = list(state._alert_state.keys())
-        state._alert_state.clear()
+        cleared = state.reset_all()
         return [TextContent(type="text", text=f"전체 쿨다운 초기화 완료: {cleared}")]
 
-    if key in state._alert_state:
+    if key in state.list_alerts():
         state.reset_alert(key)
         return [TextContent(type="text", text=f"`{key}` 쿨다운 리셋 완료")]
 


### PR DESCRIPTION
# feat: Grafana 수동 감시 자동화 - MCP 서버 + Prometheus/CloudWatch 알림 (#61)
 
---
 
## 개요
 
Grafana 대시보드를 사람이 직접 보며 수동으로 감시하던 방식을 자동화하는 MCP 서버를 구현했다.
서버는 30초마다 Prometheus와 CloudWatch를 폴링해 P1/P2/P3 임계값을 감지하고 Slack으로 즉시 알린다.
Claude가 MCP 도구 7개를 통해 운영 중 메트릭을 실시간으로 조회하고 분석할 수 있다.
 
---
 
## 배경
 
Phase B에서 100만 트래픽 테스트를 완료했지만, 운영 단계에서 사람이 직접 Grafana 13개 패널을 주시해야만 이상을 감지할 수 있었다. 10차 테스트에서 Redis Queue가 500K 상한을 초과해 데이터 425K가 유실됐을 때도 실시간 감지 수단이 없었다. 또한 테스트 종료 후 어느 구간에서 무엇이 문제였는지 파악하려면 Grafana를 수동으로 뒤져야 했다. 이 PR은 세 가지 문제를 모두 해결한다.
 
---
 
## 변경 사항
 
### 아키텍처
 
```
[APScheduler 30초]
  └─ monitor.run_monitor()
       ├─ check_p1() → 5xx 에러, Redis Queue 적재량
       ├─ check_p2() → 앱 CPU, Kafka lag, Consumer 지연, HikariCP pending
       └─ check_p3() → RDS CPU, Bridge 드레인 사이클
 
[APScheduler 1시간]
  └─ run_consistency_check() → Redis 재고 카운터 vs DB INSERT 건수 정합성
 
[FastAPI SSE]
  ├─ GET  /mcp/sse      ← Claude SSE 스트림 연결
  └─ POST /mcp/messages ← Claude 도구 호출 메시지 수신
 
[Slack Webhook]
  └─ 임계값 초과 → P1/P2/P3 레벨 알림 (5분 쿨다운)
```
 
---
 
### 감지 레벨 및 임계값
 
**P1 — 즉각 대응**
 
5xx 에러, Redis Queue 적재량, 데이터 정합성을 감지한다. Redis Queue 임계값을 MAX의 85%(850K)로 설정한 이유는 10차 테스트에서 500K 상한 초과로 데이터 425K가 유실된 경험 때문이다. 정합성 검사는 1시간마다 Redis 확정 건수와 DB INSERT 건수를 비교해 차이가 있으면 즉시 알린다.
 
| 항목 | WARNING | CRITICAL |
|---|---|---|
| 5xx 에러 (30초 합산) | — | 1건 이상 |
| Redis Queue | 700,000 (70%) | 850,000 (85%) |
| 데이터 정합성 | — | Redis ≠ DB |
 
**P2 — 추이 모니터링**
 
앱 CPU, Kafka lag, Consumer 지연, HikariCP pending을 감지한다. CPU는 CloudWatch에서 ASG 단위로 직접 조회하고, 나머지는 Prometheus에서 가져온다. Consumer 지연 임계값(50ms WARNING / 200ms CRITICAL)은 11차 테스트 정상 수치인 7.5~15ms를 기준으로 설정했다.
 
| 항목 | WARNING | CRITICAL |
|---|---|---|
| 앱 CPU (ASG 평균, CloudWatch) | 80% | 90% |
| Kafka consumer lag | 500 | 1,000 |
| Consumer 처리 지연 | 50ms | 200ms |
| HikariCP pending | 1개 이상 | — |
 
**P3 — 사전 징후**
 
RDS CPU와 Bridge 드레인 사이클을 감지한다. RDS CPU 임계값을 60%로 설정한 근거는 11차 테스트 최대치가 47%였기 때문이다. Bridge 사이클이 60초를 초과하면 Queue → Kafka 전송 지연으로 판단한다.
 
| 항목 | 임계값 |
|---|---|
| RDS CPU (CloudWatch) | 60% |
| Bridge 드레인 사이클 | 60초 |
 
---
 
### 쿨다운 시스템
 
동일한 alert가 5분 내에 반복 발송되지 않도록 인메모리 딕셔너리로 타임스탬프를 관리한다. 임계값이 해소되면 해당 키를 즉시 삭제해서 재발생 시 지연 없이 알림이 가능하다.
 
```python
# state.py
_alert_state: dict[str, float] = {}
 
def can_alert(key: str, cooldown: float) -> bool:
    last = _alert_state.get(key)
    return last is None or (time.time() - last) >= cooldown
 
def record_alert(key: str) -> None:
    _alert_state[key] = time.time()
 
def reset_alert(key: str) -> None:
    _alert_state.pop(key, None)  # 해소 즉시 삭제 → 재발생 시 즉시 알림
```
 
예를 들어 Redis Queue가 850K를 넘어 CRITICAL을 발송했다가 750K로 내려오면 키가 리셋되고, 이후 다시 850K를 초과하면 5분을 기다리지 않고 즉시 알린다.
 
---
 
### MCP 도구 7개
 
| 도구 | 용도 |
|---|---|
| `get_monitor_status` | 현재 쿨다운 상태 및 마지막 알림 시각 조회 |
| `run_check` | p1/p2/p3/all 감지기 수동 즉시 실행 |
| `query_prometheus` | PromQL instant 쿼리 — 현재 메트릭 값 확인 |
| `query_prometheus_range` | 특정 구간 메트릭 조회 (최솟값/최댓값/평균) |
| `get_test_report` | 부하 테스트 구간 핵심 메트릭 6종 한번에 요약 |
| `reset_cooldown` | 특정 alert 쿨다운 리셋 (`key=all` 전체 초기화) |
| `trigger_consistency_check` | 정합성 검사 즉시 실행 (1시간 주기 대기 없이) |
 
`get_test_report`는 5xx, Redis Queue, Kafka lag, Consumer 지연, HikariCP, Bridge 사이클 6종을 한 번에 조회해 각 메트릭의 최대값과 임계값 초과 여부를 테이블로 반환한다.
 
```
메트릭                           최대값       임계값     초과
-----------------------------------------------------------------
5xx 에러 (1분 합산)                   0건           0건     OK
Redis Queue 적재량             700,123건     850,000건     OK
Kafka consumer lag                    2          1,000     OK
Consumer 처리 지연                12.3ms         200ms     OK
HikariCP pending                      0개            1개     OK
Bridge 드레인 사이클               0.10초          60초     OK
```
 
---
 
### 인프라 변경
 
`infra/ec2.tf`에 terraform-mcp IAM 역할에 CloudWatch 읽기 권한을 추가했다. P2/P3 감지기가 ASG CPU와 RDS CPU를 CloudWatch에서 직접 조회하기 위해 필요하다.
 
```hcl
resource "aws_iam_role_policy" "terraform_mcp_cloudwatch_read" {
  name = "CloudWatchRead-for-mcp"
  role = aws_iam_role.terraform_mcp.name
 
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [{
      Effect   = "Allow"
      Action   = ["cloudwatch:GetMetricStatistics", "cloudwatch:ListMetrics"]
      Resource = "*"
    }]
  })
}
```
 
---
 
## 변경 파일
 
| 파일 | 내용 |
|---|---|
| `mcp-server/main.py` | FastAPI 앱, APScheduler 30초/1시간 작업 등록 |
| `mcp-server/tools.py` | MCP 도구 7개 정의 및 SSE transport 라우트 |
| `mcp-server/monitor.py` | P1/P2/P3 감지기 진입점 |
| `mcp-server/detectors/p1_detector.py` | 5xx, Redis Queue, 정합성 감지 |
| `mcp-server/detectors/p2_detector.py` | CPU, Kafka lag, Consumer 지연, HikariCP 감지 |
| `mcp-server/detectors/p3_detector.py` | RDS CPU, Bridge 사이클 감지 |
| `mcp-server/config.py` | 환경변수 및 임계값 상수 |
| `mcp-server/state.py` | 쿨다운 인메모리 상태 관리 |
| `mcp-server/slack.py` | Slack Webhook 알림 |
| `mcp-server/Dockerfile` | 컨테이너 빌드 |
| `infra/ec2.tf` | terraform-mcp CloudWatch IAM 정책 추가 |
| `.gitignore` | Python `__pycache__` 제외 |
| `CLAUDE.md` | Phase E 완료 반영, 배포 가이드 추가 |
 
---
 
## 변경 유형
 
- `feat` — 새 기능
- `infra` — Terraform / AWS 인프라
---
 
## 사용 방법
 
terraform-mcp EC2에서 아래 명령으로 배포한다.
 
```bash
cd ~/1milion-campaign-orchestration-system && git pull
sudo docker build -t mcp-server:latest ./mcp-server
 
sudo docker run -d \
  --name mcp-server --restart unless-stopped \
  --network monitoring -p 8000:8000 \
  -e SLACK_WEBHOOK_URL="$(aws ssm get-parameter \
    --name /batch-kafka/prod/SLACK_WEBHOOK_URL \
    --with-decryption --query Parameter.Value --output text)" \
  -e BATCH_API_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com" \
  -e BATCH_CAMPAIGN_ID="<캠페인ID>" \
  mcp-server:latest
 
curl http://localhost:8000/health
```
 
배포 후 Claude에서 MCP 연결 시 테스트 종료 직후 `get_test_report(start_minutes_ago=60)`를 호출하면 해당 구간 핵심 메트릭 요약을 즉시 받을 수 있다.
 
---
 
## 설계 원칙
 
AI는 탐지와 설명만 담당하고 실제 조치(스케일 아웃, 재시작 등)는 사람이 판단한다. MCP 도구는 모두 읽기 전용 또는 내부 쿨다운 상태 조작에 한정되며, 인프라에 직접 명령을 내리지 않는다.
 
---
 
## 체크리스트
 
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함
- [x] Phase에 맞는 변경인지 확인 (Phase E)
---
 
closes #61