### PR TITLE
feat: Phase D+E 통합 — Spring Batch 안전망 + MCP 서버 운영 자동화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ infra/terraform.tfstate
 infra/terraform.tfstate.backup
 infra/*.tfvars
 
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+
 # 환경변수 (민감정보)
 .env
 app/campaign-core/.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,11 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 - **원인: Redis Queue 적체 (유입 속도 > Consumer 배출 속도)**
   - Consumer가 Kafka 메시지를 1건씩 DB INSERT → Consumer 처리 병목
   - Kafka lag 누적 → Bridge 배출 속도 제한 → Queue 500K 상한 도달 → 신규 요청 적재 실패
-- **조치 (develop 브랜치, 배포 대기 중)**:
-  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1)
-  - JDBC URL `rewriteBatchedStatements=true` 추가 (SSM 업데이트 필요)
-  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체
+  - RDS CPU는 41%로 여유 있었음 — DB 용량 문제 아닌 순수 패턴 문제
+- **조치 완료 (develop 브랜치, 머지 대기 중)**:
+  - Consumer `jdbcTemplate.batchUpdate()` 배치 INSERT (DB 왕복 N→1) ✅
+  - SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료 ✅
+  - Consumer 건별 INFO 로그 제거 → 배치 단위 요약 로그로 교체 ✅
 
 ---
 
@@ -102,33 +103,18 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 **목표**: Consumer 배치 INSERT 적용 후 100만 트래픽 처리 검증.
 
-### 배포 전 필수 작업
-```bash
-# SSM JDBC URL에 rewriteBatchedStatements=true 추가 (terraform-mcp에서)
-CURRENT_URL=$(aws ssm get-parameter \
-  --name /batch-kafka/prod/SPRING_DATASOURCE_URL \
-  --with-decryption --query Parameter.Value --output text)
-
-if [[ "$CURRENT_URL" == *"rewriteBatchedStatements=true"* ]]; then
-  NEW_URL="$CURRENT_URL"
-elif [[ "$CURRENT_URL" == *"?"* ]]; then
-  NEW_URL="${CURRENT_URL}&rewriteBatchedStatements=true"
-else
-  NEW_URL="${CURRENT_URL}?rewriteBatchedStatements=true"
-fi
-
-aws ssm put-parameter \
-  --name /batch-kafka/prod/SPRING_DATASOURCE_URL \
-  --value "$NEW_URL" --type SecureString --overwrite
-```
+### 배포 전 필수 작업 (모두 완료 ✅)
+- SSM JDBC URL `rewriteBatchedStatements=true` 추가 완료
+- develop 브랜치 배치 INSERT 코드 작성 완료
+- **남은 것: develop → main 머지 → CI/CD 자동 배포**
 
 ### 전체 로드맵
 ```
 [완료] v3 Redis-first, Kafka 3-broker, ElastiCache CME, 8차 테스트 (50만 TPS ~1,220/s)
 [완료] Phase A — ASG Terraform (asg.tf, codedeploy.tf, EC2 SD, min=2 운영 중)
 [완료] 9차 테스트 (ASG 2대, 50만 TPS ~2,014/s)
-[진행] Phase B — Consumer 배치 INSERT 적용 후 100만 테스트
-       → 10만 검증 먼저 (records.size() 분포, Queue slope, Kafka lag 확인)
+[진행] Phase B — develop→main 머지 후 10만 검증 → 100만 테스트
+       → 10만 검증: batch processed 로그에서 polled= 분포 확인
        → 통과 시 100만 테스트
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
@@ -146,7 +132,7 @@ aws ssm put-parameter \
 | VPC | vpc-02bacd8c658dc632e (172.31.0.0/16) |
 | ASG (앱) | batch-kafka-app-asg (t3.small, min=2/max=3, private_app_2a+2b) |
 | EC2 (Kafka) | kafka-1/2/3 (t3.small, public 2a/2b/2c) |
-| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana 실행 중) |
+| EC2 (MCP) | terraform-mcp (t3.small, public_2a, Prometheus+Grafana+redis-exporter 실행 중) |
 | RDS | batch-kafka-db (MySQL 8.0.44, db.t3.micro) |
 | ALB | alb-batch-kafka-api → tg-api-8080 |
 | ElastiCache | CME 3샤드 (Valkey 7.2, cache.t3.micro × 6) |
@@ -155,6 +141,23 @@ aws ssm put-parameter \
 | S3 (tfstate) | campaign-terraform-state-631124976154 |
 | CodeDeploy | App: batch-kafka-app / DG: batch-kafka-prod-dg (ASG 연결, IaC 완료) |
 | SSM | /batch-kafka/prod/* |
+
+---
+
+## 모니터링 구성 (terraform-mcp)
+
+- Prometheus + Grafana + redis-exporter + kafka-exporter 모두 Docker 컨테이너
+- **Docker monitoring 네트워크**: 컨테이너 이름 기반 통신 (IP 변경 무관)
+  ```bash
+  # 컨테이너 재생성 시 네트워크 연결 필수
+  sudo docker network connect monitoring <container>
+  ```
+- **prometheus.yml 타겟** (IP 아닌 컨테이너 이름):
+  - spring-boot: ec2_sd_configs (ASG 동적 감지, :8080)
+  - kafka-exporter: `kafka-exporter:9308`
+  - redis-exporter: `redis-exporter:9121`
+- prometheus.yml 위치: `/home/ec2-user/prometheus.yml`
+- redis-exporter는 terraform-mcp 단독 실행 (ASG 중복 수집 방지)
 
 ---
 
@@ -167,28 +170,48 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 
 ## 인프라 ON/OFF 순서
 
-### 켤 때
+### 켤 때 (ElastiCache destroy 후 재apply 시)
 ```
-1. RDS 시작 (3~5분 대기)
-2. ASG desired=2, min=2, max=3
+1. terraform apply (ElastiCache + SSM 자동 갱신, ~10~15분)
+2. RDS 시작 (3~5분 대기)
 3. kafka-1/2/3 시작
 4. terraform-mcp 시작
-5. terraform-mcp SSM 접속 후 redis-exporter 실행:
+5. terraform-mcp에서 redis-exporter 재실행 (SSM에서 새 엔드포인트 자동 읽음):
+   sudo docker rm -f redis-exporter
    sudo docker run -d --name redis-exporter --restart unless-stopped -p 9121:9121 \
+     --network monitoring \
      -e REDIS_ADDR="$(aws ssm get-parameter --name /batch-kafka/prod/REDIS_EXPORTER_ADDR \
      --with-decryption --query Parameter.Value --output text)" \
      -e REDIS_EXPORTER_IS_CLUSTER=true oliver006/redis_exporter
+   sudo docker network connect monitoring redis-exporter
+6. ASG 콘솔에서 desired=2, min=2, max=3 (terraform apply와 독립)
+```
+
+### 켤 때 (EC2 재시작만, ElastiCache 유지 시)
+```
+1. RDS 시작
+2. kafka-1/2/3 시작
+3. terraform-mcp 시작 (--restart unless-stopped로 컨테이너 자동 복구)
+4. ASG 콘솔에서 desired=2, min=2, max=3
 ```
 
 ### 끌 때
 ```
-1. ASG desired=0, min=0, max=0
+1. ASG 콘솔에서 desired=0, min=0, max=0
 2. kafka-1/2/3 중지
 3. terraform-mcp 중지
 4. RDS 중지
 ```
 
-> ElastiCache는 중지 기능 없음 — 장기 미사용 시 terraform destroy
+### 비용 절감 (장기 미사용)
+```bash
+terraform destroy -target=aws_elasticache_replication_group.redis \
+  -target=aws_ssm_parameter.redis_cluster_nodes \
+  -target=aws_ssm_parameter.redis_exporter_addr
+```
+
+> ElastiCache destroy → apply 시 SSM(SPRING_DATA_REDIS_CLUSTER_NODES, REDIS_EXPORTER_ADDR)은 자동 갱신됨
+> ASG min/max는 ignore_changes로 보호 — terraform apply가 용량을 건드리지 않음
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 ```
 app/campaign-core/     ← Spring Boot 앱 (v3 Redis-first)
 infra/                 ← Terraform IaC
-mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase E, 미작성)
+mcp-server/            ← Python/FastAPI AI 운영 서버 (Phase E, 구현 완료 — 배포 대기)
 stress-test/           ← k6 부하 테스트 스크립트
 .github/workflows/     ← deploy.yml
 ```
@@ -93,6 +93,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | #7 ASG 수평 확장 | ✅ 완료 (2026-04-27, ASG 2대 운영 중) |
 | Spring Batch PENDING 재처리 | 미작성 |
 | 모니터링 #22~#25 | ✅ 완료 (Grafana 13패널, 커스텀 메트릭 4종) |
+| Phase E MCP 서버 (#62~#66) | ✅ 코드 완료 — terraform-mcp 수동 배포 필요 |
 
 ---
 
@@ -109,7 +110,11 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
        - terraform-mcp t3.large (k6 OOM 방지)
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
-[예정] Phase E — MCP 서버 (AI 자율 운영)
+[진행중] Phase E — MCP 서버 (AI 자율 운영)
+       - 코드 완료 (feat/mcp-server 브랜치)
+       - terraform apply -target=aws_iam_role_policy.terraform_mcp_cloudwatch_read 필요
+       - terraform-mcp EC2에서 수동 docker build & run으로 배포
+       - CI/CD 파이프라인 미구성 (mcp-server/** 트리거 없음, 수동 배포)
 ```
 
 ---
@@ -137,7 +142,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 
 ## 모니터링 구성 (terraform-mcp)
 
-- Prometheus + Grafana + redis-exporter + kafka-exporter 모두 Docker 컨테이너
+- Prometheus + Grafana + redis-exporter + kafka-exporter + **mcp-server** 모두 Docker 컨테이너
 - **Docker monitoring 네트워크**: 컨테이너 이름 기반 통신 (IP 변경 무관)
   ```bash
   # 컨테이너 재생성 시 네트워크 연결 필수
@@ -183,7 +188,8 @@ OIDC → ECR → S3 → CodeDeploy (`CodeDeployDefault.OneAtATime`)
 1. RDS 시작
 2. kafka-1/2/3 시작
 3. terraform-mcp 시작 (--restart unless-stopped로 컨테이너 자동 복구)
-4. ASG 콘솔에서 desired=2, min=2, max=3
+4. mcp-server 컨테이너 확인: `sudo docker ps | grep mcp-server` (미실행 시 아래 mcp-server 배포 섹션 참고)
+5. ASG 콘솔에서 desired=2, min=2, max=3
 ```
 
 ### 끌 때
@@ -228,6 +234,42 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 
 ---
 
+## mcp-server 배포 (terraform-mcp에서 수동)
+
+```bash
+# 최초 배포 또는 코드 업데이트 시
+cd ~/1milion-campaign-orchestration-system
+git pull
+
+sudo docker build -t mcp-server:latest ./mcp-server
+
+sudo docker run -d \
+  --name mcp-server \
+  --restart unless-stopped \
+  --network monitoring \
+  -p 8000:8000 \
+  -e SLACK_WEBHOOK_URL="$(aws ssm get-parameter --name /batch-kafka/prod/SLACK_WEBHOOK_URL \
+    --with-decryption --query Parameter.Value --output text)" \
+  -e BATCH_API_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com" \
+  -e BATCH_CAMPAIGN_ID="<캠페인ID>" \
+  mcp-server:latest
+
+# 검증
+curl http://localhost:8000/health
+sudo docker logs mcp-server --follow
+```
+
+MCP 도구 7개 (Claude에서 호출 가능):
+- `get_monitor_status` — cooldown 상태 조회
+- `run_check` — P1/P2/P3 수동 실행
+- `query_prometheus` — PromQL instant 쿼리
+- `query_prometheus_range` — 구간 메트릭 조회 (테스트 후 분석용)
+- `get_test_report` — 테스트 구간 핵심 메트릭 요약
+- `reset_cooldown` — 쿨다운 초기화
+- `trigger_consistency_check` — 정합성 검사 즉시 실행
+
+---
+
 ## 면접 핵심 멘트
 
 **프로젝트 소개**: "Redis Lua로 병목 원인을 찾고 해결한 뒤 재실험으로 검증, 데이터 기반으로 트레이드오프를 결정한 실험 중심 프로젝트. 최종적으로 100만 트래픽, 정합성 1,000,000건, 5xx 0건 달성"
@@ -241,3 +283,5 @@ BASE_URL: `http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.co
 **데이터 유실 발견 및 해결**: "10차 테스트에서 DB 정합성 검증 중 574,888건만 INSERT된 것 발견. Redis Queue 500K 상한 초과 시 LPUSH 실패해도 202 반환하는 구조적 문제. MAX_QUEUE_SIZE 1M으로 상향해 11차에서 정합성 완벽 달성"
 
 **모니터링**: "Prometheus + Grafana 커스텀 메트릭 4종(Bridge 드레인 속도/사이클, Consumer 지연, Redis Queue 적재량). Docker monitoring 네트워크로 컨테이너 이름 기반 DNS — IP 관리 불필요"
+
+**MCP 서버 (Phase E)**: "Grafana 대시보드를 사람이 직접 보던 수동 감시를 자동화. Prometheus/CloudWatch 30초 폴링 → P1/P2/P3 임계값 비교 → Slack 알림. Claude MCP 도구 7개로 운영 중 즉시 쿼리 가능. AI는 탐지와 설명만, 실행은 사람이 판단하는 구조로 설계"

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/ConsistencyRecoveryController.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/ConsistencyRecoveryController.java
@@ -1,0 +1,117 @@
+package io.eventdriven.campaign.api.controller;
+
+import io.eventdriven.campaign.api.common.ApiResponse;
+import io.eventdriven.campaign.api.dto.request.ConsistencyRecoveryRequest;
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/consistency-recovery")
+@RequiredArgsConstructor
+@SuppressWarnings("removal")
+public class ConsistencyRecoveryController {
+
+    @Qualifier("asyncJobLauncher")
+    private final JobLauncher asyncJobLauncher;
+
+    @Qualifier("consistencyRecoveryJob")
+    private final Job consistencyRecoveryJob;
+
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> run(@RequestBody(required = false) ConsistencyRecoveryRequest request) {
+        try {
+            ConsistencyRecoveryRequest effectiveRequest = request != null ? request : new ConsistencyRecoveryRequest();
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.createExecution(
+                    effectiveRequest.getRequestedBy(),
+                    effectiveRequest.getDryRun(),
+                    effectiveRequest.getAutoFix(),
+                    effectiveRequest.getCampaignId(),
+                    effectiveRequest.getMaxCampaigns()
+            );
+
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("consistencyRecoveryExecutionId", execution.getId())
+                    .addLong("ts", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution jobExecution = asyncJobLauncher.run(consistencyRecoveryJob, params);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("jobExecutionId", jobExecution.getId());
+            data.put("consistencyRecoveryExecutionId", execution.getId());
+            data.put("dryRun", execution.isDryRun());
+            data.put("autoFix", execution.isAutoFix());
+            data.put("targetCount", execution.getTargetCount());
+            data.put("maxCampaigns", execution.getMaxCampaigns());
+
+            return ResponseEntity.ok(ApiResponse.success("Consistency recovery batch started", data));
+        } catch (JobExecutionAlreadyRunningException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.fail("Consistency recovery job is already running"));
+        } catch (JobRestartException | JobInstanceAlreadyCompleteException | InvalidJobParametersException e) {
+            log.error("Failed to start consistency recovery job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to start consistency recovery job: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("Unexpected error while starting consistency recovery job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Unexpected error: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions/{executionId}")
+    public ResponseEntity<ApiResponse<?>> getExecution(@PathVariable Long executionId) {
+        try {
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.getExecution(executionId);
+            return ResponseEntity.ok(ApiResponse.success(
+                    consistencyRecoveryService.toExecutionResponse(
+                            execution,
+                            consistencyRecoveryService.getExecutionResults(executionId)
+                    )
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to read consistency recovery execution. executionId={}", executionId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read execution: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions")
+    public ResponseEntity<ApiResponse<?>> getExecutions(
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success(
+                    consistencyRecoveryService.getExecutions(Math.min(size, 100))
+            ));
+        } catch (Exception e) {
+            log.error("Failed to read consistency recovery executions", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read executions: " + e.getMessage()));
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/DlqReplayController.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/controller/DlqReplayController.java
@@ -1,0 +1,125 @@
+package io.eventdriven.campaign.api.controller;
+
+import io.eventdriven.campaign.api.common.ApiResponse;
+import io.eventdriven.campaign.api.dto.request.DlqReplayRequest;
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/dlq-replay")
+@RequiredArgsConstructor
+@SuppressWarnings("removal")
+public class DlqReplayController {
+
+    @Qualifier("asyncJobLauncher")
+    private final JobLauncher asyncJobLauncher;
+
+    @Qualifier("dlqReplayJob")
+    private final Job dlqReplayJob;
+
+    private final DlqReplayService dlqReplayService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> replay(@RequestBody(required = false) DlqReplayRequest request) {
+        try {
+            DlqReplayRequest effectiveRequest = request != null ? request : new DlqReplayRequest();
+            DlqReplayExecution execution = dlqReplayService.createExecution(
+                    effectiveRequest.getRequestedBy(),
+                    effectiveRequest.getDryRun(),
+                    effectiveRequest.getCampaignId(),
+                    effectiveRequest.getReason(),
+                    effectiveRequest.getFromTime(),
+                    effectiveRequest.getToTime(),
+                    effectiveRequest.getMaxItems()
+            );
+
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("replayExecutionId", execution.getId())
+                    .addLong("ts", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution jobExecution = asyncJobLauncher.run(dlqReplayJob, params);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("jobExecutionId", jobExecution.getId());
+            data.put("replayExecutionId", execution.getId());
+            data.put("dryRun", execution.isDryRun());
+            data.put("targetCount", execution.getTargetCount());
+            data.put("maxItems", execution.getMaxItems());
+
+            return ResponseEntity.ok(ApiResponse.success("DLQ replay batch started", data));
+        } catch (JobExecutionAlreadyRunningException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.fail("DLQ replay job is already running"));
+        } catch (JobRestartException | JobInstanceAlreadyCompleteException | InvalidJobParametersException e) {
+            log.error("Failed to start DLQ replay job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to start DLQ replay job: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("Unexpected error while starting DLQ replay job", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Unexpected error: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/executions/{executionId}")
+    public ResponseEntity<ApiResponse<?>> getExecution(@PathVariable Long executionId) {
+        try {
+            DlqReplayExecution execution = dlqReplayService.getExecution(executionId);
+            return ResponseEntity.ok(ApiResponse.success(
+                    dlqReplayService.toExecutionResponse(execution, dlqReplayService.getExecutionItems(executionId))
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to read DLQ replay execution. executionId={}", executionId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read execution: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<ApiResponse<?>> getMessages(
+            @RequestParam(required = false) DlqMessageProcessingStatus status,
+            @RequestParam(required = false) Long campaignId,
+            @RequestParam(required = false) String reason,
+            @RequestParam(defaultValue = "100") int size
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success(
+                    dlqReplayService.searchMessages(status, campaignId, reason, Math.min(size, 500))
+            ));
+        } catch (Exception e) {
+            log.error("Failed to read DLQ messages", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("Failed to read DLQ messages: " + e.getMessage()));
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/ConsistencyRecoveryRequest.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/ConsistencyRecoveryRequest.java
@@ -1,0 +1,14 @@
+package io.eventdriven.campaign.api.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ConsistencyRecoveryRequest {
+    private String requestedBy;
+    private Boolean dryRun;
+    private Boolean autoFix;
+    private Long campaignId;
+    private Integer maxCampaigns;
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/DlqReplayRequest.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/dto/request/DlqReplayRequest.java
@@ -1,0 +1,18 @@
+package io.eventdriven.campaign.api.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class DlqReplayRequest {
+    private String requestedBy;
+    private Boolean dryRun;
+    private Long campaignId;
+    private String reason;
+    private LocalDateTime fromTime;
+    private LocalDateTime toTime;
+    private Integer maxItems;
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -1,6 +1,8 @@
 package io.eventdriven.campaign.application.bridge;
 
+import io.eventdriven.campaign.application.event.DlqEventPayload;
 import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.application.service.DlqMessageService;
 import io.eventdriven.campaign.application.service.RedisStockService;
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.config.KafkaConfig;
@@ -18,66 +20,45 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Redis Queue → Kafka 유량 조절 브릿지 (v2)
- *
- * 역할: API에서 LPUSH된 메시지를 RPOP 후 Kafka로 발행.
- * - active:campaigns Set 순회 → 캠페인별 큐 드레인
- * - MAX_RETRY 3회 + exponential backoff 후 실패 시 DLQ + Slack 알림
- * - RPOP 실패 시 LPUSH 재적재 금지 (Queue 순서 뒤섞임 방지)
- * - 파티션 키: userId (파티션 균등 분산, v3에서 선착순은 Redis DECR 시점에 이미 확정)
- *
- * 주의: @EnableScheduling이 CampaignCoreApplication에 있어야 동작.
- */
 @Slf4j
 @Component
-// @RequiredArgsConstructor 미사용 이유:
-// Timer는 Spring Bean이 아닌 직접 생성 객체(Timer.builder().register())이므로
-// Lombok이 생성자 파라미터로 주입할 수 없음.
-// MeterRegistry(Bean)를 먼저 주입받은 뒤 생성자 안에서 Timer를 직접 만들어야 하므로
-// 생성자를 수동으로 작성함.
 public class ParticipationBridge {
+
+    private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
+    private static final int MAX_RETRY = 3;
 
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final RedisStockService redisStockService;
     private final SlackNotificationService slackNotificationService;
-    private final MeterRegistry meterRegistry;  // Spring Bean → 생성자 주입
+    private final MeterRegistry meterRegistry;
     private final JsonMapper jsonMapper;
-
-    private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
-    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
-    private static final int MAX_RETRY = 3;
-
-    // campaignId별 Counter 캐시
-    // campaignId는 런타임에 결정되므로 생성자에서 미리 만들 수 없음 , 첫 발행 시 lazily 생성 후 재사용
+    private final DlqMessageService dlqMessageService;
+    private final Timer drainTimer;
     private final Map<Long, Counter> publishedCounters = new ConcurrentHashMap<>();
 
-    // Timer는 Bean이 아닌 직접 생성 객체, 생성자에서 MeterRegistry를 받아 초기화
-    private final Timer drainTimer;
-
-    public ParticipationBridge(RedisTemplate<String, String> redisTemplate,
-                               KafkaTemplate<String, String> kafkaTemplate,
-                               RedisStockService redisStockService,
-                               SlackNotificationService slackNotificationService,
-                               MeterRegistry meterRegistry,
-                               JsonMapper jsonMapper) {
+    public ParticipationBridge(
+            RedisTemplate<String, String> redisTemplate,
+            KafkaTemplate<String, String> kafkaTemplate,
+            RedisStockService redisStockService,
+            SlackNotificationService slackNotificationService,
+            MeterRegistry meterRegistry,
+            JsonMapper jsonMapper,
+            DlqMessageService dlqMessageService
+    ) {
         this.redisTemplate = redisTemplate;
         this.kafkaTemplate = kafkaTemplate;
         this.redisStockService = redisStockService;
         this.slackNotificationService = slackNotificationService;
-        this.meterRegistry = meterRegistry;  // 1. Bean 주입 완료
+        this.meterRegistry = meterRegistry;
         this.jsonMapper = jsonMapper;
+        this.dlqMessageService = dlqMessageService;
         this.drainTimer = Timer.builder("bridge.drain.duration")
-                .description("drainQueues() 실행 소요시간")
-                .register(meterRegistry);    // 2. 주입된 MeterRegistry로 Timer 등록
+                .description("Time spent draining Redis queues into Kafka")
+                .register(meterRegistry);
     }
 
-    /**
-     * 100ms마다 실행 (fixedDelay: 이전 실행 완료 후 100ms 대기)
-     * active:campaigns Set에 등록된 캠페인별로 큐 드레인
-     */
     @Scheduled(fixedDelay = 100)
     public void drainQueues() {
         drainTimer.record(() -> {
@@ -90,16 +71,12 @@ public class ParticipationBridge {
                 try {
                     drainCampaignQueue(Long.parseLong(campaignIdStr));
                 } catch (Exception e) {
-                    log.error("캠페인 큐 드레인 중 예외 발생. campaignId={}", campaignIdStr, e);
+                    log.error("Failed to drain campaign queue. campaignId={}", campaignIdStr, e);
                 }
             }
         });
     }
 
-    /**
-     * 단일 캠페인 큐 드레인
-     * 큐 크기에 따라 동적으로 batchSize 결정 후 RPOP → Kafka 발행. 큐가 비면 즉시 종료.
-     */
     private void drainCampaignQueue(Long campaignId) {
         String queueKey = QUEUE_KEY_PREFIX + campaignId;
         Long queueSize = redisTemplate.opsForList().size(queueKey);
@@ -108,11 +85,9 @@ public class ParticipationBridge {
         for (int i = 0; i < dynamicBatchSize; i++) {
             String message = redisTemplate.opsForList().rightPop(queueKey);
             if (message == null) {
-                // 큐가 비었고 active flag도 없으면 재고까지 소진된 캠페인
-                // → Lua가 DEL한 active:campaign:{id}를 확인 후 전역 Set에서도 제거
                 if (!redisStockService.isActive(campaignId)) {
                     redisStockService.deactivateCampaign(campaignId);
-                    log.info("캠페인 {} 재고 소진 + 큐 드레인 완료 → active:campaigns 제거", campaignId);
+                    log.info("Campaign drained and deactivated. campaignId={}", campaignId);
                 }
                 break;
             }
@@ -120,54 +95,45 @@ public class ParticipationBridge {
         }
     }
 
-    /**
-     * 큐 크기 기반 동적 batchSize 결정
-     * 큐 적체량에 비례해 드레인 속도 자동 조절
-     */
     private int resolveBatchSize(Long queueSize) {
-        if (queueSize == null || queueSize < 10_000) return 500;
-        if (queueSize < 100_000) return 1_000;
+        if (queueSize == null || queueSize < 10_000) {
+            return 500;
+        }
+        if (queueSize < 100_000) {
+            return 1_000;
+        }
         return 2_000;
     }
 
-    /**
-     * Kafka 발행 (MAX_RETRY 3회 + exponential backoff)
-     * 최종 실패 시 DLQ 전송 + Slack 알림.
-     * 실패 메시지를 Redis Queue에 재적재하지 않음 (순서 보장 우선).
-     */
     private void publishWithRetry(Long campaignId, String message) {
         String partitionKey = extractUserIdKey(message, campaignId);
         for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
             try {
                 kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
-                // Kafka 발행 성공 카운터 — campaignId 태그로 캠페인별 구분
                 publishedCounters.computeIfAbsent(campaignId, id ->
                         Counter.builder("bridge.messages.published")
-                                .description("Kafka 발행 성공 건수")
+                                .description("Kafka messages published by bridge")
                                 .tag("campaignId", String.valueOf(id))
                                 .register(meterRegistry)
                 ).increment();
-                return; // 성공
+                return;
             } catch (Exception e) {
-                log.warn("Kafka 발행 실패 (시도 {}/{}). campaignId={}", attempt, MAX_RETRY, campaignId, e);
-
+                log.warn("Kafka publish failed. attempt={}/{}, campaignId={}", attempt, MAX_RETRY, campaignId, e);
                 if (attempt < MAX_RETRY) {
-                    long backoffMs = (long) Math.pow(2, attempt) * 100L; // 200ms → 400ms
+                    long backoffMs = (long) Math.pow(2, attempt) * 100L;
                     try {
                         Thread.sleep(backoffMs);
-                    } catch (InterruptedException ie) {
+                    } catch (InterruptedException interruptedException) {
                         Thread.currentThread().interrupt();
-                        log.error("Bridge 스레드 인터럽트. campaignId={}", campaignId);
-                        sendToDlqWithSlack(campaignId, message, "THREAD_INTERRUPTED");
+                        sendToDlqWithSlack(campaignId, partitionKey, message,
+                                "THREAD_INTERRUPTED", interruptedException.getMessage());
                         return;
                     }
                 }
             }
         }
 
-        // MAX_RETRY 모두 소진
-        log.error("Bridge MAX_RETRY({}) 초과. DLQ 전송. campaignId={}", MAX_RETRY, campaignId);
-        sendToDlqWithSlack(campaignId, message, "MAX_RETRY_EXCEEDED");
+        sendToDlqWithSlack(campaignId, partitionKey, message, "MAX_RETRY_EXCEEDED", null);
     }
 
     private String extractUserIdKey(String message, Long campaignId) {
@@ -175,26 +141,35 @@ public class ParticipationBridge {
             ParticipationEvent event = jsonMapper.readValue(message, ParticipationEvent.class);
             return String.valueOf(event.getUserId());
         } catch (Exception e) {
-            log.warn("Kafka key userId 추출 실패. campaignId={} fallback 적용", campaignId);
+            log.warn("Failed to extract userId partition key. campaignId={}", campaignId, e);
             return String.valueOf(campaignId);
         }
     }
 
-    /**
-     * DLQ 전송 + Slack 알림
-     * DLQ 전송 자체 실패 시 로그로만 기록 (무한 루프 방지)
-     */
-    private void sendToDlqWithSlack(Long campaignId, String message, String errorReason) {
+    private void sendToDlqWithSlack(
+            Long campaignId,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
         try {
-            kafkaTemplate.send(DLQ_TOPIC, String.valueOf(campaignId), message);
-            log.info("Bridge DLQ 전송 완료. campaignId={}, reason={}", campaignId, errorReason);
+            DlqEventPayload payload = dlqMessageService.createBridgePayload(
+                    campaignId,
+                    originalKey,
+                    originalMessage,
+                    errorReason,
+                    errorMessage
+            );
+            dlqMessageService.publishAndStore(payload);
+            log.info("Bridge message moved to DLQ. campaignId={}, reason={}", campaignId, errorReason);
         } catch (Exception e) {
-            log.error("CRITICAL: Bridge DLQ 전송도 실패! campaignId={}, message={}", campaignId, message, e);
+            log.error("Failed to move bridge message to DLQ. campaignId={}", campaignId, e);
         }
 
         slackNotificationService.sendDlqAlert(
-                "Bridge Produce " + errorReason,
-                "campaignId=" + campaignId
+                "Bridge " + errorReason,
+                "campaignId=" + campaignId + ", key=" + originalKey
         );
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -18,6 +18,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -26,7 +27,8 @@ public class ParticipationBridge {
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final int MAX_RETRY = 3;
+    private static final String IMMEDIATE_SEND_FAILED = "IMMEDIATE_SEND_FAILED";
+    private static final String ASYNC_SEND_FAILED = "ASYNC_SEND_FAILED";
 
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
@@ -91,7 +93,7 @@ public class ParticipationBridge {
                 }
                 break;
             }
-            publishWithRetry(campaignId, message);
+            publishAsync(campaignId, message);
         }
     }
 
@@ -105,35 +107,43 @@ public class ParticipationBridge {
         return 2_000;
     }
 
-    private void publishWithRetry(Long campaignId, String message) {
+    private void publishAsync(Long campaignId, String message) {
         String partitionKey = extractUserIdKey(message, campaignId);
-        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
-            try {
-                kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message);
-                publishedCounters.computeIfAbsent(campaignId, id ->
-                        Counter.builder("bridge.messages.published")
-                                .description("Kafka messages published by bridge")
-                                .tag("campaignId", String.valueOf(id))
-                                .register(meterRegistry)
-                ).increment();
-                return;
-            } catch (Exception e) {
-                log.warn("Kafka publish failed. attempt={}/{}, campaignId={}", attempt, MAX_RETRY, campaignId, e);
-                if (attempt < MAX_RETRY) {
-                    long backoffMs = (long) Math.pow(2, attempt) * 100L;
-                    try {
-                        Thread.sleep(backoffMs);
-                    } catch (InterruptedException interruptedException) {
-                        Thread.currentThread().interrupt();
-                        sendToDlqWithSlack(campaignId, partitionKey, message,
-                                "THREAD_INTERRUPTED", interruptedException.getMessage());
-                        return;
-                    }
-                }
-            }
-        }
+        try {
+            kafkaTemplate.send(KafkaConfig.TOPIC_NAME, partitionKey, message)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            Throwable failure = unwrapCompletionException(ex);
+                            log.warn("Kafka publish completed with failure. campaignId={}", campaignId, failure);
+                            sendToDlqWithSlack(
+                                    campaignId,
+                                    partitionKey,
+                                    message,
+                                    ASYNC_SEND_FAILED,
+                                    failure.getMessage()
+                            );
+                            return;
+                        }
 
-        sendToDlqWithSlack(campaignId, partitionKey, message, "MAX_RETRY_EXCEEDED", null);
+                        publishedCounters.computeIfAbsent(campaignId, id ->
+                                Counter.builder("bridge.messages.published")
+                                        .description("Kafka messages published by bridge")
+                                        .tag("campaignId", String.valueOf(id))
+                                        .register(meterRegistry)
+                        ).increment();
+                    });
+        } catch (Exception e) {
+            log.warn("Kafka publish failed before enqueue. campaignId={}", campaignId, e);
+            sendToDlqWithSlack(campaignId, partitionKey, message, IMMEDIATE_SEND_FAILED, e.getMessage());
+        }
+    }
+
+    private Throwable unwrapCompletionException(Throwable throwable) {
+        if (throwable instanceof CompletionException completionException
+                && completionException.getCause() != null) {
+            return completionException.getCause();
+        }
+        return throwable;
     }
 
     private String extractUserIdKey(String message, Long campaignId) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -1,6 +1,8 @@
 package io.eventdriven.campaign.application.consumer;
 
+import io.eventdriven.campaign.application.event.DlqEventPayload;
 import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.application.service.DlqMessageService;
 import io.eventdriven.campaign.application.service.SlackNotificationService;
 import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -14,7 +16,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
@@ -22,35 +23,24 @@ import tools.jackson.databind.json.JsonMapper;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-/**
- * 선착순 참여 이벤트 Consumer (v3)
- *
- * v3 역할: API에서 Redis DECR만 하고 DB 미접촉 → Consumer가 DB INSERT SUCCESS 직접 처리
- * - API: RateLimit → DECR → LPUSH → 202 (DB 없음)
- * - Consumer: (campaignId, userId, sequence) → INSERT SUCCESS
- * - 멱등성: UNIQUE(campaign_id, user_id) 제약 → DataIntegrityViolationException 무시
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ParticipationEventConsumer {
 
+    private static final String RESULT_CACHE_PREFIX = "participation:result:";
+    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
+
     private final JsonMapper jsonMapper;
     private final ParticipationHistoryRepository participationHistoryRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final KafkaTemplate<String, String> kafkaTemplate;
     private final RedisTemplate<String, String> redisTemplate;
     private final SlackNotificationService slackNotificationService;
+    private final DlqMessageService dlqMessageService;
     private final MeterRegistry meterRegistry;
-
-    private static final String DLQ_TOPIC = "campaign-participation-topic.dlq";
-    private static final String RESULT_CACHE_PREFIX = "participation:result:";
-    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
 
     @KafkaListener(
             topics = "campaign-participation-topic",
@@ -58,67 +48,67 @@ public class ParticipationEventConsumer {
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeParticipationEvent(List<ConsumerRecord<String, String>> records, Acknowledgment acknowledgment) {
-
-        // ① 메시지 파싱 — sequence 없는 메시지는 Poison Pill로 DLQ
         List<ParticipationEvent> events = parseRecords(records);
-
         if (events.isEmpty()) {
             acknowledgment.acknowledge();
             return;
         }
 
-        // ② DB INSERT SUCCESS 직접 처리 (배치 INSERT → 단건 폴백)
         LocalDateTime batchStart = LocalDateTime.now();
         List<ParticipationEvent> successEvents = new ArrayList<>();
 
         try {
-            // 배치 INSERT IGNORE — 한 번의 JDBC 왕복으로 전체 처리
             List<Object[]> batchArgs = new ArrayList<>(events.size());
             for (ParticipationEvent event : events) {
                 batchArgs.add(new Object[]{event.getCampaignId(), event.getUserId(), event.getSequence()});
             }
             jdbcTemplate.batchUpdate(
-                    "INSERT IGNORE INTO participation_history (campaign_id, user_id, sequence, status, created_at) VALUES (?, ?, ?, 'SUCCESS', NOW())",
+                    "INSERT IGNORE INTO participation_history "
+                            + "(campaign_id, user_id, sequence, status, created_at) "
+                            + "VALUES (?, ?, ?, 'SUCCESS', NOW())",
                     batchArgs
             );
             successEvents.addAll(events);
-
-        } catch (Exception batchEx) {
-            // 배치 실패 시 단건 폴백 (어떤 레코드가 문제인지 파악 + DLQ 전송)
-            log.warn("배치 INSERT 실패 → 단건 폴백. {}건", events.size(), batchEx);
+        } catch (Exception batchException) {
+            log.warn("Batch insert failed. Falling back to row-by-row insert. count={}", events.size(), batchException);
             for (ParticipationEvent event : events) {
                 try {
                     participationHistoryRepository.insertSuccess(
-                            event.getCampaignId(), event.getUserId(), event.getSequence());
+                            event.getCampaignId(),
+                            event.getUserId(),
+                            event.getSequence()
+                    );
                     successEvents.add(event);
                 } catch (DataIntegrityViolationException e) {
-                    log.warn("중복 INSERT 무시 (멱등). campaignId={}, userId={}, sequence={}",
+                    log.warn("Duplicate success ignored. campaignId={}, userId={}, sequence={}",
                             event.getCampaignId(), event.getUserId(), event.getSequence());
                     successEvents.add(event);
                 } catch (Exception e) {
-                    log.error("INSERT 실패 → DLQ. campaignId={}, userId={}, sequence={}",
+                    log.error("Insert failed. campaignId={}, userId={}, sequence={}",
                             event.getCampaignId(), event.getUserId(), event.getSequence(), e);
-                    sendToDlqWithSlack(buildMessageStr(event), "INSERT_FAILED", e);
+                    sendToDlqWithSlack(
+                            String.valueOf(event.getUserId()),
+                            serializeEvent(event),
+                            "INSERT_FAILED",
+                            e
+                    );
                 }
             }
         }
 
-        // ③ 지연시간 측정 (API LPUSH ~ Consumer INSERT 완료)
         long latencyMs = Duration.between(batchStart, LocalDateTime.now()).toMillis();
         Timer.builder("consumer.pending_to_success.latency")
-                .description("API LPUSH ~ Consumer INSERT SUCCESS 지연시간")
+                .description("Time from consumer batch start to DB success insert")
                 .register(meterRegistry)
                 .record(latencyMs, TimeUnit.MILLISECONDS);
 
-        log.info("batch processed. polled={}, parsed={}, success={}, latency_ms={}",
+        log.info("Consumer batch processed. polled={}, parsed={}, success={}, latencyMs={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        // ④ 결과 캐시 적재 (DB 커밋 후)
         if (!successEvents.isEmpty()) {
             writeResultCache(successEvents);
         }
 
-        // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
     }
 
@@ -136,9 +126,8 @@ public class ParticipationEventConsumer {
                     return null;
                 }
             });
-            log.debug("결과 캐시 적재 완료. {}건", events.size());
         } catch (Exception e) {
-            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
+            log.error("Failed to write result cache. count={}", events.size(), e);
         }
     }
 
@@ -148,36 +137,47 @@ public class ParticipationEventConsumer {
             try {
                 ParticipationEvent event = jsonMapper.readValue(record.value(), ParticipationEvent.class);
                 if (event.getSequence() == null) {
-                    log.warn("sequence 없는 메시지 (Poison Pill) - DLQ 전송: {}", record.value());
-                    sendToDlqWithSlack(record.value(), "MISSING_SEQUENCE", null);
+                    log.warn("Missing sequence. Sending to DLQ. payload={}", record.value());
+                    sendToDlqWithSlack(record.key(), record.value(), "MISSING_SEQUENCE", null);
                     continue;
                 }
                 events.add(event);
             } catch (Exception e) {
-                log.error("JSON 파싱 실패 - DLQ 전송: {}", record.value(), e);
-                sendToDlqWithSlack(record.value(), "JSON_PARSE_ERROR", e);
+                log.error("Failed to parse consumer payload. payload={}", record.value(), e);
+                sendToDlqWithSlack(record.key(), record.value(), "JSON_PARSE_ERROR", e);
             }
         }
         return events;
     }
 
-    private void sendToDlqWithSlack(String originalMessage, String errorReason, Exception exception) {
+    private void sendToDlqWithSlack(
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            Exception exception
+    ) {
         try {
-            Map<String, Object> dlqMessage = new HashMap<>();
-            dlqMessage.put("originalMessage", originalMessage);
-            dlqMessage.put("errorReason", errorReason);
-            dlqMessage.put("errorMessage", exception != null ? exception.getMessage() : null);
-            dlqMessage.put("timestamp", LocalDateTime.now().toString());
-            kafkaTemplate.send(DLQ_TOPIC, jsonMapper.writeValueAsString(dlqMessage));
-            log.info("DLQ 전송 완료 - 사유: {}", errorReason);
+            DlqEventPayload payload = dlqMessageService.createConsumerPayload(
+                    originalKey,
+                    originalMessage,
+                    errorReason,
+                    exception != null ? exception.getMessage() : null
+            );
+            dlqMessageService.publishAndStore(payload);
         } catch (Exception e) {
-            log.error("CRITICAL: DLQ 전송 실패! 원본: {}", originalMessage, e);
+            log.error("Failed to publish consumer DLQ payload. reason={}", errorReason, e);
         }
+
         slackNotificationService.sendDlqAlert("Consumer " + errorReason, originalMessage);
     }
 
-    private String buildMessageStr(ParticipationEvent event) {
-        return String.format("{campaignId:%d, userId:%d, sequence:%d}",
-                event.getCampaignId(), event.getUserId(), event.getSequence());
+    private String serializeEvent(ParticipationEvent event) {
+        try {
+            return jsonMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            return "{\"campaignId\":" + event.getCampaignId()
+                    + ",\"userId\":" + event.getUserId()
+                    + ",\"sequence\":" + event.getSequence() + "}";
+        }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -96,6 +96,7 @@ public class ParticipationEventConsumer {
             }
         }
 
+        // ③ 지연시간 측정 (API LPUSH ~ Consumer INSERT 완료)
         long latencyMs = Duration.between(batchStart, LocalDateTime.now()).toMillis();
         Timer.builder("consumer.pending_to_success.latency")
                 .description("Time from consumer batch start to DB success insert")
@@ -105,10 +106,8 @@ public class ParticipationEventConsumer {
         log.info("Consumer batch processed. polled={}, parsed={}, success={}, latencyMs={}",
                 records.size(), events.size(), successEvents.size(), latencyMs);
 
-        if (!successEvents.isEmpty()) {
-            writeResultCache(successEvents);
-        }
 
+        // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
     }
 
@@ -126,8 +125,9 @@ public class ParticipationEventConsumer {
                     return null;
                 }
             });
+            log.debug("결과 캐시 적재 완료. {}건", events.size());
         } catch (Exception e) {
-            log.error("Failed to write result cache. count={}", events.size(), e);
+            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
         }
     }
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -11,9 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -31,13 +28,9 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class ParticipationEventConsumer {
 
-    private static final String RESULT_CACHE_PREFIX = "participation:result:";
-    private static final Duration RESULT_CACHE_TTL = Duration.ofSeconds(300);
-
     private final JsonMapper jsonMapper;
     private final ParticipationHistoryRepository participationHistoryRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final RedisTemplate<String, String> redisTemplate;
     private final SlackNotificationService slackNotificationService;
     private final DlqMessageService dlqMessageService;
     private final MeterRegistry meterRegistry;
@@ -109,26 +102,6 @@ public class ParticipationEventConsumer {
 
         // ⑤ Kafka 오프셋 커밋
         acknowledgment.acknowledge();
-    }
-
-    @SuppressWarnings("unchecked")
-    private void writeResultCache(List<ParticipationEvent> events) {
-        try {
-            redisTemplate.executePipelined(new SessionCallback<Object>() {
-                @Override
-                public <K, V> Object execute(RedisOperations<K, V> operations) {
-                    RedisOperations<String, String> ops = (RedisOperations<String, String>) operations;
-                    for (ParticipationEvent event : events) {
-                        String key = RESULT_CACHE_PREFIX + event.getUserId() + ":" + event.getCampaignId();
-                        ops.opsForValue().set(key, "SUCCESS", RESULT_CACHE_TTL);
-                    }
-                    return null;
-                }
-            });
-            log.debug("결과 캐시 적재 완료. {}건", events.size());
-        } catch (Exception e) {
-            log.error("결과 캐시 적재 실패 (무시 — DB는 이미 SUCCESS). {}건", events.size(), e);
-        }
     }
 
     private List<ParticipationEvent> parseRecords(List<ConsumerRecord<String, String>> records) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/DlqEventPayload.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/event/DlqEventPayload.java
@@ -1,0 +1,108 @@
+package io.eventdriven.campaign.application.event;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.DlqSourceType;
+
+import java.time.LocalDateTime;
+
+public class DlqEventPayload {
+    private DlqSourceType sourceType;
+    private String originalTopic;
+    private String originalKey;
+    private String originalMessage;
+    private String errorReason;
+    private String errorMessage;
+    private Long campaignId;
+    private Long userId;
+    private Long sequence;
+    private DlqReplayClassification replayClassification;
+    private LocalDateTime occurredAt;
+
+    public DlqSourceType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(DlqSourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public String getOriginalTopic() {
+        return originalTopic;
+    }
+
+    public void setOriginalTopic(String originalTopic) {
+        this.originalTopic = originalTopic;
+    }
+
+    public String getOriginalKey() {
+        return originalKey;
+    }
+
+    public void setOriginalKey(String originalKey) {
+        this.originalKey = originalKey;
+    }
+
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    public void setOriginalMessage(String originalMessage) {
+        this.originalMessage = originalMessage;
+    }
+
+    public String getErrorReason() {
+        return errorReason;
+    }
+
+    public void setErrorReason(String errorReason) {
+        this.errorReason = errorReason;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Long getCampaignId() {
+        return campaignId;
+    }
+
+    public void setCampaignId(Long campaignId) {
+        this.campaignId = campaignId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(Long sequence) {
+        this.sequence = sequence;
+    }
+
+    public DlqReplayClassification getReplayClassification() {
+        return replayClassification;
+    }
+
+    public void setReplayClassification(DlqReplayClassification replayClassification) {
+        this.replayClassification = replayClassification;
+    }
+
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(LocalDateTime occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
@@ -1,0 +1,416 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.config.BatchProperties;
+import io.eventdriven.campaign.domain.entity.*;
+import io.eventdriven.campaign.domain.repository.CampaignRepository;
+import io.eventdriven.campaign.domain.repository.ConsistencyRecoveryExecutionRepository;
+import io.eventdriven.campaign.domain.repository.ConsistencyRecoveryResultRepository;
+import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ConsistencyRecoveryService {
+
+    private final CampaignRepository campaignRepository;
+    private final ParticipationHistoryRepository participationHistoryRepository;
+    private final ConsistencyRecoveryExecutionRepository executionRepository;
+    private final ConsistencyRecoveryResultRepository resultRepository;
+    private final RedisStockService redisStockService;
+    private final RedisQueueService redisQueueService;
+    private final BatchProperties batchProperties;
+    private final MeterRegistry meterRegistry;
+
+    @Transactional
+    public ConsistencyRecoveryExecution createExecution(
+            String requestedBy,
+            Boolean dryRun,
+            Boolean autoFix,
+            Long campaignId,
+            Integer maxCampaigns
+    ) {
+        int effectiveMaxCampaigns = maxCampaigns != null && maxCampaigns > 0
+                ? maxCampaigns
+                : batchProperties.getConsistency().getDefaultMaxCampaigns();
+        long targetCount = resolveTargetCount(campaignId, effectiveMaxCampaigns);
+        return executionRepository.save(new ConsistencyRecoveryExecution(
+                normalize(requestedBy),
+                Boolean.TRUE.equals(dryRun),
+                Boolean.TRUE.equals(autoFix),
+                campaignId,
+                effectiveMaxCampaigns,
+                targetCount
+        ));
+    }
+
+    @Transactional
+    public void markRunning(Long executionId) {
+        getExecutionEntity(executionId).markRunning(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void markCompleted(Long executionId) {
+        ConsistencyRecoveryExecution execution = getExecutionEntity(executionId);
+        if (execution.getStatus() != ConsistencyRecoveryExecutionStatus.FAILED) {
+            execution.markCompleted(LocalDateTime.now());
+        }
+    }
+
+    @Transactional
+    public void markFailed(Long executionId) {
+        getExecutionEntity(executionId).markFailed(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void processExecution(Long executionId) {
+        ConsistencyRecoveryExecution execution = getExecutionEntity(executionId);
+        List<Campaign> campaigns = loadTargetCampaigns(execution);
+
+        for (Campaign campaign : campaigns) {
+            inspectCampaign(execution, campaign);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public ConsistencyRecoveryExecution getExecution(Long executionId) {
+        return getExecutionEntity(executionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsistencyRecoveryResult> getExecutionResults(Long executionId) {
+        return resultRepository.findByExecutionIdOrderByIdAsc(executionId, PageRequest.of(0, 200));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsistencyRecoveryExecution> getExecutions(int size) {
+        return executionRepository.findByOrderByIdDesc(PageRequest.of(0, Math.max(1, size)));
+    }
+
+    public Map<String, Object> toExecutionResponse(
+            ConsistencyRecoveryExecution execution,
+            List<ConsistencyRecoveryResult> results
+    ) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("execution", execution);
+        data.put("results", results);
+        return data;
+    }
+
+    private void inspectCampaign(ConsistencyRecoveryExecution execution, Campaign campaign) {
+        long successCount = nvl(participationHistoryRepository.countByCampaignIdAndStatus(
+                campaign.getId(), ParticipationStatus.SUCCESS));
+        long pendingCount = nvl(participationHistoryRepository.countByCampaignIdAndStatus(
+                campaign.getId(), ParticipationStatus.PENDING));
+        Long redisRemainingStock = redisStockService.getStock(campaign.getId());
+        Long redisTotalStock = redisStockService.getTotal(campaign.getId());
+        long queueSize = nvl(redisQueueService.size(campaign.getId()));
+        boolean activeFlagPresent = redisStockService.isActive(campaign.getId());
+        boolean activeSetPresent = redisStockService.isRegisteredInActiveCampaigns(campaign.getId());
+
+        CampaignRuntimeSnapshot snapshot = new CampaignRuntimeSnapshot(
+                campaign,
+                successCount,
+                pendingCount,
+                redisRemainingStock,
+                redisTotalStock,
+                queueSize,
+                activeFlagPresent,
+                activeSetPresent
+        );
+
+        List<AnomalyDecision> decisions = detectAnomalies(snapshot);
+        for (AnomalyDecision decision : decisions) {
+            handleDecision(execution, snapshot, decision);
+        }
+    }
+
+    private List<AnomalyDecision> detectAnomalies(CampaignRuntimeSnapshot snapshot) {
+        List<AnomalyDecision> decisions = new ArrayList<>();
+        long derivedRemaining = snapshot.derivedRemainingStock();
+
+        if (snapshot.successCount() + snapshot.pendingCount() > snapshot.campaign().getTotalStock()) {
+            decisions.add(new AnomalyDecision(
+                    ConsistencyAnomalyType.SUCCESS_PENDING_EXCEEDS_TOTAL,
+                    ConsistencySeverity.CRITICAL,
+                    ConsistencyRecoveryAction.REPORT_ONLY,
+                    false,
+                    "success + pending exceeds totalStock"
+            ));
+        }
+
+        if (snapshot.redisRemainingStock() != null && snapshot.redisRemainingStock() < 0) {
+            decisions.add(new AnomalyDecision(
+                    ConsistencyAnomalyType.NEGATIVE_REDIS_STOCK,
+                    ConsistencySeverity.CRITICAL,
+                    ConsistencyRecoveryAction.REPORT_ONLY,
+                    false,
+                    "Redis remaining stock is negative"
+            ));
+        }
+
+        if (snapshot.campaign().getStatus() == CampaignStatus.OPEN) {
+            boolean safeRestore = snapshot.successCount() + snapshot.pendingCount() <= snapshot.campaign().getTotalStock();
+
+            if (snapshot.redisRemainingStock() == null) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.MISSING_REDIS_STOCK,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.RESTORE_REDIS_STATE,
+                        safeRestore,
+                        "Redis stock key is missing"
+                ));
+            }
+
+            if (snapshot.redisTotalStock() == null) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.MISSING_REDIS_TOTAL,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.RESTORE_REDIS_STATE,
+                        safeRestore,
+                        "Redis total key is missing"
+                ));
+            }
+
+            if (snapshot.redisRemainingStock() != null
+                    && safeRestore
+                    && snapshot.redisRemainingStock() != derivedRemaining) {
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.REDIS_REMAINING_MISMATCH,
+                        ConsistencySeverity.CRITICAL,
+                        ConsistencyRecoveryAction.REPORT_ONLY,
+                        false,
+                        "Redis remaining stock does not match DB-derived remaining stock"
+                ));
+            }
+
+            boolean shouldBeActive = derivedRemaining > 0 || snapshot.queueSize() > 0;
+            if (shouldBeActive && (!snapshot.activeFlagPresent() || !snapshot.activeSetPresent())) {
+                decisions.add(new AnomalyDecision(
+                        snapshot.queueSize() > 0
+                                ? ConsistencyAnomalyType.QUEUE_WITHOUT_ACTIVE_STATE
+                                : ConsistencyAnomalyType.MISSING_ACTIVE_STATE,
+                        ConsistencySeverity.WARNING,
+                        ConsistencyRecoveryAction.ACTIVATE_CAMPAIGN,
+                        true,
+                        "Open campaign is not fully active in Redis"
+                ));
+            }
+        }
+
+        if (snapshot.campaign().getStatus() == CampaignStatus.CLOSED) {
+            boolean hasRedisResidue = snapshot.redisRemainingStock() != null
+                    || snapshot.redisTotalStock() != null
+                    || snapshot.activeFlagPresent()
+                    || snapshot.activeSetPresent();
+
+            if (hasRedisResidue) {
+                boolean safeCleanup = snapshot.queueSize() == 0;
+                decisions.add(new AnomalyDecision(
+                        ConsistencyAnomalyType.CLOSED_REDIS_RESIDUE,
+                        safeCleanup ? ConsistencySeverity.WARNING : ConsistencySeverity.CRITICAL,
+                        safeCleanup ? ConsistencyRecoveryAction.CLEANUP_REDIS_STATE : ConsistencyRecoveryAction.REPORT_ONLY,
+                        safeCleanup,
+                        safeCleanup
+                                ? "Closed campaign still has Redis runtime state"
+                                : "Closed campaign has Redis runtime state and queued messages"
+                ));
+            }
+        }
+
+        return decisions;
+    }
+
+    private void handleDecision(
+            ConsistencyRecoveryExecution execution,
+            CampaignRuntimeSnapshot snapshot,
+            AnomalyDecision decision
+    ) {
+        boolean fixed = false;
+        ConsistencyRecoveryAction actionTaken = decision.action();
+        String detailMessage = decision.detail();
+
+        if (execution.isDryRun()) {
+            actionTaken = decision.action() == ConsistencyRecoveryAction.NONE
+                    ? ConsistencyRecoveryAction.NONE
+                    : ConsistencyRecoveryAction.REPORT_ONLY;
+            detailMessage = "Dry run: " + detailMessage;
+        } else if (!execution.isAutoFix() || !decision.fixable()) {
+            if (decision.action() != ConsistencyRecoveryAction.REPORT_ONLY
+                    && decision.action() != ConsistencyRecoveryAction.NONE) {
+                actionTaken = ConsistencyRecoveryAction.REPORT_ONLY;
+                detailMessage = detailMessage + " (auto-fix not applied)";
+            }
+        } else {
+            fixed = applyFix(snapshot, decision.action());
+            if (!fixed && decision.action() != ConsistencyRecoveryAction.REPORT_ONLY) {
+                actionTaken = ConsistencyRecoveryAction.REPORT_ONLY;
+                detailMessage = detailMessage + " (auto-fix failed)";
+            }
+        }
+
+        execution.incrementAnomalyCount();
+        if (fixed) {
+            execution.incrementFixedCount();
+            fixedCounter(decision.anomalyType()).increment();
+        } else {
+            execution.incrementReportOnlyCount();
+            anomalyCounter(decision.anomalyType()).increment();
+        }
+
+        resultRepository.save(new ConsistencyRecoveryResult(
+                execution,
+                snapshot.campaign().getId(),
+                snapshot.campaign().getStatus(),
+                snapshot.campaign().getTotalStock(),
+                snapshot.successCount(),
+                snapshot.pendingCount(),
+                snapshot.redisRemainingStock(),
+                snapshot.redisTotalStock(),
+                snapshot.queueSize(),
+                snapshot.activeFlagPresent(),
+                snapshot.activeSetPresent(),
+                decision.anomalyType(),
+                decision.severity(),
+                actionTaken,
+                fixed,
+                detailMessage,
+                LocalDateTime.now()
+        ));
+    }
+
+    private boolean applyFix(CampaignRuntimeSnapshot snapshot, ConsistencyRecoveryAction action) {
+        try {
+            return switch (action) {
+                case RESTORE_REDIS_STATE -> restoreRedisState(snapshot);
+                case ACTIVATE_CAMPAIGN -> activateCampaign(snapshot);
+                case CLEANUP_REDIS_STATE -> cleanupRedisState(snapshot);
+                case REPORT_ONLY, NONE -> false;
+            };
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean restoreRedisState(CampaignRuntimeSnapshot snapshot) {
+        long remaining = snapshot.derivedRemainingStock();
+        redisStockService.initializeStock(snapshot.campaign().getId(), remaining);
+        redisStockService.initializeTotal(snapshot.campaign().getId(), snapshot.campaign().getTotalStock());
+        if (remaining > 0 || snapshot.queueSize() > 0) {
+            redisStockService.activateCampaign(snapshot.campaign().getId());
+        }
+        return true;
+    }
+
+    private boolean activateCampaign(CampaignRuntimeSnapshot snapshot) {
+        redisStockService.activateCampaign(snapshot.campaign().getId());
+        return true;
+    }
+
+    private boolean cleanupRedisState(CampaignRuntimeSnapshot snapshot) {
+        redisStockService.clearRuntimeState(snapshot.campaign().getId());
+        return true;
+    }
+
+    private List<Campaign> loadTargetCampaigns(ConsistencyRecoveryExecution execution) {
+        if (execution.getFilterCampaignId() != null) {
+            return campaignRepository.findById(execution.getFilterCampaignId())
+                    .map(List::of)
+                    .orElseGet(List::of);
+        }
+
+        int remaining = execution.getMaxCampaigns();
+        int pageSize = Math.max(1, batchProperties.getConsistency().getPageSize());
+        int page = 0;
+        List<Campaign> campaigns = new ArrayList<>();
+
+        while (remaining > 0) {
+            Page<Campaign> result = campaignRepository.findAll(PageRequest.of(
+                    page,
+                    Math.min(pageSize, remaining),
+                    Sort.by(Sort.Direction.ASC, "id")
+            ));
+            if (result.isEmpty()) {
+                break;
+            }
+            campaigns.addAll(result.getContent());
+            remaining = execution.getMaxCampaigns() - campaigns.size();
+            page++;
+        }
+
+        return campaigns;
+    }
+
+    private long resolveTargetCount(Long campaignId, int maxCampaigns) {
+        if (campaignId != null) {
+            return campaignRepository.existsById(campaignId) ? 1L : 0L;
+        }
+        return Math.min(campaignRepository.count(), maxCampaigns);
+    }
+
+    private ConsistencyRecoveryExecution getExecutionEntity(Long executionId) {
+        return executionRepository.findById(executionId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Consistency recovery execution not found: " + executionId
+                ));
+    }
+
+    private long nvl(Long value) {
+        return value == null ? 0L : value;
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    private Counter anomalyCounter(ConsistencyAnomalyType anomalyType) {
+        return Counter.builder("batch.consistency_recovery.anomaly")
+                .tag("type", anomalyType.name())
+                .register(meterRegistry);
+    }
+
+    private Counter fixedCounter(ConsistencyAnomalyType anomalyType) {
+        return Counter.builder("batch.consistency_recovery.fixed")
+                .tag("type", anomalyType.name())
+                .register(meterRegistry);
+    }
+
+    private record CampaignRuntimeSnapshot(
+            Campaign campaign,
+            long successCount,
+            long pendingCount,
+            Long redisRemainingStock,
+            Long redisTotalStock,
+            long queueSize,
+            boolean activeFlagPresent,
+            boolean activeSetPresent
+    ) {
+        private long derivedRemainingStock() {
+            return Math.max(campaign.getTotalStock() - successCount - pendingCount, 0L);
+        }
+    }
+
+    private record AnomalyDecision(
+            ConsistencyAnomalyType anomalyType,
+            ConsistencySeverity severity,
+            ConsistencyRecoveryAction action,
+            boolean fixable,
+            String detail
+    ) {
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ConsistencyRecoveryService.java
@@ -9,6 +9,7 @@ import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -21,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConsistencyRecoveryService {
@@ -238,6 +240,7 @@ public class ConsistencyRecoveryService {
             CampaignRuntimeSnapshot snapshot,
             AnomalyDecision decision
     ) {
+        Map<String, Object> beforeState = snapshotState(snapshot);
         boolean fixed = false;
         ConsistencyRecoveryAction actionTaken = decision.action();
         String detailMessage = decision.detail();
@@ -261,6 +264,10 @@ public class ConsistencyRecoveryService {
             }
         }
 
+        Map<String, Object> afterState = fixed
+                ? refreshRuntimeState(snapshot.campaign().getId(), snapshot)
+                : beforeState;
+
         execution.incrementAnomalyCount();
         if (fixed) {
             execution.incrementFixedCount();
@@ -269,6 +276,19 @@ public class ConsistencyRecoveryService {
             execution.incrementReportOnlyCount();
             anomalyCounter(decision.anomalyType()).increment();
         }
+
+        log.info(
+                "Consistency recovery decision. executionId={}, campaignId={}, anomalyType={}, requestedAction={}, actionTaken={}, fixed={}, before={}, after={}, detail={}",
+                execution.getId(),
+                snapshot.campaign().getId(),
+                decision.anomalyType(),
+                decision.action(),
+                actionTaken,
+                fixed,
+                beforeState,
+                afterState,
+                detailMessage
+        );
 
         resultRepository.save(new ConsistencyRecoveryResult(
                 execution,
@@ -388,6 +408,36 @@ public class ConsistencyRecoveryService {
         return Counter.builder("batch.consistency_recovery.fixed")
                 .tag("type", anomalyType.name())
                 .register(meterRegistry);
+    }
+
+    private Map<String, Object> snapshotState(CampaignRuntimeSnapshot snapshot) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("campaignStatus", snapshot.campaign().getStatus());
+        state.put("totalStock", snapshot.campaign().getTotalStock());
+        state.put("successCount", snapshot.successCount());
+        state.put("pendingCount", snapshot.pendingCount());
+        state.put("derivedRemainingStock", snapshot.derivedRemainingStock());
+        state.put("redisRemainingStock", snapshot.redisRemainingStock());
+        state.put("redisTotalStock", snapshot.redisTotalStock());
+        state.put("queueSize", snapshot.queueSize());
+        state.put("activeFlagPresent", snapshot.activeFlagPresent());
+        state.put("activeSetPresent", snapshot.activeSetPresent());
+        return state;
+    }
+
+    private Map<String, Object> refreshRuntimeState(Long campaignId, CampaignRuntimeSnapshot snapshot) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("campaignStatus", snapshot.campaign().getStatus());
+        state.put("totalStock", snapshot.campaign().getTotalStock());
+        state.put("successCount", snapshot.successCount());
+        state.put("pendingCount", snapshot.pendingCount());
+        state.put("derivedRemainingStock", snapshot.derivedRemainingStock());
+        state.put("redisRemainingStock", redisStockService.getStock(campaignId));
+        state.put("redisTotalStock", redisStockService.getTotal(campaignId));
+        state.put("queueSize", nvl(redisQueueService.size(campaignId)));
+        state.put("activeFlagPresent", redisStockService.isActive(campaignId));
+        state.put("activeSetPresent", redisStockService.isRegisteredInActiveCampaigns(campaignId));
+        return state;
     }
 
     private record CampaignRuntimeSnapshot(

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqMessageService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqMessageService.java
@@ -1,0 +1,134 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.application.event.DlqEventPayload;
+import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.config.KafkaConfig;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.DlqSourceType;
+import io.eventdriven.campaign.domain.repository.DlqMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DlqMessageService {
+
+    public static final String DLQ_TOPIC = KafkaConfig.TOPIC_NAME + ".dlq";
+
+    private final DlqMessageRepository dlqMessageRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final tools.jackson.databind.json.JsonMapper jsonMapper;
+
+    public DlqEventPayload createBridgePayload(
+            Long fallbackCampaignId,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
+        ParticipationEvent event = tryParseParticipationEvent(originalMessage);
+        DlqEventPayload payload = new DlqEventPayload();
+        payload.setSourceType(DlqSourceType.BRIDGE);
+        payload.setOriginalTopic(KafkaConfig.TOPIC_NAME);
+        payload.setOriginalKey(originalKey);
+        payload.setOriginalMessage(originalMessage);
+        payload.setErrorReason(errorReason);
+        payload.setErrorMessage(errorMessage);
+        payload.setCampaignId(event != null && event.getCampaignId() != null ? event.getCampaignId() : fallbackCampaignId);
+        payload.setUserId(event != null ? event.getUserId() : null);
+        payload.setSequence(event != null ? event.getSequence() : null);
+        payload.setReplayClassification(resolveBridgeClassification(event));
+        payload.setOccurredAt(LocalDateTime.now());
+        return payload;
+    }
+
+    public DlqEventPayload createConsumerPayload(
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage
+    ) {
+        ParticipationEvent event = tryParseParticipationEvent(originalMessage);
+        DlqEventPayload payload = new DlqEventPayload();
+        payload.setSourceType(DlqSourceType.CONSUMER);
+        payload.setOriginalTopic(KafkaConfig.TOPIC_NAME);
+        payload.setOriginalKey(originalKey);
+        payload.setOriginalMessage(originalMessage);
+        payload.setErrorReason(errorReason);
+        payload.setErrorMessage(errorMessage);
+        payload.setCampaignId(event != null ? event.getCampaignId() : null);
+        payload.setUserId(event != null ? event.getUserId() : null);
+        payload.setSequence(event != null ? event.getSequence() : null);
+        payload.setReplayClassification(resolveConsumerClassification(errorReason, event));
+        payload.setOccurredAt(LocalDateTime.now());
+        return payload;
+    }
+
+    @Transactional
+    public void publishAndStore(DlqEventPayload payload) {
+        saveDlqMessage(payload);
+        publishDlqEvent(payload);
+    }
+
+    private DlqReplayClassification resolveBridgeClassification(ParticipationEvent event) {
+        if (event == null || event.getCampaignId() == null || event.getUserId() == null || event.getSequence() == null) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        return DlqReplayClassification.REPLAYABLE;
+    }
+
+    private DlqReplayClassification resolveConsumerClassification(String errorReason, ParticipationEvent event) {
+        if ("JSON_PARSE_ERROR".equals(errorReason) || "MISSING_SEQUENCE".equals(errorReason)) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        if (event == null || event.getCampaignId() == null || event.getUserId() == null || event.getSequence() == null) {
+            return DlqReplayClassification.NON_REPLAYABLE;
+        }
+        return DlqReplayClassification.CONDITIONALLY_REPLAYABLE;
+    }
+
+    private ParticipationEvent tryParseParticipationEvent(String originalMessage) {
+        try {
+            return jsonMapper.readValue(originalMessage, ParticipationEvent.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void saveDlqMessage(DlqEventPayload payload) {
+        try {
+            dlqMessageRepository.save(new DlqMessageRecord(
+                    payload.getSourceType(),
+                    payload.getOriginalTopic(),
+                    payload.getOriginalKey(),
+                    payload.getOriginalMessage(),
+                    payload.getErrorReason(),
+                    payload.getErrorMessage(),
+                    payload.getCampaignId(),
+                    payload.getUserId(),
+                    payload.getSequence(),
+                    payload.getReplayClassification()
+            ));
+        } catch (Exception e) {
+            log.error("Failed to persist DLQ message. sourceType={}, reason={}",
+                    payload.getSourceType(), payload.getErrorReason(), e);
+        }
+    }
+
+    private void publishDlqEvent(DlqEventPayload payload) {
+        try {
+            String message = jsonMapper.writeValueAsString(payload);
+            kafkaTemplate.send(DLQ_TOPIC, payload.getOriginalKey(), message);
+        } catch (Exception e) {
+            log.error("Failed to publish DLQ event. sourceType={}, reason={}",
+                    payload.getSourceType(), payload.getErrorReason(), e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayPolicyService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayPolicyService.java
@@ -1,0 +1,71 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.application.event.ParticipationEvent;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayAction;
+import io.eventdriven.campaign.domain.entity.DlqReplayClassification;
+import io.eventdriven.campaign.domain.entity.ParticipationStatus;
+import io.eventdriven.campaign.domain.repository.CampaignRepository;
+import io.eventdriven.campaign.domain.repository.ParticipationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DlqReplayPolicyService {
+
+    private final CampaignRepository campaignRepository;
+    private final ParticipationHistoryRepository participationHistoryRepository;
+    private final tools.jackson.databind.json.JsonMapper jsonMapper;
+
+    public DlqReplayDecision decide(DlqMessageRecord message) {
+        if (message.getReplayClassification() == DlqReplayClassification.NON_REPLAYABLE) {
+            return DlqReplayDecision.finalFail("NON_REPLAYABLE", "Payload is not safe to replay");
+        }
+
+        Long campaignId = message.getCampaignId();
+        Long userId = message.getUserId();
+        Long sequence = message.getSequence();
+
+        if (campaignId == null || userId == null || sequence == null) {
+            return DlqReplayDecision.finalFail("MISSING_REQUIRED_FIELDS", "campaignId/userId/sequence must exist");
+        }
+
+        if (campaignRepository.findById(campaignId).isEmpty()) {
+            return DlqReplayDecision.finalFail("CAMPAIGN_NOT_FOUND", "Campaign does not exist");
+        }
+
+        if (participationHistoryRepository.existsSuccessHistory(
+                campaignId, userId, ParticipationStatus.SUCCESS)) {
+            return DlqReplayDecision.skip("ALREADY_SUCCESS", "Participation already succeeded");
+        }
+
+        try {
+            String replayPayload = jsonMapper.writeValueAsString(new ParticipationEvent(campaignId, userId, sequence));
+            return DlqReplayDecision.replay(String.valueOf(userId), replayPayload,
+                    "REPLAYABLE", "Replay to main participation topic");
+        } catch (Exception e) {
+            return DlqReplayDecision.finalFail("SERIALIZATION_FAILED", e.getMessage());
+        }
+    }
+
+    public record DlqReplayDecision(
+            DlqReplayAction action,
+            String reason,
+            String detail,
+            String replayKey,
+            String replayPayload
+    ) {
+        public static DlqReplayDecision replay(String replayKey, String replayPayload, String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.REPLAY, reason, detail, replayKey, replayPayload);
+        }
+
+        public static DlqReplayDecision skip(String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.SKIP, reason, detail, null, null);
+        }
+
+        public static DlqReplayDecision finalFail(String reason, String detail) {
+            return new DlqReplayDecision(DlqReplayAction.FINAL_FAIL, reason, detail, null, null);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
@@ -15,6 +15,7 @@ import io.eventdriven.campaign.domain.repository.DlqReplayExecutionRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DlqReplayService {
@@ -169,11 +171,33 @@ public class DlqReplayService {
         DlqReplayPolicyService.DlqReplayDecision decision = dlqReplayPolicyService.decide(message);
         LocalDateTime now = LocalDateTime.now();
 
+        log.info(
+                "DLQ replay decision. executionId={}, messageId={}, classification={}, action={}, publishKey={}, reason={}, detail={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                decision.reason(),
+                decision.detail()
+        );
+
         if (execution.isDryRun()) {
             recordItem(execution, message, decision, DlqReplayItemResult.DRY_RUN,
                     "Dry run only: " + decision.detail());
             incrementExecutionCounter(execution, decision.action());
             counterFor(decision.action(), true).increment();
+            log.info(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.DRY_RUN,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount()
+            );
             return;
         }
 
@@ -205,6 +229,17 @@ public class DlqReplayService {
                     now
             ));
             counterFor(DlqReplayAction.REPLAY, false).increment();
+            log.info(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.SUCCESS,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount()
+            );
         } catch (Exception e) {
             message.incrementReplayAttempt();
             execution.incrementPublishFailed();
@@ -218,6 +253,18 @@ public class DlqReplayService {
                     now
             ));
             counterForFailure().increment();
+            log.warn(
+                    "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}, error={}",
+                    execution.getId(),
+                    message.getId(),
+                    message.getReplayClassification(),
+                    decision.action(),
+                    decision.replayKey(),
+                    DlqReplayItemResult.FAILED,
+                    message.getProcessingStatus(),
+                    message.getReplayAttemptCount(),
+                    e.getMessage()
+            );
         }
     }
 
@@ -231,6 +278,17 @@ public class DlqReplayService {
         execution.incrementSkipped();
         recordItem(execution, message, decision, DlqReplayItemResult.SKIPPED, decision.detail());
         counterFor(DlqReplayAction.SKIP, false).increment();
+        log.info(
+                "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                DlqReplayItemResult.SKIPPED,
+                message.getProcessingStatus(),
+                message.getReplayAttemptCount()
+        );
     }
 
     private void finalFail(
@@ -243,6 +301,17 @@ public class DlqReplayService {
         execution.incrementFinalFailed();
         recordItem(execution, message, decision, DlqReplayItemResult.FINAL_FAILED, decision.detail());
         counterFor(DlqReplayAction.FINAL_FAIL, false).increment();
+        log.info(
+                "DLQ replay result. executionId={}, messageId={}, classification={}, action={}, publishKey={}, result={}, processingStatus={}, replayAttempts={}",
+                execution.getId(),
+                message.getId(),
+                message.getReplayClassification(),
+                decision.action(),
+                decision.replayKey(),
+                DlqReplayItemResult.FINAL_FAILED,
+                message.getProcessingStatus(),
+                message.getReplayAttemptCount()
+        );
     }
 
     private void recordItem(

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/DlqReplayService.java
@@ -1,0 +1,301 @@
+package io.eventdriven.campaign.application.service;
+
+import io.eventdriven.campaign.config.BatchProperties;
+import io.eventdriven.campaign.config.KafkaConfig;
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import io.eventdriven.campaign.domain.entity.DlqReplayAction;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionItem;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionStatus;
+import io.eventdriven.campaign.domain.entity.DlqReplayItemResult;
+import io.eventdriven.campaign.domain.repository.DlqMessageRepository;
+import io.eventdriven.campaign.domain.repository.DlqReplayExecutionItemRepository;
+import io.eventdriven.campaign.domain.repository.DlqReplayExecutionRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class DlqReplayService {
+
+    private final DlqMessageRepository dlqMessageRepository;
+    private final DlqReplayExecutionRepository dlqReplayExecutionRepository;
+    private final DlqReplayExecutionItemRepository dlqReplayExecutionItemRepository;
+    private final DlqReplayPolicyService dlqReplayPolicyService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final BatchProperties batchProperties;
+    private final MeterRegistry meterRegistry;
+
+    @Transactional
+    public DlqReplayExecution createExecution(
+            String requestedBy,
+            Boolean dryRun,
+            Long campaignId,
+            String reason,
+            LocalDateTime fromTime,
+            LocalDateTime toTime,
+            Integer maxItems
+    ) {
+        int effectiveMaxItems = maxItems != null && maxItems > 0
+                ? maxItems
+                : batchProperties.getReplay().getDefaultMaxItems();
+        long targetCount = dlqMessageRepository.countReplayCandidates(
+                DlqMessageProcessingStatus.PENDING,
+                campaignId,
+                normalize(reason),
+                fromTime,
+                toTime
+        );
+        DlqReplayExecution execution = new DlqReplayExecution(
+                normalize(requestedBy),
+                Boolean.TRUE.equals(dryRun),
+                campaignId,
+                normalize(reason),
+                fromTime,
+                toTime,
+                effectiveMaxItems,
+                Math.min(targetCount, effectiveMaxItems)
+        );
+        return dlqReplayExecutionRepository.save(execution);
+    }
+
+    @Transactional
+    public void markRunning(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        execution.markRunning(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void markCompleted(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        if (execution.getStatus() != DlqReplayExecutionStatus.FAILED) {
+            execution.markCompleted(LocalDateTime.now());
+        }
+    }
+
+    @Transactional
+    public void markFailed(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        execution.markFailed(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void processExecution(Long executionId) {
+        DlqReplayExecution execution = getExecutionEntity(executionId);
+        int pageSize = Math.max(1, batchProperties.getReplay().getPageSize());
+        int remaining = execution.getMaxItems();
+        long afterId = 0L;
+        Set<Long> processedIds = new HashSet<>();
+
+        while (remaining > 0) {
+            List<DlqMessageRecord> candidates = dlqMessageRepository.findReplayCandidates(
+                    DlqMessageProcessingStatus.PENDING,
+                    afterId,
+                    execution.getFilterCampaignId(),
+                    execution.getFilterReason(),
+                    execution.getFilterFromTime(),
+                    execution.getFilterToTime(),
+                    PageRequest.of(0, Math.min(pageSize, remaining))
+            );
+
+            if (candidates.isEmpty()) {
+                return;
+            }
+
+            for (DlqMessageRecord candidate : candidates) {
+                afterId = candidate.getId();
+                if (!processedIds.add(candidate.getId())) {
+                    continue;
+                }
+                processSingleMessage(execution, candidate);
+                remaining--;
+                if (remaining == 0) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public DlqReplayExecution getExecution(Long executionId) {
+        return getExecutionEntity(executionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DlqReplayExecutionItem> getExecutionItems(Long executionId) {
+        return dlqReplayExecutionItemRepository.findByExecutionIdOrderByIdAsc(
+                executionId,
+                PageRequest.of(0, 100)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<DlqMessageRecord> searchMessages(
+            DlqMessageProcessingStatus status,
+            Long campaignId,
+            String reason,
+            int size
+    ) {
+        int safeSize = Math.max(1, size);
+        return dlqMessageRepository.searchMessages(
+                status,
+                campaignId,
+                normalize(reason),
+                PageRequest.of(0, safeSize)
+        );
+    }
+
+    public Map<String, Object> toExecutionResponse(DlqReplayExecution execution, List<DlqReplayExecutionItem> items) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("execution", execution);
+        data.put("items", items);
+        return data;
+    }
+
+    private void processSingleMessage(DlqReplayExecution execution, DlqMessageRecord message) {
+        DlqReplayPolicyService.DlqReplayDecision decision = dlqReplayPolicyService.decide(message);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (execution.isDryRun()) {
+            recordItem(execution, message, decision, DlqReplayItemResult.DRY_RUN,
+                    "Dry run only: " + decision.detail());
+            incrementExecutionCounter(execution, decision.action());
+            counterFor(decision.action(), true).increment();
+            return;
+        }
+
+        switch (decision.action()) {
+            case REPLAY -> replay(execution, message, decision, now);
+            case SKIP -> skip(execution, message, decision, now);
+            case FINAL_FAIL -> finalFail(execution, message, decision, now);
+        }
+    }
+
+    private void replay(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        try {
+            kafkaTemplate.send(KafkaConfig.TOPIC_NAME, decision.replayKey(), decision.replayPayload()).get();
+            message.incrementReplayAttempt();
+            message.markReplayed(now);
+            execution.incrementReplayed();
+            dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                    execution,
+                    message,
+                    decision.reason(),
+                    DlqReplayAction.REPLAY,
+                    DlqReplayItemResult.SUCCESS,
+                    decision.detail(),
+                    now
+            ));
+            counterFor(DlqReplayAction.REPLAY, false).increment();
+        } catch (Exception e) {
+            message.incrementReplayAttempt();
+            execution.incrementPublishFailed();
+            dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                    execution,
+                    message,
+                    decision.reason(),
+                    DlqReplayAction.REPLAY,
+                    DlqReplayItemResult.FAILED,
+                    e.getMessage(),
+                    now
+            ));
+            counterForFailure().increment();
+        }
+    }
+
+    private void skip(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        message.markSkipped(decision.reason());
+        execution.incrementSkipped();
+        recordItem(execution, message, decision, DlqReplayItemResult.SKIPPED, decision.detail());
+        counterFor(DlqReplayAction.SKIP, false).increment();
+    }
+
+    private void finalFail(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            LocalDateTime now
+    ) {
+        message.markFinalFailed(decision.reason());
+        execution.incrementFinalFailed();
+        recordItem(execution, message, decision, DlqReplayItemResult.FINAL_FAILED, decision.detail());
+        counterFor(DlqReplayAction.FINAL_FAIL, false).increment();
+    }
+
+    private void recordItem(
+            DlqReplayExecution execution,
+            DlqMessageRecord message,
+            DlqReplayPolicyService.DlqReplayDecision decision,
+            DlqReplayItemResult result,
+            String detail
+    ) {
+        dlqReplayExecutionItemRepository.save(new DlqReplayExecutionItem(
+                execution,
+                message,
+                decision.reason(),
+                decision.action(),
+                result,
+                detail,
+                LocalDateTime.now()
+        ));
+    }
+
+    private void incrementExecutionCounter(DlqReplayExecution execution, DlqReplayAction action) {
+        switch (action) {
+            case REPLAY -> execution.incrementReplayed();
+            case SKIP -> execution.incrementSkipped();
+            case FINAL_FAIL -> execution.incrementFinalFailed();
+        }
+    }
+
+    private Counter counterFor(DlqReplayAction action, boolean dryRun) {
+        String suffix = switch (action) {
+            case REPLAY -> "replayed";
+            case SKIP -> "skipped";
+            case FINAL_FAIL -> "final_failed";
+        };
+        return Counter.builder("batch.dlq_replay." + suffix)
+                .tag("dryRun", String.valueOf(dryRun))
+                .register(meterRegistry);
+    }
+
+    private Counter counterForFailure() {
+        return Counter.builder("batch.dlq_replay.publish_failed")
+                .register(meterRegistry);
+    }
+
+    private DlqReplayExecution getExecutionEntity(Long executionId) {
+        return dlqReplayExecutionRepository.findById(executionId)
+                .orElseThrow(() -> new IllegalArgumentException("DLQ replay execution not found: " + executionId));
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
@@ -87,6 +87,31 @@ public class RedisStockService {
         redisTemplate.opsForValue().set(getTotalKey(campaignId), String.valueOf(totalStock));
     }
 
+    public Long getTotal(Long campaignId) {
+        String total = redisTemplate.opsForValue().get(getTotalKey(campaignId));
+        return total != null ? Long.parseLong(total) : null;
+    }
+
+    public boolean hasTotal(Long campaignId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(getTotalKey(campaignId)));
+    }
+
+    public boolean isRegisteredInActiveCampaigns(Long campaignId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(ACTIVE_CAMPAIGNS_KEY, campaignId.toString())
+        );
+    }
+
+    public void deleteTotal(Long campaignId) {
+        redisTemplate.delete(getTotalKey(campaignId));
+    }
+
+    public void clearRuntimeState(Long campaignId) {
+        deleteStock(campaignId);
+        deleteTotal(campaignId);
+        deactivateCampaign(campaignId);
+    }
+
     private String getTotalKey(Long campaignId) {
         return TOTAL_KEY_PREFIX + campaignId + "}";
     }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -19,10 +20,12 @@ public class SlackNotificationService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    @Async("slackTaskExecutor")
     public void sendDlqAlert(String reason, String detail) {
         sendAlert("[DLQ 알림] " + reason, detail);
     }
 
+    @Async("slackTaskExecutor")
     public void sendBatchAlert(String title, String detail) {
         sendAlert("[Batch 알림] " + title, detail);
     }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/SlackNotificationService.java
@@ -10,13 +10,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
-/**
- * Slack Incoming Webhook 알림 서비스
- *
- * DLQ 적재 시 Slack 채널로 알림 발송.
- * webhook-url 미설정 시 로그만 남기고 스킵 (로컬/테스트 환경 안전).
- * SSM Parameter Store → 환경변수 SLACK_WEBHOOK_URL → slack.webhook-url 순으로 주입.
- */
 @Slf4j
 @Service
 public class SlackNotificationService {
@@ -26,29 +19,30 @@ public class SlackNotificationService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    /**
-     * DLQ 적재 알림 발송
-     *
-     * @param reason  알림 사유 (예: "Bridge Produce MAX_RETRY 초과")
-     * @param detail  상세 정보 (historyId 또는 campaignId 포함)
-     */
     public void sendDlqAlert(String reason, String detail) {
+        sendAlert("[DLQ 알림] " + reason, detail);
+    }
+
+    public void sendBatchAlert(String title, String detail) {
+        sendAlert("[Batch 알림] " + title, detail);
+    }
+
+    private void sendAlert(String title, String detail) {
         if (webhookUrl == null || webhookUrl.isBlank()) {
-            log.warn("[Slack 미설정] DLQ 알림 스킵. reason={}, detail={}", reason, detail);
+            log.warn("[Slack 미설정] 알림 스킵. title={}, detail={}", title, detail);
             return;
         }
         try {
-            String text = String.format("[DLQ 알림] %s | %s", reason, detail);
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
             restTemplate.postForEntity(
                     webhookUrl,
-                    new HttpEntity<>(Map.of("text", text), headers),
+                    new HttpEntity<>(Map.of("text", title + " | " + detail), headers),
                     String.class
             );
-            log.info("Slack 알림 전송 완료. reason={}", reason);
+            log.info("Slack 알림 전송 완료. title={}", title);
         } catch (Exception e) {
-            log.error("Slack 알림 전송 실패. reason={}", reason, e);
+            log.error("Slack 알림 전송 실패. title={}", title, e);
         }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
@@ -1,0 +1,89 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ConsistencyRecoveryJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+    private final ConsistencyRecoveryJobExecutionListener consistencyRecoveryJobExecutionListener;
+
+    @Bean
+    public Job consistencyRecoveryJob(
+            Step consistencyRecoveryStartStep,
+            Step consistencyRecoveryProcessStep,
+            Step consistencyRecoveryFinishStep
+    ) {
+        return new JobBuilder("consistencyRecoveryJob", jobRepository)
+                .listener(consistencyRecoveryJobExecutionListener)
+                .start(consistencyRecoveryStartStep)
+                .next(consistencyRecoveryProcessStep)
+                .next(consistencyRecoveryFinishStep)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryStartStep() {
+        return new StepBuilder("consistencyRecoveryStartStep", jobRepository)
+                .tasklet(markRunningTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryProcessStep() {
+        return new StepBuilder("consistencyRecoveryProcessStep", jobRepository)
+                .tasklet(processTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step consistencyRecoveryFinishStep() {
+        return new StepBuilder("consistencyRecoveryFinishStep", jobRepository)
+                .tasklet(markCompletedTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet markRunningTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.markRunning(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet processTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.processExecution(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet markCompletedTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext()
+                    .getJobParameters().get("consistencyRecoveryExecutionId");
+            consistencyRecoveryService.markCompleted(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobConfig.java
@@ -39,26 +39,26 @@ public class ConsistencyRecoveryJobConfig {
     @Bean
     public Step consistencyRecoveryStartStep() {
         return new StepBuilder("consistencyRecoveryStartStep", jobRepository)
-                .tasklet(markRunningTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryMarkRunningTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step consistencyRecoveryProcessStep() {
         return new StepBuilder("consistencyRecoveryProcessStep", jobRepository)
-                .tasklet(processTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryProcessTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step consistencyRecoveryFinishStep() {
         return new StepBuilder("consistencyRecoveryFinishStep", jobRepository)
-                .tasklet(markCompletedTasklet(), transactionManager)
+                .tasklet(consistencyRecoveryMarkCompletedTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
-    public Tasklet markRunningTasklet() {
+    public Tasklet consistencyRecoveryMarkRunningTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");
@@ -68,7 +68,7 @@ public class ConsistencyRecoveryJobConfig {
     }
 
     @Bean
-    public Tasklet processTasklet() {
+    public Tasklet consistencyRecoveryProcessTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");
@@ -78,7 +78,7 @@ public class ConsistencyRecoveryJobConfig {
     }
 
     @Bean
-    public Tasklet markCompletedTasklet() {
+    public Tasklet consistencyRecoveryMarkCompletedTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext()
                     .getJobParameters().get("consistencyRecoveryExecutionId");

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobExecutionListener.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/ConsistencyRecoveryJobExecutionListener.java
@@ -1,0 +1,66 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.ConsistencyRecoveryService;
+import io.eventdriven.campaign.application.service.SlackNotificationService;
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConsistencyRecoveryJobExecutionListener implements JobExecutionListener {
+
+    private final ConsistencyRecoveryService consistencyRecoveryService;
+    private final SlackNotificationService slackNotificationService;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (!"consistencyRecoveryJob".equals(jobExecution.getJobInstance().getJobName())) {
+            return;
+        }
+
+        Long executionId = jobExecution.getJobParameters().getLong("consistencyRecoveryExecutionId");
+        if (executionId == null) {
+            return;
+        }
+
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            try {
+                consistencyRecoveryService.markFailed(executionId);
+            } catch (Exception e) {
+                log.error("Failed to mark consistency recovery execution as failed. executionId={}", executionId, e);
+            }
+        }
+
+        sendAlert(executionId, jobExecution.getStatus());
+    }
+
+    private void sendAlert(Long executionId, BatchStatus batchStatus) {
+        try {
+            ConsistencyRecoveryExecution execution = consistencyRecoveryService.getExecution(executionId);
+            slackNotificationService.sendBatchAlert(
+                    batchStatus == BatchStatus.FAILED
+                            ? "Consistency Recovery Failed"
+                            : "Consistency Recovery Completed",
+                    String.format(
+                            "executionId=%d, status=%s, dryRun=%s, autoFix=%s, target=%d, anomalies=%d, fixed=%d, reportOnly=%d",
+                            execution.getId(),
+                            execution.getStatus(),
+                            execution.isDryRun(),
+                            execution.isAutoFix(),
+                            execution.getTargetCount(),
+                            execution.getAnomalyCount(),
+                            execution.getFixedCount(),
+                            execution.getReportOnlyCount()
+                    )
+            );
+        } catch (Exception e) {
+            log.error("Failed to send consistency recovery Slack alert. executionId={}", executionId, e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
@@ -39,26 +39,26 @@ public class DlqReplayJobConfig {
     @Bean
     public Step dlqReplayStartStep() {
         return new StepBuilder("dlqReplayStartStep", jobRepository)
-                .tasklet(markRunningTasklet(), transactionManager)
+                .tasklet(dlqReplayMarkRunningTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step dlqReplayProcessStep() {
         return new StepBuilder("dlqReplayProcessStep", jobRepository)
-                .tasklet(processReplayTasklet(), transactionManager)
+                .tasklet(dlqReplayProcessTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
     public Step dlqReplayFinishStep() {
         return new StepBuilder("dlqReplayFinishStep", jobRepository)
-                .tasklet(markCompletedTasklet(), transactionManager)
+                .tasklet(dlqReplayMarkCompletedTasklet(), transactionManager)
                 .build();
     }
 
     @Bean
-    public Tasklet markRunningTasklet() {
+    public Tasklet dlqReplayMarkRunningTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.markRunning(executionId);
@@ -67,7 +67,7 @@ public class DlqReplayJobConfig {
     }
 
     @Bean
-    public Tasklet processReplayTasklet() {
+    public Tasklet dlqReplayProcessTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.processExecution(executionId);
@@ -76,7 +76,7 @@ public class DlqReplayJobConfig {
     }
 
     @Bean
-    public Tasklet markCompletedTasklet() {
+    public Tasklet dlqReplayMarkCompletedTasklet() {
         return (contribution, chunkContext) -> {
             Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
             dlqReplayService.markCompleted(executionId);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobConfig.java
@@ -1,0 +1,86 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class DlqReplayJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final DlqReplayService dlqReplayService;
+    private final DlqReplayJobExecutionListener dlqReplayJobExecutionListener;
+
+    @Bean
+    public Job dlqReplayJob(
+            Step dlqReplayStartStep,
+            Step dlqReplayProcessStep,
+            Step dlqReplayFinishStep
+    ) {
+        return new JobBuilder("dlqReplayJob", jobRepository)
+                .listener(dlqReplayJobExecutionListener)
+                .start(dlqReplayStartStep)
+                .next(dlqReplayProcessStep)
+                .next(dlqReplayFinishStep)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayStartStep() {
+        return new StepBuilder("dlqReplayStartStep", jobRepository)
+                .tasklet(markRunningTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayProcessStep() {
+        return new StepBuilder("dlqReplayProcessStep", jobRepository)
+                .tasklet(processReplayTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step dlqReplayFinishStep() {
+        return new StepBuilder("dlqReplayFinishStep", jobRepository)
+                .tasklet(markCompletedTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet markRunningTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.markRunning(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet processReplayTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.processExecution(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Tasklet markCompletedTasklet() {
+        return (contribution, chunkContext) -> {
+            Long executionId = (Long) chunkContext.getStepContext().getJobParameters().get("replayExecutionId");
+            dlqReplayService.markCompleted(executionId);
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobExecutionListener.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/DlqReplayJobExecutionListener.java
@@ -1,0 +1,65 @@
+package io.eventdriven.campaign.batch;
+
+import io.eventdriven.campaign.application.service.SlackNotificationService;
+import io.eventdriven.campaign.application.service.DlqReplayService;
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DlqReplayJobExecutionListener implements JobExecutionListener {
+
+    private final DlqReplayService dlqReplayService;
+    private final SlackNotificationService slackNotificationService;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (!"dlqReplayJob".equals(jobExecution.getJobInstance().getJobName())) {
+            return;
+        }
+
+        Long replayExecutionId = jobExecution.getJobParameters().getLong("replayExecutionId");
+        if (replayExecutionId == null) {
+            return;
+        }
+
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            try {
+                dlqReplayService.markFailed(replayExecutionId);
+            } catch (Exception e) {
+                log.error("Failed to mark DLQ replay execution as failed. replayExecutionId={}", replayExecutionId, e);
+            }
+        }
+
+        sendReplayAlert(jobExecution.getStatus(), replayExecutionId);
+    }
+
+    private void sendReplayAlert(BatchStatus batchStatus, Long replayExecutionId) {
+        try {
+            DlqReplayExecution execution = dlqReplayService.getExecution(replayExecutionId);
+            String title = batchStatus == BatchStatus.FAILED
+                    ? "DLQ Replay Failed"
+                    : "DLQ Replay Completed";
+            String detail = String.format(
+                    "executionId=%d, status=%s, dryRun=%s, target=%d, replayed=%d, skipped=%d, finalFailed=%d, publishFailed=%d",
+                    execution.getId(),
+                    execution.getStatus(),
+                    execution.isDryRun(),
+                    execution.getTargetCount(),
+                    execution.getReplayedCount(),
+                    execution.getSkippedCount(),
+                    execution.getFinalFailedCount(),
+                    execution.getPublishFailedCount()
+            );
+            slackNotificationService.sendBatchAlert(title, detail);
+        } catch (Exception e) {
+            log.error("Failed to send DLQ replay Slack alert. replayExecutionId={}", replayExecutionId, e);
+        }
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/batch/PendingRecoveryJobConfig.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,38 +53,56 @@ public class PendingRecoveryJobConfig {
     @Bean
     public Tasklet pendingRecoveryTasklet() {
         return (contribution, chunkContext) -> {
-            LocalDateTime cutoff = LocalDateTime.now().minusMinutes(5);
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime cutoff = now.minusMinutes(5);
             List<ParticipationHistory> pendingList =
                     participationHistoryRepository.findByStatusAndCreatedAtBefore(
                             ParticipationStatus.PENDING, cutoff);
 
             if (pendingList.isEmpty()) {
+                log.info("Pending recovery completed. candidates=0, republished=0");
                 return RepeatStatus.FINISHED;
             }
 
             int successCount = 0;
             for (ParticipationHistory history : pendingList) {
                 String message = buildMessage(history);
+                Long ageMinutes = history.getCreatedAt() == null
+                        ? null
+                        : Math.max(0L, ChronoUnit.MINUTES.between(history.getCreatedAt(), now));
                 try {
-                    // Redis Queue 대신 Kafka 직접 발행
-                    // 이유: 재고 소진 시 active:campaigns에서 SREM → Bridge가 큐를 드레인하지 않음
-                    //       Batch 복구 대상은 소량이므로 Bridge 우회해도 부하 없음
                     kafkaTemplate.send(KafkaConfig.TOPIC_NAME, String.valueOf(history.getCampaign().getId()), message)
                             .whenComplete((result, ex) -> {
                                 if (ex != null) {
-                                    log.error("PENDING 재발행 실패. historyId={}", history.getId(), ex);
+                                    log.error(
+                                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=false",
+                                            history.getId(),
+                                            history.getCampaign().getId(),
+                                            ageMinutes,
+                                            ex
+                                    );
                                 } else {
-                                    log.info("PENDING 재발행 성공. historyId={}", history.getId());
+                                    log.info(
+                                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=true",
+                                            history.getId(),
+                                            history.getCampaign().getId(),
+                                            ageMinutes
+                                    );
                                 }
                             });
                     successCount++;
                 } catch (Exception e) {
-                    log.warn("PENDING 재발행 실패. historyId={}, campaignId={}",
-                            history.getId(), history.getCampaign().getId(), e);
+                    log.warn(
+                            "Pending recovery publish result. historyId={}, campaignId={}, ageMinutes={}, republished=false",
+                            history.getId(),
+                            history.getCampaign().getId(),
+                            ageMinutes,
+                            e
+                    );
                 }
             }
 
-            log.info("PENDING 재처리 완료. 전체={}, 재발행={}", pendingList.size(), successCount);
+            log.info("Pending recovery completed. candidates={}, republished={}", pendingList.size(), successCount);
 
             return RepeatStatus.FINISHED;
         };
@@ -97,7 +116,7 @@ public class PendingRecoveryJobConfig {
             msg.put("sequence", history.getSequence());
             return jsonMapper.writeValueAsString(msg);
         } catch (Exception e) {
-            throw new RuntimeException("메시지 직렬화 실패. historyId=" + history.getId(), e);
+            throw new RuntimeException("Message serialization failed. historyId=" + history.getId(), e);
         }
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchConfig.java
@@ -3,15 +3,20 @@ package io.eventdriven.campaign.config;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Spring Batch 설정
  * - 비동기 JobLauncher: 배치 실행 시 API 응답 지연 방지
  */
+@EnableAsync
 @Configuration
 @SuppressWarnings("removal")
 public class BatchConfig {
@@ -36,6 +41,18 @@ public class BatchConfig {
         return executor;
     }
 
+    @Bean(name = "slackTaskExecutor")
+    public ThreadPoolTaskExecutor slackTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("slack-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.initialize();
+        return executor;
+    }
+
     /**
      * 비동기 JobLauncher
      * - 배치 작업을 백그라운드에서 실행
@@ -47,7 +64,7 @@ public class BatchConfig {
     @Bean(name = "asyncJobLauncher")
     public JobLauncher asyncJobLauncher(
             JobRepository jobRepository,
-            ThreadPoolTaskExecutor batchTaskExecutor
+            @Qualifier("batchTaskExecutor") ThreadPoolTaskExecutor batchTaskExecutor
     ) throws Exception {
         TaskExecutorJobLauncher jobLauncher = new TaskExecutorJobLauncher();
         jobLauncher.setJobRepository(jobRepository);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchProperties.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/config/BatchProperties.java
@@ -5,10 +5,6 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-/**
- * 배치 작업 관련 설정 프로퍼티
- * - application.yml의 batch.* 설정을 주입받음
- */
 @Getter
 @Setter
 @Component
@@ -17,22 +13,32 @@ public class BatchProperties {
 
     private Aggregation aggregation = new Aggregation();
     private Metadata metadata = new Metadata();
+    private Replay replay = new Replay();
+    private Consistency consistency = new Consistency();
 
     @Getter
     @Setter
     public static class Aggregation {
-        /**
-         * 집계 가능한 최대 과거 기간 (년)
-         */
         private int maxPastYears = 1;
     }
 
     @Getter
     @Setter
     public static class Metadata {
-        /**
-         * 배치 메타데이터 보관 기간 (일)
-         */
         private int retentionDays = 90;
+    }
+
+    @Getter
+    @Setter
+    public static class Replay {
+        private int pageSize = 100;
+        private int defaultMaxItems = 100;
+    }
+
+    @Getter
+    @Setter
+    public static class Consistency {
+        private int pageSize = 100;
+        private int defaultMaxCampaigns = 100;
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyAnomalyType.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyAnomalyType.java
@@ -1,0 +1,12 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyAnomalyType {
+    MISSING_REDIS_STOCK,
+    MISSING_REDIS_TOTAL,
+    MISSING_ACTIVE_STATE,
+    CLOSED_REDIS_RESIDUE,
+    QUEUE_WITHOUT_ACTIVE_STATE,
+    SUCCESS_PENDING_EXCEEDS_TOTAL,
+    REDIS_REMAINING_MISMATCH,
+    NEGATIVE_REDIS_STOCK
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryAction.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryAction.java
@@ -1,0 +1,9 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyRecoveryAction {
+    NONE,
+    REPORT_ONLY,
+    RESTORE_REDIS_STATE,
+    ACTIVATE_CAMPAIGN,
+    CLEANUP_REDIS_STATE
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecution.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecution.java
@@ -1,0 +1,101 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "consistency_recovery_execution")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsistencyRecoveryExecution extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requested_by", length = 100)
+    private String requestedBy;
+
+    @Column(name = "dry_run", nullable = false)
+    private boolean dryRun;
+
+    @Column(name = "auto_fix", nullable = false)
+    private boolean autoFix;
+
+    @Column(name = "filter_campaign_id")
+    private Long filterCampaignId;
+
+    @Column(name = "max_campaigns", nullable = false)
+    private int maxCampaigns;
+
+    @Column(name = "target_count", nullable = false)
+    private long targetCount;
+
+    @Column(name = "anomaly_count", nullable = false)
+    private long anomalyCount;
+
+    @Column(name = "fixed_count", nullable = false)
+    private long fixedCount;
+
+    @Column(name = "report_only_count", nullable = false)
+    private long reportOnlyCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private ConsistencyRecoveryExecutionStatus status;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    public ConsistencyRecoveryExecution(
+            String requestedBy,
+            boolean dryRun,
+            boolean autoFix,
+            Long filterCampaignId,
+            int maxCampaigns,
+            long targetCount
+    ) {
+        this.requestedBy = requestedBy;
+        this.dryRun = dryRun;
+        this.autoFix = autoFix;
+        this.filterCampaignId = filterCampaignId;
+        this.maxCampaigns = maxCampaigns;
+        this.targetCount = targetCount;
+        this.status = ConsistencyRecoveryExecutionStatus.REQUESTED;
+    }
+
+    public void markRunning(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.RUNNING;
+        this.startedAt = now;
+        this.endedAt = null;
+    }
+
+    public void incrementAnomalyCount() {
+        this.anomalyCount++;
+    }
+
+    public void incrementFixedCount() {
+        this.fixedCount++;
+    }
+
+    public void incrementReportOnlyCount() {
+        this.reportOnlyCount++;
+    }
+
+    public void markCompleted(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.COMPLETED;
+        this.endedAt = now;
+    }
+
+    public void markFailed(LocalDateTime now) {
+        this.status = ConsistencyRecoveryExecutionStatus.FAILED;
+        this.endedAt = now;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecutionStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryExecutionStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencyRecoveryExecutionStatus {
+    REQUESTED,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryResult.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencyRecoveryResult.java
@@ -1,0 +1,113 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "consistency_recovery_result")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsistencyRecoveryResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "execution_id", nullable = false)
+    private ConsistencyRecoveryExecution execution;
+
+    @Column(name = "campaign_id", nullable = false)
+    private Long campaignId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "campaign_status", nullable = false, length = 32)
+    private CampaignStatus campaignStatus;
+
+    @Column(name = "total_stock", nullable = false)
+    private long totalStock;
+
+    @Column(name = "success_count", nullable = false)
+    private long successCount;
+
+    @Column(name = "pending_count", nullable = false)
+    private long pendingCount;
+
+    @Column(name = "redis_remaining_stock")
+    private Long redisRemainingStock;
+
+    @Column(name = "redis_total_stock")
+    private Long redisTotalStock;
+
+    @Column(name = "queue_size", nullable = false)
+    private long queueSize;
+
+    @Column(name = "active_flag_present", nullable = false)
+    private boolean activeFlagPresent;
+
+    @Column(name = "active_set_present", nullable = false)
+    private boolean activeSetPresent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "anomaly_type", nullable = false, length = 64)
+    private ConsistencyAnomalyType anomalyType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false, length = 32)
+    private ConsistencySeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_taken", nullable = false, length = 32)
+    private ConsistencyRecoveryAction actionTaken;
+
+    @Column(name = "fixed", nullable = false)
+    private boolean fixed;
+
+    @Column(name = "detail_message", length = 1000)
+    private String detailMessage;
+
+    @Column(name = "checked_at", nullable = false)
+    private LocalDateTime checkedAt;
+
+    public ConsistencyRecoveryResult(
+            ConsistencyRecoveryExecution execution,
+            Long campaignId,
+            CampaignStatus campaignStatus,
+            long totalStock,
+            long successCount,
+            long pendingCount,
+            Long redisRemainingStock,
+            Long redisTotalStock,
+            long queueSize,
+            boolean activeFlagPresent,
+            boolean activeSetPresent,
+            ConsistencyAnomalyType anomalyType,
+            ConsistencySeverity severity,
+            ConsistencyRecoveryAction actionTaken,
+            boolean fixed,
+            String detailMessage,
+            LocalDateTime checkedAt
+    ) {
+        this.execution = execution;
+        this.campaignId = campaignId;
+        this.campaignStatus = campaignStatus;
+        this.totalStock = totalStock;
+        this.successCount = successCount;
+        this.pendingCount = pendingCount;
+        this.redisRemainingStock = redisRemainingStock;
+        this.redisTotalStock = redisTotalStock;
+        this.queueSize = queueSize;
+        this.activeFlagPresent = activeFlagPresent;
+        this.activeSetPresent = activeSetPresent;
+        this.anomalyType = anomalyType;
+        this.severity = severity;
+        this.actionTaken = actionTaken;
+        this.fixed = fixed;
+        this.detailMessage = detailMessage;
+        this.checkedAt = checkedAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencySeverity.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/ConsistencySeverity.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum ConsistencySeverity {
+    INFO,
+    WARNING,
+    CRITICAL
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageProcessingStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageProcessingStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqMessageProcessingStatus {
+    PENDING,
+    REPLAYED,
+    SKIPPED,
+    FINAL_FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -27,8 +29,8 @@ public class DlqMessageRecord extends BaseTimeEntity {
     @Column(name = "original_key")
     private String originalKey;
 
-    @Lob
-    @Column(name = "original_message", nullable = false)
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "original_message", nullable = false, columnDefinition = "TEXT")
     private String originalMessage;
 
     @Column(name = "error_reason", nullable = false, length = 100)

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqMessageRecord.java
@@ -1,0 +1,111 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqMessageRecord extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 32)
+    private DlqSourceType sourceType;
+
+    @Column(name = "original_topic", nullable = false)
+    private String originalTopic;
+
+    @Column(name = "original_key")
+    private String originalKey;
+
+    @Lob
+    @Column(name = "original_message", nullable = false)
+    private String originalMessage;
+
+    @Column(name = "error_reason", nullable = false, length = 100)
+    private String errorReason;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Column(name = "campaign_id")
+    private Long campaignId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "sequence_no")
+    private Long sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "replay_classification", nullable = false, length = 32)
+    private DlqReplayClassification replayClassification;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "processing_status", nullable = false, length = 32)
+    private DlqMessageProcessingStatus processingStatus;
+
+    @Column(name = "replay_attempt_count", nullable = false)
+    private int replayAttemptCount;
+
+    @Column(name = "final_failure_reason", length = 255)
+    private String finalFailureReason;
+
+    @Column(name = "last_replayed_at")
+    private LocalDateTime lastReplayedAt;
+
+    public DlqMessageRecord(
+            DlqSourceType sourceType,
+            String originalTopic,
+            String originalKey,
+            String originalMessage,
+            String errorReason,
+            String errorMessage,
+            Long campaignId,
+            Long userId,
+            Long sequence,
+            DlqReplayClassification replayClassification
+    ) {
+        this.sourceType = sourceType;
+        this.originalTopic = originalTopic;
+        this.originalKey = originalKey;
+        this.originalMessage = originalMessage;
+        this.errorReason = errorReason;
+        this.errorMessage = errorMessage;
+        this.campaignId = campaignId;
+        this.userId = userId;
+        this.sequence = sequence;
+        this.replayClassification = replayClassification;
+        this.processingStatus = DlqMessageProcessingStatus.PENDING;
+        this.replayAttemptCount = 0;
+    }
+
+    public void incrementReplayAttempt() {
+        this.replayAttemptCount++;
+    }
+
+    public void markReplayed(LocalDateTime replayedAt) {
+        this.processingStatus = DlqMessageProcessingStatus.REPLAYED;
+        this.lastReplayedAt = replayedAt;
+        this.finalFailureReason = null;
+    }
+
+    public void markSkipped(String reason) {
+        this.processingStatus = DlqMessageProcessingStatus.SKIPPED;
+        this.finalFailureReason = reason;
+    }
+
+    public void markFinalFailed(String reason) {
+        this.processingStatus = DlqMessageProcessingStatus.FINAL_FAILED;
+        this.finalFailureReason = reason;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayAction.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayAction.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayAction {
+    REPLAY,
+    SKIP,
+    FINAL_FAIL
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayClassification.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayClassification.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayClassification {
+    REPLAYABLE,
+    CONDITIONALLY_REPLAYABLE,
+    NON_REPLAYABLE
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecution.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecution.java
@@ -1,0 +1,118 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_replay_execution")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqReplayExecution extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requested_by", length = 100)
+    private String requestedBy;
+
+    @Column(name = "dry_run", nullable = false)
+    private boolean dryRun;
+
+    @Column(name = "filter_campaign_id")
+    private Long filterCampaignId;
+
+    @Column(name = "filter_reason", length = 100)
+    private String filterReason;
+
+    @Column(name = "filter_from_time")
+    private LocalDateTime filterFromTime;
+
+    @Column(name = "filter_to_time")
+    private LocalDateTime filterToTime;
+
+    @Column(name = "max_items", nullable = false)
+    private int maxItems;
+
+    @Column(name = "target_count", nullable = false)
+    private long targetCount;
+
+    @Column(name = "replayed_count", nullable = false)
+    private long replayedCount;
+
+    @Column(name = "skipped_count", nullable = false)
+    private long skippedCount;
+
+    @Column(name = "final_failed_count", nullable = false)
+    private long finalFailedCount;
+
+    @Column(name = "publish_failed_count", nullable = false)
+    private long publishFailedCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private DlqReplayExecutionStatus status;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    public DlqReplayExecution(
+            String requestedBy,
+            boolean dryRun,
+            Long filterCampaignId,
+            String filterReason,
+            LocalDateTime filterFromTime,
+            LocalDateTime filterToTime,
+            int maxItems,
+            long targetCount
+    ) {
+        this.requestedBy = requestedBy;
+        this.dryRun = dryRun;
+        this.filterCampaignId = filterCampaignId;
+        this.filterReason = filterReason;
+        this.filterFromTime = filterFromTime;
+        this.filterToTime = filterToTime;
+        this.maxItems = maxItems;
+        this.targetCount = targetCount;
+        this.status = DlqReplayExecutionStatus.REQUESTED;
+    }
+
+    public void markRunning(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.RUNNING;
+        this.startedAt = now;
+        this.endedAt = null;
+    }
+
+    public void incrementReplayed() {
+        this.replayedCount++;
+    }
+
+    public void incrementSkipped() {
+        this.skippedCount++;
+    }
+
+    public void incrementFinalFailed() {
+        this.finalFailedCount++;
+    }
+
+    public void incrementPublishFailed() {
+        this.publishFailedCount++;
+    }
+
+    public void markCompleted(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.COMPLETED;
+        this.endedAt = now;
+    }
+
+    public void markFailed(LocalDateTime now) {
+        this.status = DlqReplayExecutionStatus.FAILED;
+        this.endedAt = now;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionItem.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionItem.java
@@ -1,0 +1,70 @@
+package io.eventdriven.campaign.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dlq_replay_execution_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DlqReplayExecutionItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "execution_id", nullable = false)
+    private DlqReplayExecution execution;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dlq_message_id", nullable = false)
+    private DlqMessageRecord dlqMessage;
+
+    @Column(name = "original_topic", nullable = false)
+    private String originalTopic;
+
+    @Column(name = "original_key")
+    private String originalKey;
+
+    @Column(name = "reason", nullable = false, length = 100)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action", nullable = false, length = 32)
+    private DlqReplayAction action;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result", nullable = false, length = 32)
+    private DlqReplayItemResult result;
+
+    @Column(name = "detail_message", length = 1000)
+    private String detailMessage;
+
+    @Column(name = "processed_at", nullable = false)
+    private LocalDateTime processedAt;
+
+    public DlqReplayExecutionItem(
+            DlqReplayExecution execution,
+            DlqMessageRecord dlqMessage,
+            String reason,
+            DlqReplayAction action,
+            DlqReplayItemResult result,
+            String detailMessage,
+            LocalDateTime processedAt
+    ) {
+        this.execution = execution;
+        this.dlqMessage = dlqMessage;
+        this.originalTopic = dlqMessage.getOriginalTopic();
+        this.originalKey = dlqMessage.getOriginalKey();
+        this.reason = reason;
+        this.action = action;
+        this.result = result;
+        this.detailMessage = detailMessage;
+        this.processedAt = processedAt;
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionStatus.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayExecutionStatus.java
@@ -1,0 +1,8 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayExecutionStatus {
+    REQUESTED,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayItemResult.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqReplayItemResult.java
@@ -1,0 +1,9 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqReplayItemResult {
+    SUCCESS,
+    SKIPPED,
+    FINAL_FAILED,
+    FAILED,
+    DRY_RUN
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqSourceType.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/entity/DlqSourceType.java
@@ -1,0 +1,6 @@
+package io.eventdriven.campaign.domain.entity;
+
+public enum DlqSourceType {
+    BRIDGE,
+    CONSUMER
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryExecutionRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryExecutionRepository.java
@@ -1,0 +1,12 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryExecution;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConsistencyRecoveryExecutionRepository extends JpaRepository<ConsistencyRecoveryExecution, Long> {
+
+    List<ConsistencyRecoveryExecution> findByOrderByIdDesc(Pageable pageable);
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryResultRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ConsistencyRecoveryResultRepository.java
@@ -1,0 +1,23 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.ConsistencyRecoveryResult;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ConsistencyRecoveryResultRepository extends JpaRepository<ConsistencyRecoveryResult, Long> {
+
+    @Query("""
+        SELECT r
+        FROM ConsistencyRecoveryResult r
+        WHERE r.execution.id = :executionId
+        ORDER BY r.id ASC
+    """)
+    List<ConsistencyRecoveryResult> findByExecutionIdOrderByIdAsc(
+            @Param("executionId") Long executionId,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqMessageRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqMessageRepository.java
@@ -1,0 +1,67 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqMessageProcessingStatus;
+import io.eventdriven.campaign.domain.entity.DlqMessageRecord;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DlqMessageRepository extends JpaRepository<DlqMessageRecord, Long> {
+
+    @Query("""
+        SELECT COUNT(d)
+        FROM DlqMessageRecord d
+        WHERE d.processingStatus = :status
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+          AND (:fromTime IS NULL OR d.createdAt >= :fromTime)
+          AND (:toTime IS NULL OR d.createdAt <= :toTime)
+    """)
+    long countReplayCandidates(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            @Param("fromTime") LocalDateTime fromTime,
+            @Param("toTime") LocalDateTime toTime
+    );
+
+    @Query("""
+        SELECT d
+        FROM DlqMessageRecord d
+        WHERE d.processingStatus = :status
+          AND d.id > :afterId
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+          AND (:fromTime IS NULL OR d.createdAt >= :fromTime)
+          AND (:toTime IS NULL OR d.createdAt <= :toTime)
+        ORDER BY d.id ASC
+    """)
+    List<DlqMessageRecord> findReplayCandidates(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("afterId") Long afterId,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            @Param("fromTime") LocalDateTime fromTime,
+            @Param("toTime") LocalDateTime toTime,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT d
+        FROM DlqMessageRecord d
+        WHERE (:status IS NULL OR d.processingStatus = :status)
+          AND (:campaignId IS NULL OR d.campaignId = :campaignId)
+          AND (:reason IS NULL OR d.errorReason = :reason)
+        ORDER BY d.id DESC
+    """)
+    List<DlqMessageRecord> searchMessages(
+            @Param("status") DlqMessageProcessingStatus status,
+            @Param("campaignId") Long campaignId,
+            @Param("reason") String reason,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionItemRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionItemRepository.java
@@ -1,0 +1,23 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayExecutionItem;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DlqReplayExecutionItemRepository extends JpaRepository<DlqReplayExecutionItem, Long> {
+
+    @Query("""
+        SELECT i
+        FROM DlqReplayExecutionItem i
+        WHERE i.execution.id = :executionId
+        ORDER BY i.id ASC
+    """)
+    List<DlqReplayExecutionItem> findByExecutionIdOrderByIdAsc(
+            @Param("executionId") Long executionId,
+            Pageable pageable
+    );
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/DlqReplayExecutionRepository.java
@@ -1,0 +1,7 @@
+package io.eventdriven.campaign.domain.repository;
+
+import io.eventdriven.campaign.domain.entity.DlqReplayExecution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DlqReplayExecutionRepository extends JpaRepository<DlqReplayExecution, Long> {
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ParticipationHistoryRepository.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/domain/repository/ParticipationHistoryRepository.java
@@ -61,6 +61,19 @@ public interface ParticipationHistoryRepository extends JpaRepository<Participat
      */
     Optional<ParticipationHistory> findByCampaignIdAndUserId(Long campaignId, Long userId);
 
+    @Query("""
+        SELECT COUNT(ph) > 0
+        FROM ParticipationHistory ph
+        WHERE ph.campaign.id = :campaignId
+          AND ph.userId = :userId
+          AND ph.status = :status
+    """)
+    boolean existsSuccessHistory(
+            @Param("campaignId") Long campaignId,
+            @Param("userId") Long userId,
+            @Param("status") ParticipationStatus status
+    );
+
     // 5분 초과 PENDING 재처리 배치용
     List<ParticipationHistory> findByStatusAndCreatedAtBefore(ParticipationStatus status, LocalDateTime cutoff);
 

--- a/app/campaign-core/src/main/resources/db/migration/V5__dlq_replay_schema.sql
+++ b/app/campaign-core/src/main/resources/db/migration/V5__dlq_replay_schema.sql
@@ -1,0 +1,76 @@
+CREATE TABLE dlq_message (
+    id                      BIGINT       NOT NULL AUTO_INCREMENT,
+    source_type             VARCHAR(32)  NOT NULL,
+    original_topic          VARCHAR(255) NOT NULL,
+    original_key            VARCHAR(255),
+    original_message        TEXT         NOT NULL,
+    error_reason            VARCHAR(100) NOT NULL,
+    error_message           VARCHAR(1000),
+    campaign_id             BIGINT,
+    user_id                 BIGINT,
+    sequence_no             BIGINT,
+    replay_classification   VARCHAR(32)  NOT NULL,
+    processing_status       VARCHAR(32)  NOT NULL,
+    replay_attempt_count    INT          NOT NULL DEFAULT 0,
+    final_failure_reason    VARCHAR(255),
+    last_replayed_at        DATETIME(6),
+    created_at              DATETIME(6)  NOT NULL,
+    updated_at              DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dlq_message_status_id
+    ON dlq_message (processing_status, id);
+
+CREATE INDEX idx_dlq_message_campaign_status
+    ON dlq_message (campaign_id, processing_status);
+
+CREATE INDEX idx_dlq_message_reason_status
+    ON dlq_message (error_reason, processing_status);
+
+CREATE TABLE dlq_replay_execution (
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
+    requested_by         VARCHAR(100),
+    dry_run              BIT(1)       NOT NULL,
+    filter_campaign_id   BIGINT,
+    filter_reason        VARCHAR(100),
+    filter_from_time     DATETIME(6),
+    filter_to_time       DATETIME(6),
+    max_items            INT          NOT NULL,
+    target_count         BIGINT       NOT NULL DEFAULT 0,
+    replayed_count       BIGINT       NOT NULL DEFAULT 0,
+    skipped_count        BIGINT       NOT NULL DEFAULT 0,
+    final_failed_count   BIGINT       NOT NULL DEFAULT 0,
+    publish_failed_count BIGINT       NOT NULL DEFAULT 0,
+    status               VARCHAR(32)  NOT NULL,
+    started_at           DATETIME(6),
+    ended_at             DATETIME(6),
+    created_at           DATETIME(6)  NOT NULL,
+    updated_at           DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE dlq_replay_execution_item (
+    id             BIGINT        NOT NULL AUTO_INCREMENT,
+    execution_id   BIGINT        NOT NULL,
+    dlq_message_id BIGINT        NOT NULL,
+    original_topic VARCHAR(255)  NOT NULL,
+    original_key   VARCHAR(255),
+    reason         VARCHAR(100)  NOT NULL,
+    action         VARCHAR(32)   NOT NULL,
+    result         VARCHAR(32)   NOT NULL,
+    detail_message VARCHAR(1000),
+    processed_at   DATETIME(6)   NOT NULL,
+    created_at     DATETIME(6)   NOT NULL,
+    updated_at     DATETIME(6)   NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_dlq_replay_execution_item_execution
+        FOREIGN KEY (execution_id) REFERENCES dlq_replay_execution (id),
+    CONSTRAINT fk_dlq_replay_execution_item_message
+        FOREIGN KEY (dlq_message_id) REFERENCES dlq_message (id),
+    CONSTRAINT uk_dlq_replay_execution_message
+        UNIQUE (execution_id, dlq_message_id)
+);
+
+CREATE INDEX idx_dlq_replay_execution_item_execution
+    ON dlq_replay_execution_item (execution_id);

--- a/app/campaign-core/src/main/resources/db/migration/V6__consistency_recovery_schema.sql
+++ b/app/campaign-core/src/main/resources/db/migration/V6__consistency_recovery_schema.sql
@@ -1,0 +1,47 @@
+CREATE TABLE consistency_recovery_execution (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    requested_by VARCHAR(100) NULL,
+    dry_run BIT NOT NULL,
+    auto_fix BIT NOT NULL,
+    filter_campaign_id BIGINT NULL,
+    max_campaigns INT NOT NULL,
+    target_count BIGINT NOT NULL DEFAULT 0,
+    anomaly_count BIGINT NOT NULL DEFAULT 0,
+    fixed_count BIGINT NOT NULL DEFAULT 0,
+    report_only_count BIGINT NOT NULL DEFAULT 0,
+    status VARCHAR(32) NOT NULL,
+    started_at DATETIME NULL,
+    ended_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    INDEX idx_consistency_execution_status (status),
+    INDEX idx_consistency_execution_campaign (filter_campaign_id)
+);
+
+CREATE TABLE consistency_recovery_result (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    execution_id BIGINT NOT NULL,
+    campaign_id BIGINT NOT NULL,
+    campaign_status VARCHAR(32) NOT NULL,
+    total_stock BIGINT NOT NULL,
+    success_count BIGINT NOT NULL,
+    pending_count BIGINT NOT NULL,
+    redis_remaining_stock BIGINT NULL,
+    redis_total_stock BIGINT NULL,
+    queue_size BIGINT NOT NULL,
+    active_flag_present BIT NOT NULL,
+    active_set_present BIT NOT NULL,
+    anomaly_type VARCHAR(64) NOT NULL,
+    severity VARCHAR(32) NOT NULL,
+    action_taken VARCHAR(32) NOT NULL,
+    fixed BIT NOT NULL,
+    detail_message VARCHAR(1000) NULL,
+    checked_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT fk_consistency_result_execution
+        FOREIGN KEY (execution_id) REFERENCES consistency_recovery_execution(id),
+    INDEX idx_consistency_result_execution (execution_id),
+    INDEX idx_consistency_result_campaign (campaign_id),
+    INDEX idx_consistency_result_anomaly (anomaly_type)
+);

--- a/infra/asg.tf
+++ b/infra/asg.tf
@@ -53,7 +53,7 @@ resource "aws_autoscaling_group" "app" {
   }
 
   lifecycle {
-    ignore_changes = [desired_capacity]  # 수동 스케일 조정 보호
+    ignore_changes = [desired_capacity, min_size, max_size]  # 수동 스케일 조정 보호
   }
 }
 

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -37,6 +37,24 @@ resource "aws_iam_role_policy" "terraform_mcp_ec2_describe" {
   })
 }
 
+# MCP 모니터링 서버용 — CloudWatch 읽기 (ASG CPU, RDS CPU)
+resource "aws_iam_role_policy" "terraform_mcp_cloudwatch_read" {
+  name = "CloudWatchRead-for-mcp"
+  role = aws_iam_role.terraform_mcp.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
 # terraform-mcp 보안 그룹
 resource "aws_security_group" "terraform_mcp" {
   name        = "terraform-mcp-sg"

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+CMD ["python", "main.py"]

--- a/mcp-server/MCP_SERVER.md
+++ b/mcp-server/MCP_SERVER.md
@@ -1,0 +1,606 @@
+# MCP Monitor Server — 상세 설명서
+
+## 목차
+
+1. [이게 뭔가 / 왜 만들었나](#1-이게-뭔가--왜-만들었나)
+2. [전체 파일 구조](#2-전체-파일-구조)
+3. [파일별 상세 설명](#3-파일별-상세-설명)
+4. [전체 동작 메커니즘](#4-전체-동작-메커니즘)
+5. [인프라 적용 방법](#5-인프라-적용-방법)
+6. [Claude (AI) 연동](#6-claude-ai-연동)
+7. [생각보다 금방 끝난 이유](#7-생각보다-금방-끝난-이유)
+
+---
+
+## 1. 이게 뭔가 / 왜 만들었나
+
+### 한 줄 요약
+
+> Prometheus / CloudWatch를 30초마다 폴링해서 이상 감지하면 Slack으로 알림 보내는 AI 운영 서버.
+> Claude가 도구를 직접 호출해서 운영 상황을 묻고 분석할 수 있게 MCP 프로토콜로 도구를 노출한다.
+
+### 배경
+
+100만 트래픽 캠페인 시스템(Phase B)을 구축했는데, 운영하면서 사람이 Grafana를 24시간 보고 있을 수는 없다.
+Phase E 목표: **AI가 이상을 탐지하고 설명한다. 실행(인프라 변경)은 사람이 한다.**
+
+AWS 쓰기 권한 없음 — 읽기 전용으로만 동작한다.
+
+### 감지 범위
+
+| 우선순위 | 항목 | 임계값 |
+|----------|------|--------|
+| P1 (즉시 대응) | 5xx 에러 발생 | 1건 이상 |
+| P1 | Redis Queue CRITICAL | 850,000건 (85%) |
+| P1 | 데이터 정합성 불일치 | Redis ≠ DB |
+| P2 (성능 경고) | 앱 CPU CRITICAL | 90% |
+| P2 | 앱 CPU WARNING | 80% |
+| P2 | Kafka consumer lag CRITICAL | 1,000 |
+| P2 | Kafka consumer lag WARNING | 500 |
+| P2 | Consumer 처리 지연 CRITICAL | 200ms |
+| P2 | Consumer 처리 지연 WARNING | 50ms |
+| P2 | HikariCP 커넥션 대기 | 1개 이상 |
+| P3 (인프라 모니터링) | RDS CPU WARNING | 60% |
+| P3 | Bridge 드레인 사이클 지연 | 60초 초과 |
+
+---
+
+## 2. 전체 파일 구조
+
+```
+mcp-server/
+├── main.py                # FastAPI 앱 진입점 + APScheduler 등록 + MCP 마운트
+├── monitor.py             # 폴링 루프 — 각 detector 호출 조율
+├── config.py              # 임계값 + 환경변수 단일 관리 포인트
+├── state.py               # 중복 알림 방지 cooldown 관리 (인메모리)
+├── slack.py               # Slack Webhook 전송 + 메시지 포맷
+├── tools.py               # MCP 도구 5개 노출 (Claude용)
+├── requirements.txt       # Python 의존성
+├── Dockerfile
+└── detectors/
+    ├── __init__.py
+    ├── p1_detector.py     # 5xx 에러 / Redis Queue / 데이터 정합성
+    ├── p2_detector.py     # 앱 CPU / Kafka lag / Consumer 지연 / HikariCP
+    └── p3_detector.py     # RDS CPU / Bridge 드레인 사이클
+```
+
+---
+
+## 3. 파일별 상세 설명
+
+---
+
+### `config.py` — 설정 단일 관리 포인트
+
+모든 임계값과 환경변수를 **이 파일에서만** 관리한다.
+detector 파일들이 각자 숫자를 하드코딩하지 않고 `import config` 하나로 참조한다.
+임계값을 바꾸고 싶으면 이 파일만 수정하면 된다.
+
+```python
+SLACK_WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]  # 필수 — 없으면 기동 즉시 에러
+PROMETHEUS_URL    = os.environ.get("PROMETHEUS_URL", "http://prometheus:9090")
+AWS_REGION        = os.environ.get("AWS_REGION", "ap-northeast-2")
+ASG_NAME          = os.environ.get("ASG_NAME", "batch-kafka-app-asg")
+RDS_ID            = os.environ.get("RDS_ID", "batch-kafka-db")
+BATCH_API_URL     = os.environ.get("BATCH_API_URL", "http://alb-...")
+BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
+```
+
+`SLACK_WEBHOOK_URL`만 필수값.
+나머지는 기본값이 있어서 환경변수 주입 없이도 로컬 테스트 가능.
+
+---
+
+### `state.py` — 중복 알림 방지
+
+30초마다 폴링하는데 CPU가 10분 동안 90%면 Slack 알림이 20번 울린다.
+이걸 막는 역할. 쿨다운(기본 5분) 동안은 같은 알림을 보내지 않는다.
+
+```python
+_alert_state: dict[str, float] = {}  # {"cpu_critical": 1714900000.0}
+
+can_alert(key, cooldown)   # 쿨다운이 지났으면 True → 알림 보내도 됨
+record_alert(key)          # 알림 보낸 시각 기록 → 쿨다운 시작
+reset_alert(key)           # 이상 상태 해소 시 상태 삭제 → 다음 이상 시 즉시 알림
+```
+
+**쿨다운 동작 흐름**
+
+```
+이상 감지 → can_alert() True → 알림 발송 → record_alert() → 5분 쿨다운 시작
+30초 후   → can_alert() False (4분 30초 남음) → 스킵
+5분 후    → can_alert() True → 다시 알림
+이상 해소 → reset_alert() → 상태 초기화 → 다음 이상 시 즉시 알림 가능
+```
+
+인메모리 dict라서 컨테이너 재시작 시 초기화된다.
+이건 의도적 설계 — 재시작 후 이전 상태 오염 없이 깨끗하게 시작.
+
+---
+
+### `slack.py` — Slack 메시지 전송
+
+모든 detector가 공통으로 쓰는 Slack 전송 창구.
+`send_alert(level, title, body)` 하나만 노출.
+
+```python
+LEVEL_EMOJI = {
+    "P1": ":red_circle:",          # 🔴
+    "P2": ":large_yellow_circle:", # 🟡
+    "P3": ":large_blue_circle:",   # 🔵
+    "OK": ":white_check_mark:",    # ✅
+}
+```
+
+실제 Slack에 오는 메시지 예시:
+```
+🔴 *[P1] Redis Queue CRITICAL*
+Queue 적재량 870,000 (임계값 850,000 / 85%)
+데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박
+```
+
+`try/except`로 전송 실패를 삼킨다.
+Slack이 다운돼도 모니터링 서버가 죽으면 안 되기 때문.
+
+---
+
+### `monitor.py` — 폴링 루프 조율자
+
+`main.py`에서 스케줄러가 직접 부르는 함수 2개를 제공한다.
+
+```python
+def run_monitor() -> None:          # 30초마다
+    for check in [check_p1, check_p2, check_p3]:
+        try:
+            check()
+        except Exception as e:
+            logger.error(...)       # 에러 로그만, 다음 detector는 계속 실행
+
+def run_consistency_check() -> None:  # 1시간마다
+    check_consistency()
+```
+
+**핵심 설계**: 각 detector를 개별 `try/except`로 감쌈.
+p1이 Prometheus 연결 실패로 터져도 p2, p3는 정상 실행된다.
+
+---
+
+### `detectors/p1_detector.py` — P1 (가장 심각)
+
+#### 5xx 에러 감지
+
+```python
+promql = 'sum(increase(http_server_requests_seconds_count{status=~"5.."}[30s]))'
+```
+
+`increase(...[30s])`는 Prometheus가 **최근 30초 증가량을 직접 계산해서 반환**한다.
+별도 delta 계산 없이 이 값 자체를 사용.
+1건이라도 발생하면 P1 알림 (`HTTP_5XX_THRESHOLD=0`).
+
+#### Redis Queue 적재량 감지
+
+```python
+promql = "campaign_redis_queue_size"
+```
+
+2단계 임계값:
+- `>= 700,000` (70%) → P2 WARNING "Consumer 확인 권장"
+- `>= 850,000` (85%) → P1 CRITICAL "데이터 유실 위험"
+
+CRITICAL 발생 시 WARNING 쿨다운은 리셋 — CRITICAL 알림이 오면 WARNING 중복 방지.
+
+#### 데이터 정합성 검사 (1시간 주기)
+
+```python
+GET /api/admin/campaigns/{id}/consistency
+→ {"redisCount": 1000000, "dbCount": 1000000}
+```
+
+Redis 확정 건수 vs DB INSERT 건수 비교.
+차이 > 0 이면 P1 (유실 또는 중복 의심).
+일치하면 OK 알림 (1시간마다 "정상 확인" 메시지).
+
+`BATCH_CAMPAIGN_ID=0`이면 검사 스킵 — 환경변수 미설정 안전 처리.
+
+---
+
+### `detectors/p2_detector.py` — P2 (성능 경고)
+
+#### 앱 CPU (CloudWatch)
+
+Prometheus가 아닌 **CloudWatch** 사용 이유:
+Prometheus는 앱 자체 JVM 메트릭만 노출한다.
+EC2 인스턴스 레벨 CPU는 CloudWatch ASG 디멘션으로 조회해야 정확하다.
+
+```python
+Namespace="AWS/EC2"
+Dimensions=[{"Name": "AutoScalingGroupName", "Value": "batch-kafka-app-asg"}]
+Statistics=["Average"]
+```
+
+최근 2분 데이터포인트 중 **최고값** 기준 (최근 1분이 CloudWatch 집계 지연으로 비어있을 수 있음).
+
+#### Kafka lag
+
+```python
+promql = "sum(kafka_consumergroup_lag_sum)"
+```
+
+파티션 10개 × Consumer group 전체 합산.
+11차 테스트 때 rebalancing 순간 700 스파이크 경험 → WARNING=500, CRITICAL=1,000으로 설정.
+
+#### Consumer 처리 지연
+
+```python
+promql = "campaign_consumer_latency_ms"
+```
+
+11차 테스트 정상 범위: 7.5~15ms.
+50ms부터 이상 신호, 200ms는 DB 병목 또는 rebalancing 의심.
+
+#### HikariCP pending
+
+```python
+promql = "max(hikaricp_pending_threads)"
+```
+
+`avg()`가 아닌 `max()` — ASG 2대 중 **한 대라도** pending 있으면 알림.
+avg()면 한 대가 100이어도 다른 한 대 0이면 50으로 희석된다.
+
+---
+
+### `detectors/p3_detector.py` — P3 (인프라 모니터링)
+
+#### RDS CPU (CloudWatch)
+
+```python
+Namespace="AWS/RDS"
+Dimensions=[{"Name": "DBInstanceIdentifier", "Value": "batch-kafka-db"}]
+```
+
+11차 테스트 최대치 47% → **60%부터 이상**으로 판단.
+알림 메시지에 "11차 테스트 최대치 47%" 기준을 명시 — 운영자가 맥락 없이도 판단 가능.
+
+#### Bridge 드레인 사이클
+
+```python
+promql = "campaign_bridge_cycle_seconds"
+```
+
+`ParticipationBridge`는 `@Scheduled(fixedDelay=100ms)`.
+정상이면 사이클이 수백ms 이내.
+60초 초과 → Bridge가 멈췄거나 Kafka 연결 문제로 블로킹된 것.
+알림에 Redis Queue 적재량 연계 확인 힌트 포함.
+
+---
+
+### `tools.py` — MCP 도구 5개
+
+Claude가 SSE로 연결해서 직접 호출할 수 있는 도구들.
+**이 파일이 "MCP 서버"의 핵심 — Claude가 운영 상황을 직접 물어볼 수 있는 인터페이스.**
+
+| 도구 | 하는 일 | 예시 사용 상황 |
+|------|---------|--------------|
+| `get_monitor_status` | 현재 cooldown 상태 조회 | "지금 어떤 알림이 쿨다운 중이야?" |
+| `run_check` | p1/p2/p3/all 수동 즉시 실행 | "지금 당장 P1 검사 돌려봐" |
+| `query_prometheus` | PromQL 현재 값 조회 | "Redis Queue 지금 몇 건이야?" |
+| `query_prometheus_range` | 특정 구간 메트릭 시계열 조회 | "40분 전~20분 전 Kafka lag 봐줘" |
+| `get_test_report` | 테스트 구간 전체 핵심 메트릭 요약 | "방금 끝난 테스트 어디서 문제였어?" |
+| `reset_cooldown` | 특정 alert 쿨다운 리셋 | "cpu_critical 쿨다운 풀어줘" |
+| `trigger_consistency_check` | 정합성 검사 즉시 트리거 | "지금 정합성 검사 돌려봐" |
+
+MCP 엔드포인트: `GET /mcp/sse` (Claude 연결점)
+
+---
+
+### `main.py` — 진입점
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler.add_job(run_monitor, "interval", seconds=30, id="monitor")
+    scheduler.add_job(run_consistency_check, "interval", hours=1, id="consistency")
+    scheduler.start()
+    send_alert("OK", "모니터링 시작", "MCP 모니터링 서버가 정상 기동되었습니다.")
+    yield                          # ← 여기서 앱 실행 중
+    scheduler.shutdown(wait=False) # ← 종료 시 실행
+
+app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan)
+```
+
+FastAPI가 HTTP 서버 역할, APScheduler가 백그라운드 스케줄러 역할.
+둘이 같은 프로세스 안에서 동작.
+`@app.on_event`는 FastAPI 0.93+에서 deprecated — `lifespan` 컨텍스트 매니저 패턴 사용.
+
+`GET /health` → `{"status": "ok"}` — Docker HEALTHCHECK용.
+
+---
+
+### `Dockerfile`
+
+```dockerfile
+FROM python:3.11-slim          # 가벼운 베이스 이미지
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt   # 의존성 레이어 캐싱
+COPY . .
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+CMD ["python", "main.py"]
+```
+
+HEALTHCHECK가 `/health`를 30초마다 찌름. 3번 실패 시 컨테이너 `unhealthy` 상태 표시.
+`python:3.11-slim`에는 curl이 없어서 표준 라이브러리 `urllib.request`로 대체.
+
+---
+
+## 4. 전체 동작 메커니즘
+
+```
+docker run 실행
+        │
+        ▼
+    main.py 기동
+        │
+        ├── FastAPI 앱 시작 (port 8000)
+        │       ├── GET /health       ← Docker HEALTHCHECK
+        │       └── GET /mcp/sse      ← Claude 연결 진입점
+        │
+        ├── APScheduler 시작
+        │       │
+        │       ├── [30초마다] run_monitor()
+        │       │       │
+        │       │       ├── check_p1()
+        │       │       │     ├── Prometheus 쿼리 (5xx 건수)
+        │       │       │     └── Prometheus 쿼리 (Redis Queue 크기)
+        │       │       │
+        │       │       ├── check_p2()
+        │       │       │     ├── CloudWatch 조회 (ASG CPU)
+        │       │       │     ├── Prometheus 쿼리 (Kafka lag)
+        │       │       │     ├── Prometheus 쿼리 (Consumer 지연)
+        │       │       │     └── Prometheus 쿼리 (HikariCP pending)
+        │       │       │
+        │       │       └── check_p3()
+        │       │             ├── CloudWatch 조회 (RDS CPU)
+        │       │             └── Prometheus 쿼리 (Bridge 사이클)
+        │       │
+        │       └── [1시간마다] run_consistency_check()
+        │               └── GET /api/admin/campaigns/{id}/consistency
+        │
+        └── Slack "모니터링 시작" 전송
+```
+
+**이상 감지 시 상세 흐름 예시 (CPU)**
+
+```
+[T+0s]   check_p2() 실행
+         → CloudWatch: ASG CPU = 91%
+         → 91% >= CPU_CRITICAL_PERCENT(90%) 조건 충족
+         → can_alert("cpu_critical") == True  ← 쿨다운 없음
+         → send_alert("P2", "앱 CPU CRITICAL", "ASG CPU 91%...")
+         → record_alert("cpu_critical")  ← 5분 쿨다운 시작
+         → Slack에 🟡 [P2] 메시지 수신
+
+[T+30s]  check_p2() 실행
+         → CloudWatch: ASG CPU = 93%
+         → can_alert("cpu_critical") == False  ← 쿨다운 중 (4분 30초 남음)
+         → 스킵 (Slack 발송 없음)
+
+[T+300s] check_p2() 실행
+         → CloudWatch: ASG CPU = 88%
+         → 88% < CPU_CRITICAL_PERCENT(90%)
+         → 88% >= CPU_WARNING_PERCENT(80%)
+         → can_alert("cpu_warning") == True
+         → send_alert("P2", "앱 CPU WARNING", "ASG CPU 88%...")
+         → record_alert("cpu_warning")
+         → reset_alert("cpu_critical")  ← CRITICAL 상태 초기화
+
+[T+600s] check_p2() 실행
+         → CloudWatch: ASG CPU = 72%
+         → 72% < CPU_WARNING_PERCENT(80%)
+         → reset_alert("cpu_critical"), reset_alert("cpu_warning")
+         → 정상 (Slack 발송 없음)
+```
+
+---
+
+## 5. 인프라 적용 방법
+
+### 실행 환경
+
+`terraform-mcp` EC2 인스턴스에서 Docker 컨테이너로 실행.
+기존 `monitoring` Docker 네트워크에 합류 — Prometheus, redis-exporter와 컨테이너 이름 기반 통신.
+
+```
+monitoring 네트워크
+├── prometheus       ← mcp-monitor가 http://prometheus:9090 으로 접근
+├── redis-exporter
+├── kafka-exporter
+└── mcp-monitor      ← 신규 추가
+```
+
+### 빌드 및 실행
+
+```bash
+# terraform-mcp EC2에서 실행
+
+# 1. 레포 클론 (또는 pull)
+cd ~/1milion-campaign-orchestration-system
+
+# 2. 이미지 빌드
+sudo docker build -t mcp-monitor ./mcp-server
+
+# 3. 컨테이너 실행
+sudo docker run -d \
+  --name mcp-monitor \
+  --restart unless-stopped \
+  --network monitoring \
+  -p 8000:8000 \
+  -e SLACK_WEBHOOK_URL="https://hooks.slack.com/services/xxx/yyy/zzz" \
+  -e PROMETHEUS_URL="http://prometheus:9090" \
+  -e AWS_REGION="ap-northeast-2" \
+  -e ASG_NAME="batch-kafka-app-asg" \
+  -e RDS_ID="batch-kafka-db" \
+  -e BATCH_API_URL="http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com" \
+  -e BATCH_CAMPAIGN_ID="1" \
+  mcp-monitor
+
+# 4. monitoring 네트워크 연결 (run 시 --network로 이미 연결됨, 확인용)
+sudo docker network inspect monitoring | grep mcp-monitor
+
+# 5. 기동 확인
+curl http://localhost:8000/health
+# → {"status": "ok"}
+
+# 6. 로그 확인
+sudo docker logs mcp-monitor --follow
+```
+
+### AWS IAM 권한 설정
+
+CloudWatch 조회(ASG CPU, RDS CPU)를 위해 `terraform-mcp` EC2 인스턴스 역할에 아래 권한 필요:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "cloudwatch:GetMetricStatistics",
+    "cloudwatch:ListMetrics"
+  ],
+  "Resource": "*"
+}
+```
+
+boto3는 EC2 인스턴스 역할(Instance Profile)에서 자동으로 자격증명을 가져온다.
+별도 AWS_ACCESS_KEY 주입 불필요.
+
+### 컨테이너 재시작 후 복구
+
+`--restart unless-stopped` 옵션으로 EC2 재시작 시 자동 복구됨.
+단, monitoring 네트워크는 별도로 재연결 필요 없음 — run 시 `--network monitoring` 지정으로 고정.
+
+### Slack Incoming Webhook 발급
+
+1. Slack 워크스페이스 → Apps → Incoming Webhooks
+2. 채널 선택 → Webhook URL 복사
+3. `SLACK_WEBHOOK_URL` 환경변수에 주입
+
+---
+
+## 6. Claude (AI) 연동
+
+### MCP가 뭔가
+
+**MCP (Model Context Protocol)** — Anthropic이 만든 AI 도구 연동 표준 프로토콜.
+쉽게 말하면: Claude가 외부 시스템의 도구를 직접 호출할 수 있게 해주는 규격.
+
+이 서버에서 `tools.py`가 MCP 서버 역할을 한다.
+Claude가 `/mcp/sse`로 SSE 연결하면 어떤 도구가 있는지 목록을 받고, 도구를 직접 호출한다.
+
+### 어떤 AI가 쓰이는가
+
+**Claude** (Anthropic).
+Claude Desktop 또는 Claude Code가 이 MCP 서버에 연결해서 운영 도구를 사용한다.
+
+### 연결 방법 — Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS 기준):
+
+```json
+{
+  "mcpServers": {
+    "campaign-monitor": {
+      "url": "http://<terraform-mcp-public-ip>:8000/mcp/sse"
+    }
+  }
+}
+```
+
+Claude Desktop을 재시작하면 좌측 도구 목록에 `campaign-monitor`가 뜬다.
+
+### 실제 사용 시나리오
+
+Claude Desktop에서 대화:
+
+```
+사용자: 지금 Redis Queue 상태 어때?
+
+Claude: query_prometheus 도구를 사용해서 확인할게요.
+        [도구 호출: query_prometheus("campaign_redis_queue_size")]
+        → 현재 342,000건입니다. 임계값(700,000)의 34% 수준으로 정상입니다.
+
+사용자: Kafka lag은?
+
+Claude: [도구 호출: query_prometheus("sum(kafka_consumergroup_lag_sum)")]
+        → 현재 lag은 12입니다. 정상 범위입니다 (CRITICAL 임계값: 1,000).
+
+사용자: 아까 cpu_critical 알림 왔는데 지금은 어때?
+
+Claude: [도구 호출: get_monitor_status()]
+        → cpu_critical: 마지막 알림 240초 전, 쿨다운 잔여 60초
+        [도구 호출: query_prometheus("(ASG CPU PromQL)")]
+        → 현재 CPU 추이도 함께 설명...
+```
+
+### AI의 역할 범위
+
+| 할 수 있는 것 | 할 수 없는 것 |
+|--------------|--------------|
+| 메트릭 조회 및 분석 | 인스턴스 재시작 |
+| 이상 원인 설명 | ASG 스케일 조정 |
+| 수동 감지 트리거 | 코드 배포 |
+| 정합성 검사 실행 | DB 데이터 수정 |
+| 쿨다운 리셋 | 인프라 변경 |
+
+**설계 원칙: AI는 탐지와 설명만, 실행은 사람이 한다.**
+
+---
+
+## 7. 생각보다 금방 끝난 이유
+
+맞다. 상대적으로 빠르게 완성됐다. 이유가 있다.
+
+### 1단계 설계를 미리 잘 잡았다
+
+뼈대를 먼저 잡았기 때문에 2~5단계는 **패턴을 채워넣는 작업**이었다.
+모든 detector가 구조적으로 동일하다:
+
+```
+메트릭 조회 (Prometheus or CloudWatch)
+    → 임계값 비교
+    → can_alert() 확인
+    → send_alert()
+    → record_alert()
+```
+
+p1 작성하고 나면 p2, p3는 쿼리와 임계값만 바꾸면 됐다.
+
+### 실제 복잡도가 낮은 구간
+
+- `state.py`: dict 3개 함수, 10줄
+- `slack.py`: HTTP POST 하나, 25줄
+- `monitor.py`: for loop + try/except, 20줄
+- `tools.py`: 도구 정의 + 핸들러, 실제 로직은 기존 함수 호출뿐
+
+### 복잡도가 숨어있는 곳
+
+이 서버 자체보다 **연동하는 시스템이 이미 완성돼 있었다**:
+
+- Prometheus에 커스텀 메트릭 4종이 이미 수집 중 (Phase B에서 구축)
+- CloudWatch에 ASG/RDS 메트릭이 자동 수집 중
+- Slack Webhook은 기존 규격 그대로 사용
+- MCP 프로토콜은 라이브러리가 핵심 처리를 담당
+
+이 서버는 기존 인프라를 **연결하는 레이어**다.
+핵심 복잡도(부하 분산, Kafka 파티셔닝, Redis 원자 처리)는 이미 Phase A/B에서 해결됐다.
+
+### 남은 복잡도
+
+실제로 EC2에 올려서 돌리면 생길 이슈들:
+
+- Prometheus 메트릭 이름이 실제와 다를 경우 쿼리 조정
+- CloudWatch API 레이트리밋 (30초마다 폴링 × 2개 메트릭)
+- `check_consistency` API가 Spring Boot에 아직 구현 안 됐을 가능성
+- MCP SSE 연결 안정성 (네트워크 끊김 시 재연결)
+
+이런 부분은 실제 배포 후 로그 보면서 조정한다.

--- a/mcp-server/config.py
+++ b/mcp-server/config.py
@@ -12,7 +12,7 @@ BATCH_API_URL     = os.environ.get(
 BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
 
 # P1
-HTTP_5XX_THRESHOLD           = 0
+HTTP_5XX_THRESHOLD           = 1
 REDIS_QUEUE_WARNING          = 700_000   # 70%
 REDIS_QUEUE_CRITICAL         = 850_000   # 85%
 

--- a/mcp-server/config.py
+++ b/mcp-server/config.py
@@ -1,0 +1,33 @@
+import os
+
+SLACK_WEBHOOK_URL = os.environ["SLACK_WEBHOOK_URL"]
+PROMETHEUS_URL    = os.environ.get("PROMETHEUS_URL", "http://prometheus:9090")
+AWS_REGION        = os.environ.get("AWS_REGION", "ap-northeast-2")
+ASG_NAME          = os.environ.get("ASG_NAME", "batch-kafka-app-asg")
+RDS_ID            = os.environ.get("RDS_ID", "batch-kafka-db")
+BATCH_API_URL     = os.environ.get(
+    "BATCH_API_URL",
+    "http://alb-batch-kafka-api-1351817547.ap-northeast-2.elb.amazonaws.com",
+)
+BATCH_CAMPAIGN_ID = int(os.environ.get("BATCH_CAMPAIGN_ID", "0"))
+
+# P1
+HTTP_5XX_THRESHOLD           = 0
+REDIS_QUEUE_WARNING          = 700_000   # 70%
+REDIS_QUEUE_CRITICAL         = 850_000   # 85%
+
+# P2
+CPU_WARNING_PERCENT          = 80.0
+CPU_CRITICAL_PERCENT         = 90.0
+KAFKA_LAG_WARNING            = 500
+KAFKA_LAG_CRITICAL           = 1_000
+CONSUMER_LATENCY_WARNING_MS  = 50
+CONSUMER_LATENCY_CRITICAL_MS = 200
+HIKARI_PENDING_THRESHOLD     = 1
+
+# P3
+RDS_CPU_WARNING_PERCENT      = 60.0
+BRIDGE_CYCLE_WARNING_SECONDS = 60
+
+# Cooldown
+COOLDOWN_SECONDS = 300  # 5분

--- a/mcp-server/detectors/p1_detector.py
+++ b/mcp-server/detectors/p1_detector.py
@@ -5,7 +5,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -45,14 +45,13 @@ def _check_5xx() -> None:
 
     if delta > config.HTTP_5XX_THRESHOLD:
         key = "5xx_error"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "5xx 에러 발생",
                 f"최근 30초간 5xx 에러 *{delta:.0f}건* 감지\n"
                 f"Prometheus: `{promql}`",
             )
-            record_alert(key)
             logger.warning("P1 5xx=%.0f", delta)
     else:
         reset_alert("5xx_error")
@@ -72,27 +71,25 @@ def _check_redis_queue() -> None:
 
     if queue_size >= config.REDIS_QUEUE_CRITICAL:
         key = "redis_queue_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "Redis Queue CRITICAL",
                 f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_CRITICAL:,} / 85%)\n"
                 f"데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박",
             )
-            record_alert(key)
             logger.warning("P1 redis_queue CRITICAL size=%d", queue_size)
         reset_alert("redis_queue_warning")
 
     elif queue_size >= config.REDIS_QUEUE_WARNING:
         key = "redis_queue_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Redis Queue WARNING",
                 f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_WARNING:,} / 70%)\n"
                 f"Consumer 처리 속도 확인 권장",
             )
-            record_alert(key)
             logger.warning("P1 redis_queue WARNING size=%d", queue_size)
 
     else:
@@ -127,7 +124,7 @@ def check_consistency() -> None:
 
     if diff > 0:
         key = "consistency_mismatch"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P1",
                 "데이터 정합성 불일치",
@@ -135,7 +132,6 @@ def check_consistency() -> None:
                 f"DB INSERT 건수: *{db_count:,}*\n"
                 f"차이: *{diff:,}건* — 유실 또는 중복 가능성",
             )
-            record_alert(key)
     else:
         reset_alert("consistency_mismatch")
         send_alert(

--- a/mcp-server/detectors/p1_detector.py
+++ b/mcp-server/detectors/p1_detector.py
@@ -1,0 +1,154 @@
+"""P1 감지 — 5xx 에러 / Redis Queue 적재량 / 데이터 정합성."""
+import logging
+
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    """Prometheus instant query. 결과 없으면 None 반환."""
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 5xx 에러 감지
+# ---------------------------------------------------------------------------
+
+def _check_5xx() -> None:
+    # increase()가 이미 "최근 30초 증가량"을 반환 — 별도 delta 계산 불필요
+    promql = 'sum(increase(http_server_requests_seconds_count{status=~"5.."}[30s]))'
+    delta = _query_prometheus(promql)
+    if delta is None:
+        return
+
+    if delta > config.HTTP_5XX_THRESHOLD:
+        key = "5xx_error"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "5xx 에러 발생",
+                f"최근 30초간 5xx 에러 *{delta:.0f}건* 감지\n"
+                f"Prometheus: `{promql}`",
+            )
+            record_alert(key)
+            logger.warning("P1 5xx=%.0f", delta)
+    else:
+        reset_alert("5xx_error")
+
+
+# ---------------------------------------------------------------------------
+# Redis Queue 적재량 감지
+# ---------------------------------------------------------------------------
+
+def _check_redis_queue() -> None:
+    promql = "campaign_redis_queue_size"
+    value = _query_prometheus(promql)
+    if value is None:
+        return
+
+    queue_size = int(value)
+
+    if queue_size >= config.REDIS_QUEUE_CRITICAL:
+        key = "redis_queue_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "Redis Queue CRITICAL",
+                f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_CRITICAL:,} / 85%)\n"
+                f"데이터 유실 위험 — MAX_QUEUE_SIZE 초과 임박",
+            )
+            record_alert(key)
+            logger.warning("P1 redis_queue CRITICAL size=%d", queue_size)
+        reset_alert("redis_queue_warning")
+
+    elif queue_size >= config.REDIS_QUEUE_WARNING:
+        key = "redis_queue_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Redis Queue WARNING",
+                f"Queue 적재량 *{queue_size:,}* (임계값 {config.REDIS_QUEUE_WARNING:,} / 70%)\n"
+                f"Consumer 처리 속도 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P1 redis_queue WARNING size=%d", queue_size)
+
+    else:
+        reset_alert("redis_queue_critical")
+        reset_alert("redis_queue_warning")
+
+
+# ---------------------------------------------------------------------------
+# 데이터 정합성 검사 (1시간 폴링)
+# ---------------------------------------------------------------------------
+
+def check_consistency() -> None:
+    """Redis 재고 카운터 vs DB INSERT 건수 정합성 확인."""
+    if config.BATCH_CAMPAIGN_ID == 0:
+        logger.info("BATCH_CAMPAIGN_ID 미설정 — 정합성 검사 스킵")
+        return
+
+    url = f"{config.BATCH_API_URL}/api/admin/campaigns/{config.BATCH_CAMPAIGN_ID}/consistency"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.error("정합성 API 호출 실패: %s", e)
+        return
+
+    redis_count = data.get("redisCount", 0)
+    db_count    = data.get("dbCount", 0)
+    diff        = abs(redis_count - db_count)
+
+    logger.info("정합성 검사 — redis=%d db=%d diff=%d", redis_count, db_count, diff)
+
+    if diff > 0:
+        key = "consistency_mismatch"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P1",
+                "데이터 정합성 불일치",
+                f"Redis 확정 건수: *{redis_count:,}*\n"
+                f"DB INSERT 건수: *{db_count:,}*\n"
+                f"차이: *{diff:,}건* — 유실 또는 중복 가능성",
+            )
+            record_alert(key)
+    else:
+        reset_alert("consistency_mismatch")
+        send_alert(
+            "OK",
+            "정합성 검사 통과",
+            f"Redis = DB = *{db_count:,}건* 일치",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p1() -> None:
+    _check_5xx()
+    _check_redis_queue()

--- a/mcp-server/detectors/p2_detector.py
+++ b/mcp-server/detectors/p2_detector.py
@@ -1,0 +1,230 @@
+"""P2 감지 — 앱 CPU / Kafka lag / Consumer 지연 / HikariCP pending."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+_cw = boto3.client("cloudwatch", region_name=config.AWS_REGION)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+def _query_cloudwatch_asg_cpu() -> float | None:
+    """ASG 전체 인스턴스 평균 CPU (최근 1분)."""
+    now = datetime.now(timezone.utc)
+    try:
+        resp = _cw.get_metric_statistics(
+            Namespace="AWS/EC2",
+            MetricName="CPUUtilization",
+            Dimensions=[{"Name": "AutoScalingGroupName", "Value": config.ASG_NAME}],
+            StartTime=now - timedelta(minutes=2),
+            EndTime=now,
+            Period=60,
+            Statistics=["Average"],
+        )
+        datapoints = resp.get("Datapoints", [])
+        if not datapoints:
+            return None
+        return max(dp["Average"] for dp in datapoints)
+    except Exception as e:
+        logger.error("CloudWatch CPU 조회 실패: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 앱 CPU 감지
+# ---------------------------------------------------------------------------
+
+def _check_cpu() -> None:
+    cpu = _query_cloudwatch_asg_cpu()
+    if cpu is None:
+        return
+
+    logger.info("ASG CPU=%.1f%%", cpu)
+
+    if cpu >= config.CPU_CRITICAL_PERCENT:
+        key = "cpu_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "앱 CPU CRITICAL",
+                f"ASG `{config.ASG_NAME}` 평균 CPU *{cpu:.1f}%* "
+                f"(임계값 {config.CPU_CRITICAL_PERCENT}%)\n"
+                f"ASG Scale-out 또는 인스턴스 타입 확인 필요",
+            )
+            record_alert(key)
+            logger.warning("P2 CPU CRITICAL=%.1f%%", cpu)
+        reset_alert("cpu_warning")
+
+    elif cpu >= config.CPU_WARNING_PERCENT:
+        key = "cpu_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "앱 CPU WARNING",
+                f"ASG `{config.ASG_NAME}` 평균 CPU *{cpu:.1f}%* "
+                f"(임계값 {config.CPU_WARNING_PERCENT}%)\n"
+                f"트래픽 추이 모니터링 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 CPU WARNING=%.1f%%", cpu)
+
+    else:
+        reset_alert("cpu_critical")
+        reset_alert("cpu_warning")
+
+
+# ---------------------------------------------------------------------------
+# Kafka lag 감지
+# ---------------------------------------------------------------------------
+
+def _check_kafka_lag() -> None:
+    promql = "sum(kafka_consumergroup_lag_sum)"
+    lag = _query_prometheus(promql)
+    if lag is None:
+        return
+
+    lag = int(lag)
+    logger.info("Kafka lag=%d", lag)
+
+    if lag >= config.KAFKA_LAG_CRITICAL:
+        key = "kafka_lag_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Kafka lag CRITICAL",
+                f"Consumer group lag *{lag:,}* "
+                f"(임계값 {config.KAFKA_LAG_CRITICAL:,})\n"
+                f"Consumer 처리 속도 저하 또는 재균형 발생 가능",
+            )
+            record_alert(key)
+            logger.warning("P2 Kafka lag CRITICAL=%d", lag)
+        reset_alert("kafka_lag_warning")
+
+    elif lag >= config.KAFKA_LAG_WARNING:
+        key = "kafka_lag_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Kafka lag WARNING",
+                f"Consumer group lag *{lag:,}* "
+                f"(임계값 {config.KAFKA_LAG_WARNING:,})\n"
+                f"일시적 스파이크인지 추이 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 Kafka lag WARNING=%d", lag)
+
+    else:
+        reset_alert("kafka_lag_critical")
+        reset_alert("kafka_lag_warning")
+
+
+# ---------------------------------------------------------------------------
+# Consumer 지연 감지
+# ---------------------------------------------------------------------------
+
+def _check_consumer_latency() -> None:
+    promql = "campaign_consumer_latency_ms"
+    latency = _query_prometheus(promql)
+    if latency is None:
+        return
+
+    logger.info("Consumer latency=%.1fms", latency)
+
+    if latency >= config.CONSUMER_LATENCY_CRITICAL_MS:
+        key = "consumer_latency_critical"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Consumer 지연 CRITICAL",
+                f"Consumer 처리 지연 *{latency:.0f}ms* "
+                f"(임계값 {config.CONSUMER_LATENCY_CRITICAL_MS}ms)\n"
+                f"DB INSERT 병목 또는 Kafka rebalancing 의심",
+            )
+            record_alert(key)
+            logger.warning("P2 consumer latency CRITICAL=%.1fms", latency)
+        reset_alert("consumer_latency_warning")
+
+    elif latency >= config.CONSUMER_LATENCY_WARNING_MS:
+        key = "consumer_latency_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "Consumer 지연 WARNING",
+                f"Consumer 처리 지연 *{latency:.0f}ms* "
+                f"(임계값 {config.CONSUMER_LATENCY_WARNING_MS}ms)\n"
+                f"HikariCP pending 및 RDS CPU 함께 확인 권장",
+            )
+            record_alert(key)
+            logger.warning("P2 consumer latency WARNING=%.1fms", latency)
+
+    else:
+        reset_alert("consumer_latency_critical")
+        reset_alert("consumer_latency_warning")
+
+
+# ---------------------------------------------------------------------------
+# HikariCP pending 감지
+# ---------------------------------------------------------------------------
+
+def _check_hikari_pending() -> None:
+    # 전체 인스턴스 중 최대값 기준
+    promql = "max(hikaricp_pending_threads)"
+    pending = _query_prometheus(promql)
+    if pending is None:
+        return
+
+    pending = int(pending)
+    logger.info("HikariCP pending=%d", pending)
+
+    if pending >= config.HIKARI_PENDING_THRESHOLD:
+        key = "hikari_pending"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P2",
+                "HikariCP pending 발생",
+                f"DB 커넥션 대기 *{pending}개* "
+                f"(임계값 {config.HIKARI_PENDING_THRESHOLD})\n"
+                f"RDS CPU 및 slow query 확인 필요",
+            )
+            record_alert(key)
+            logger.warning("P2 HikariCP pending=%d", pending)
+    else:
+        reset_alert("hikari_pending")
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p2() -> None:
+    _check_cpu()
+    _check_kafka_lag()
+    _check_consumer_latency()
+    _check_hikari_pending()

--- a/mcp-server/detectors/p2_detector.py
+++ b/mcp-server/detectors/p2_detector.py
@@ -7,7 +7,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def _check_cpu() -> None:
 
     if cpu >= config.CPU_CRITICAL_PERCENT:
         key = "cpu_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "앱 CPU CRITICAL",
@@ -78,13 +78,12 @@ def _check_cpu() -> None:
                 f"(임계값 {config.CPU_CRITICAL_PERCENT}%)\n"
                 f"ASG Scale-out 또는 인스턴스 타입 확인 필요",
             )
-            record_alert(key)
             logger.warning("P2 CPU CRITICAL=%.1f%%", cpu)
         reset_alert("cpu_warning")
 
     elif cpu >= config.CPU_WARNING_PERCENT:
         key = "cpu_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "앱 CPU WARNING",
@@ -92,7 +91,6 @@ def _check_cpu() -> None:
                 f"(임계값 {config.CPU_WARNING_PERCENT}%)\n"
                 f"트래픽 추이 모니터링 권장",
             )
-            record_alert(key)
             logger.warning("P2 CPU WARNING=%.1f%%", cpu)
 
     else:
@@ -115,7 +113,7 @@ def _check_kafka_lag() -> None:
 
     if lag >= config.KAFKA_LAG_CRITICAL:
         key = "kafka_lag_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Kafka lag CRITICAL",
@@ -123,13 +121,12 @@ def _check_kafka_lag() -> None:
                 f"(임계값 {config.KAFKA_LAG_CRITICAL:,})\n"
                 f"Consumer 처리 속도 저하 또는 재균형 발생 가능",
             )
-            record_alert(key)
             logger.warning("P2 Kafka lag CRITICAL=%d", lag)
         reset_alert("kafka_lag_warning")
 
     elif lag >= config.KAFKA_LAG_WARNING:
         key = "kafka_lag_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Kafka lag WARNING",
@@ -137,7 +134,6 @@ def _check_kafka_lag() -> None:
                 f"(임계값 {config.KAFKA_LAG_WARNING:,})\n"
                 f"일시적 스파이크인지 추이 확인 권장",
             )
-            record_alert(key)
             logger.warning("P2 Kafka lag WARNING=%d", lag)
 
     else:
@@ -159,7 +155,7 @@ def _check_consumer_latency() -> None:
 
     if latency >= config.CONSUMER_LATENCY_CRITICAL_MS:
         key = "consumer_latency_critical"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Consumer 지연 CRITICAL",
@@ -167,13 +163,12 @@ def _check_consumer_latency() -> None:
                 f"(임계값 {config.CONSUMER_LATENCY_CRITICAL_MS}ms)\n"
                 f"DB INSERT 병목 또는 Kafka rebalancing 의심",
             )
-            record_alert(key)
             logger.warning("P2 consumer latency CRITICAL=%.1fms", latency)
         reset_alert("consumer_latency_warning")
 
     elif latency >= config.CONSUMER_LATENCY_WARNING_MS:
         key = "consumer_latency_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "Consumer 지연 WARNING",
@@ -181,7 +176,6 @@ def _check_consumer_latency() -> None:
                 f"(임계값 {config.CONSUMER_LATENCY_WARNING_MS}ms)\n"
                 f"HikariCP pending 및 RDS CPU 함께 확인 권장",
             )
-            record_alert(key)
             logger.warning("P2 consumer latency WARNING=%.1fms", latency)
 
     else:
@@ -205,7 +199,7 @@ def _check_hikari_pending() -> None:
 
     if pending >= config.HIKARI_PENDING_THRESHOLD:
         key = "hikari_pending"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P2",
                 "HikariCP pending 발생",
@@ -213,7 +207,6 @@ def _check_hikari_pending() -> None:
                 f"(임계값 {config.HIKARI_PENDING_THRESHOLD})\n"
                 f"RDS CPU 및 slow query 확인 필요",
             )
-            record_alert(key)
             logger.warning("P2 HikariCP pending=%d", pending)
     else:
         reset_alert("hikari_pending")

--- a/mcp-server/detectors/p3_detector.py
+++ b/mcp-server/detectors/p3_detector.py
@@ -1,0 +1,124 @@
+"""P3 감지 — RDS CPU / Bridge 드레인 사이클."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import requests
+
+import config
+from slack import send_alert
+from state import can_alert, record_alert, reset_alert
+
+logger = logging.getLogger(__name__)
+
+_cw = boto3.client("cloudwatch", region_name=config.AWS_REGION)
+
+
+# ---------------------------------------------------------------------------
+# 내부 헬퍼
+# ---------------------------------------------------------------------------
+
+def _query_prometheus(promql: str) -> float | None:
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+        if not result:
+            return None
+        return float(result[0]["value"][1])
+    except Exception as e:
+        logger.error("Prometheus 쿼리 실패 [%s]: %s", promql, e)
+        return None
+
+
+def _query_cloudwatch_rds_cpu() -> float | None:
+    """RDS 인스턴스 CPU 평균 (최근 1분)."""
+    now = datetime.now(timezone.utc)
+    try:
+        resp = _cw.get_metric_statistics(
+            Namespace="AWS/RDS",
+            MetricName="CPUUtilization",
+            Dimensions=[{"Name": "DBInstanceIdentifier", "Value": config.RDS_ID}],
+            StartTime=now - timedelta(minutes=2),
+            EndTime=now,
+            Period=60,
+            Statistics=["Average"],
+        )
+        datapoints = resp.get("Datapoints", [])
+        if not datapoints:
+            return None
+        return max(dp["Average"] for dp in datapoints)
+    except Exception as e:
+        logger.error("CloudWatch RDS CPU 조회 실패: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# RDS CPU 감지
+# ---------------------------------------------------------------------------
+
+def _check_rds_cpu() -> None:
+    cpu = _query_cloudwatch_rds_cpu()
+    if cpu is None:
+        return
+
+    logger.info("RDS CPU=%.1f%%", cpu)
+
+    if cpu >= config.RDS_CPU_WARNING_PERCENT:
+        key = "rds_cpu_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P3",
+                "RDS CPU WARNING",
+                f"DB `{config.RDS_ID}` CPU *{cpu:.1f}%* "
+                f"(임계값 {config.RDS_CPU_WARNING_PERCENT}%)\n"
+                f"slow query 또는 HikariCP pool 크기 확인 권장\n"
+                f"11차 테스트 최대치: 47% — 현재 {cpu:.0f}%는 비정상 수준",
+            )
+            record_alert(key)
+            logger.warning("P3 RDS CPU WARNING=%.1f%%", cpu)
+    else:
+        reset_alert("rds_cpu_warning")
+
+
+# ---------------------------------------------------------------------------
+# Bridge 드레인 사이클 감지
+# ---------------------------------------------------------------------------
+
+def _check_bridge_cycle() -> None:
+    """Bridge 사이클 시간이 임계값 초과 시 Queue 드레인 지연 의심."""
+    promql = "campaign_bridge_cycle_seconds"
+    cycle_sec = _query_prometheus(promql)
+    if cycle_sec is None:
+        return
+
+    logger.info("Bridge cycle=%.2fs", cycle_sec)
+
+    if cycle_sec >= config.BRIDGE_CYCLE_WARNING_SECONDS:
+        key = "bridge_cycle_warning"
+        if can_alert(key, config.COOLDOWN_SECONDS):
+            send_alert(
+                "P3",
+                "Bridge 드레인 사이클 지연",
+                f"ParticipationBridge 사이클 *{cycle_sec:.1f}초* "
+                f"(임계값 {config.BRIDGE_CYCLE_WARNING_SECONDS}초)\n"
+                f"Queue → Kafka 전송 지연 — Redis Queue 적재량 함께 확인\n"
+                f"정상 범위: 100ms 간격 스케줄, 사이클당 최대 2,000건 배치",
+            )
+            record_alert(key)
+            logger.warning("P3 Bridge cycle WARNING=%.2fs", cycle_sec)
+    else:
+        reset_alert("bridge_cycle_warning")
+
+
+# ---------------------------------------------------------------------------
+# 30초 폴링 진입점
+# ---------------------------------------------------------------------------
+
+def check_p3() -> None:
+    _check_rds_cpu()
+    _check_bridge_cycle()

--- a/mcp-server/detectors/p3_detector.py
+++ b/mcp-server/detectors/p3_detector.py
@@ -7,7 +7,7 @@ import requests
 
 import config
 from slack import send_alert
-from state import can_alert, record_alert, reset_alert
+from state import check_and_record, reset_alert
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def _check_rds_cpu() -> None:
 
     if cpu >= config.RDS_CPU_WARNING_PERCENT:
         key = "rds_cpu_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P3",
                 "RDS CPU WARNING",
@@ -79,7 +79,6 @@ def _check_rds_cpu() -> None:
                 f"slow query 또는 HikariCP pool 크기 확인 권장\n"
                 f"11차 테스트 최대치: 47% — 현재 {cpu:.0f}%는 비정상 수준",
             )
-            record_alert(key)
             logger.warning("P3 RDS CPU WARNING=%.1f%%", cpu)
     else:
         reset_alert("rds_cpu_warning")
@@ -100,7 +99,7 @@ def _check_bridge_cycle() -> None:
 
     if cycle_sec >= config.BRIDGE_CYCLE_WARNING_SECONDS:
         key = "bridge_cycle_warning"
-        if can_alert(key, config.COOLDOWN_SECONDS):
+        if check_and_record(key, config.COOLDOWN_SECONDS):
             send_alert(
                 "P3",
                 "Bridge 드레인 사이클 지연",
@@ -109,7 +108,6 @@ def _check_bridge_cycle() -> None:
                 f"Queue → Kafka 전송 지연 — Redis Queue 적재량 함께 확인\n"
                 f"정상 범위: 100ms 간격 스케줄, 사이클당 최대 2,000건 배치",
             )
-            record_alert(key)
             logger.warning("P3 Bridge cycle WARNING=%.2fs", cycle_sec)
     else:
         reset_alert("bridge_cycle_warning")

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -1,0 +1,42 @@
+import logging
+from contextlib import asynccontextmanager
+
+import uvicorn
+from apscheduler.schedulers.background import BackgroundScheduler
+from fastapi import FastAPI
+
+from monitor import run_consistency_check, run_monitor
+from slack import send_alert
+from tools import mcp_routes
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+scheduler = BackgroundScheduler()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler.add_job(run_monitor, "interval", seconds=30, id="monitor")
+    scheduler.add_job(run_consistency_check, "interval", hours=1, id="consistency")
+    scheduler.start()
+    logger.info("스케줄러 시작 — 30초 폴링, 1시간 정합성 검사")
+    send_alert("OK", "모니터링 시작", "MCP 모니터링 서버가 정상 기동되었습니다.")
+    yield
+    scheduler.shutdown(wait=False)
+    logger.info("스케줄러 종료")
+
+
+app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=False)

--- a/mcp-server/monitor.py
+++ b/mcp-server/monitor.py
@@ -1,0 +1,24 @@
+import logging
+
+from detectors.p1_detector import check_p1
+from detectors.p2_detector import check_p2
+from detectors.p3_detector import check_p3
+
+logger = logging.getLogger(__name__)
+
+
+def run_monitor() -> None:
+    for check in [check_p1, check_p2, check_p3]:
+        try:
+            check()
+        except Exception as e:
+            logger.error("%s 오류: %s", check.__name__, e)
+
+
+def run_consistency_check() -> None:
+    """1시간마다 실행되는 정합성 검사 (p1_detector에서 구현)."""
+    try:
+        from detectors.p1_detector import check_consistency
+        check_consistency()
+    except Exception as e:
+        logger.error("consistency_check 오류: %s", e)

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.6
+uvicorn==0.30.6
+apscheduler==3.10.4
+requests==2.32.3
+boto3==1.35.0
+mcp==1.0.0

--- a/mcp-server/slack.py
+++ b/mcp-server/slack.py
@@ -1,0 +1,28 @@
+import logging
+
+import requests
+
+from config import SLACK_WEBHOOK_URL
+
+logger = logging.getLogger(__name__)
+
+LEVEL_EMOJI = {
+    "P1": ":red_circle:",
+    "P2": ":large_yellow_circle:",
+    "P3": ":large_blue_circle:",
+    "OK": ":white_check_mark:",
+}
+
+
+def send_alert(level: str, title: str, body: str) -> None:
+    emoji = LEVEL_EMOJI.get(level, "")
+    text = f"{emoji} *[{level}] {title}*\n{body}"
+    try:
+        resp = requests.post(
+            SLACK_WEBHOOK_URL,
+            json={"text": text},
+            timeout=5,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.error("Slack 전송 실패: %s", e)

--- a/mcp-server/state.py
+++ b/mcp-server/state.py
@@ -1,0 +1,15 @@
+import time
+
+_alert_state: dict[str, float] = {}
+
+
+def can_alert(key: str, cooldown: int) -> bool:
+    return (time.time() - _alert_state.get(key, 0)) >= cooldown
+
+
+def record_alert(key: str) -> None:
+    _alert_state[key] = time.time()
+
+
+def reset_alert(key: str) -> None:
+    _alert_state.pop(key, None)

--- a/mcp-server/state.py
+++ b/mcp-server/state.py
@@ -1,15 +1,31 @@
+import threading
 import time
 
 _alert_state: dict[str, float] = {}
+_lock = threading.Lock()
 
 
-def can_alert(key: str, cooldown: int) -> bool:
-    return (time.time() - _alert_state.get(key, 0)) >= cooldown
-
-
-def record_alert(key: str) -> None:
-    _alert_state[key] = time.time()
+def check_and_record(key: str, cooldown: int) -> bool:
+    """can_alert + record_alert를 atomic하게 실행. True면 알림 발송 가능."""
+    with _lock:
+        if (time.time() - _alert_state.get(key, 0)) >= cooldown:
+            _alert_state[key] = time.time()
+            return True
+        return False
 
 
 def reset_alert(key: str) -> None:
-    _alert_state.pop(key, None)
+    with _lock:
+        _alert_state.pop(key, None)
+
+
+def list_alerts() -> dict[str, float]:
+    with _lock:
+        return dict(_alert_state)
+
+
+def reset_all() -> list[str]:
+    with _lock:
+        keys = list(_alert_state.keys())
+        _alert_state.clear()
+        return keys

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -1,0 +1,446 @@
+"""MCP 도구 노출 — Claude가 직접 호출할 수 있는 읽기 전용 운영 도구."""
+import logging
+import time
+
+import requests
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+from mcp.types import TextContent, Tool
+from starlette.routing import Route
+
+import config
+import state
+from detectors.p1_detector import check_consistency, check_p1
+from detectors.p2_detector import check_p2
+from detectors.p3_detector import check_p3
+
+logger = logging.getLogger(__name__)
+
+mcp_server = Server("mcp-monitor")
+
+
+# ---------------------------------------------------------------------------
+# 도구 목록 정의
+# ---------------------------------------------------------------------------
+
+@mcp_server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="get_monitor_status",
+            description=(
+                "현재 alert cooldown 상태를 반환합니다. "
+                "어떤 알림이 활성화(쿨다운 중)인지, 마지막 알림 시각이 언제인지 확인합니다."
+            ),
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="run_check",
+            description=(
+                "P1/P2/P3 detector를 수동으로 즉시 실행합니다. "
+                "쿨다운 무시 없이 실제 감지 로직을 실행하며, Slack 알림도 발송됩니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "level": {
+                        "type": "string",
+                        "enum": ["p1", "p2", "p3", "all"],
+                        "description": "실행할 detector (p1/p2/p3/all)",
+                    }
+                },
+                "required": ["level"],
+            },
+        ),
+        Tool(
+            name="query_prometheus",
+            description=(
+                "Prometheus에 PromQL 쿼리를 실행하고 결과를 반환합니다. "
+                "현재 메트릭 값을 직접 확인할 때 사용합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "promql": {
+                        "type": "string",
+                        "description": "실행할 PromQL 쿼리 (예: campaign_redis_queue_size)",
+                    }
+                },
+                "required": ["promql"],
+            },
+        ),
+        Tool(
+            name="reset_cooldown",
+            description=(
+                "특정 alert의 쿨다운을 리셋합니다. "
+                "쿨다운 중인 알림을 즉시 재발송 가능하게 만들 때 사용합니다. "
+                "key를 'all'로 지정하면 모든 쿨다운을 초기화합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": (
+                            "리셋할 alert key "
+                            "(예: 5xx_error / redis_queue_critical / cpu_warning / all)"
+                        ),
+                    }
+                },
+                "required": ["key"],
+            },
+        ),
+        Tool(
+            name="trigger_consistency_check",
+            description=(
+                "Redis 재고 카운터와 DB INSERT 건수 정합성 검사를 즉시 실행합니다. "
+                "1시간 주기를 기다리지 않고 수동으로 트리거합니다."
+            ),
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="query_prometheus_range",
+            description=(
+                "Prometheus에 특정 시간 구간의 메트릭을 조회합니다. "
+                "부하 테스트 종료 후 '아까 어디서 문제였나' 분석에 사용합니다. "
+                "start/end는 Unix timestamp 또는 'now-1h' 같은 상대 표현 사용 가능."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "promql": {
+                        "type": "string",
+                        "description": "실행할 PromQL 쿼리",
+                    },
+                    "start_minutes_ago": {
+                        "type": "integer",
+                        "description": "조회 시작점 (현재로부터 몇 분 전). 예: 60 → 1시간 전부터",
+                    },
+                    "end_minutes_ago": {
+                        "type": "integer",
+                        "description": "조회 종료점 (현재로부터 몇 분 전). 예: 0 → 지금까지",
+                        "default": 0,
+                    },
+                    "step_seconds": {
+                        "type": "integer",
+                        "description": "데이터 포인트 간격(초). 기본 30초",
+                        "default": 30,
+                    },
+                },
+                "required": ["promql", "start_minutes_ago"],
+            },
+        ),
+        Tool(
+            name="get_test_report",
+            description=(
+                "부하 테스트 구간 전체 핵심 메트릭을 한번에 조회해서 요약합니다. "
+                "테스트 종료 후 '어디서 문제가 있었나' 파악할 때 사용합니다. "
+                "각 메트릭의 최대값과 임계값 초과 여부를 함께 반환합니다."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "start_minutes_ago": {
+                        "type": "integer",
+                        "description": "테스트 시작 시각 (현재로부터 몇 분 전). 예: 60",
+                    },
+                    "end_minutes_ago": {
+                        "type": "integer",
+                        "description": "테스트 종료 시각 (현재로부터 몇 분 전). 예: 0 → 지금",
+                        "default": 0,
+                    },
+                },
+                "required": ["start_minutes_ago"],
+            },
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 도구 실행 핸들러
+# ---------------------------------------------------------------------------
+
+@mcp_server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name == "get_monitor_status":
+        return _handle_get_monitor_status()
+
+    if name == "run_check":
+        return _handle_run_check(arguments.get("level", "all"))
+
+    if name == "query_prometheus":
+        return _handle_query_prometheus(arguments.get("promql", ""))
+
+    if name == "reset_cooldown":
+        return _handle_reset_cooldown(arguments.get("key", ""))
+
+    if name == "trigger_consistency_check":
+        return _handle_trigger_consistency_check()
+
+    if name == "query_prometheus_range":
+        return _handle_query_prometheus_range(
+            promql=arguments.get("promql", ""),
+            start_minutes_ago=arguments.get("start_minutes_ago", 60),
+            end_minutes_ago=arguments.get("end_minutes_ago", 0),
+            step_seconds=arguments.get("step_seconds", 30),
+        )
+
+    if name == "get_test_report":
+        return _handle_get_test_report(
+            start_minutes_ago=arguments.get("start_minutes_ago", 60),
+            end_minutes_ago=arguments.get("end_minutes_ago", 0),
+        )
+
+    return [TextContent(type="text", text=f"알 수 없는 도구: {name}")]
+
+
+# ---------------------------------------------------------------------------
+# 핸들러 구현
+# ---------------------------------------------------------------------------
+
+def _handle_get_monitor_status() -> list[TextContent]:
+    now = time.time()
+    alert_state = state._alert_state
+
+    if not alert_state:
+        return [TextContent(type="text", text="현재 활성화된 alert 없음 (모든 쿨다운 초기화 상태)")]
+
+    lines = ["**현재 alert cooldown 상태**\n"]
+    for key, last_time in sorted(alert_state.items()):
+        elapsed = now - last_time
+        remaining = max(0.0, config.COOLDOWN_SECONDS - elapsed)
+        lines.append(
+            f"- `{key}`: 마지막 알림 {elapsed:.0f}초 전 / "
+            f"쿨다운 잔여 {remaining:.0f}초"
+        )
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+def _handle_run_check(level: str) -> list[TextContent]:
+    results = []
+    checks = {
+        "p1": ("P1 (5xx / Redis Queue)", check_p1),
+        "p2": ("P2 (CPU / Kafka lag / Consumer / HikariCP)", check_p2),
+        "p3": ("P3 (RDS CPU / Bridge 사이클)", check_p3),
+    }
+
+    targets = checks.items() if level == "all" else [(level, checks[level])] if level in checks else []
+
+    if not targets:
+        return [TextContent(type="text", text=f"알 수 없는 level: {level}")]
+
+    for key, (label, fn) in targets:
+        try:
+            fn()
+            results.append(f"✓ {label} 실행 완료")
+        except Exception as e:
+            results.append(f"✗ {label} 실행 실패: {e}")
+
+    return [TextContent(type="text", text="\n".join(results))]
+
+
+def _handle_query_prometheus(promql: str) -> list[TextContent]:
+    if not promql:
+        return [TextContent(type="text", text="promql 파라미터가 필요합니다.")]
+
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query",
+            params={"query": promql},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        result = data.get("data", {}).get("result", [])
+
+        if not result:
+            return [TextContent(type="text", text=f"`{promql}` → 결과 없음 (메트릭 미수집 또는 쿼리 오류)")]
+
+        lines = [f"**Prometheus 쿼리**: `{promql}`\n"]
+        for item in result:
+            metric = item.get("metric", {})
+            value = item["value"][1]
+            label_str = ", ".join(f'{k}="{v}"' for k, v in metric.items()) or "(no labels)"
+            lines.append(f"- {label_str}: **{value}**")
+
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Prometheus 쿼리 실패: {e}")]
+
+
+def _handle_reset_cooldown(key: str) -> list[TextContent]:
+    if not key:
+        return [TextContent(type="text", text="key 파라미터가 필요합니다.")]
+
+    if key == "all":
+        cleared = list(state._alert_state.keys())
+        state._alert_state.clear()
+        return [TextContent(type="text", text=f"전체 쿨다운 초기화 완료: {cleared}")]
+
+    if key in state._alert_state:
+        state.reset_alert(key)
+        return [TextContent(type="text", text=f"`{key}` 쿨다운 리셋 완료")]
+
+    return [TextContent(type="text", text=f"`{key}` 는 현재 쿨다운 상태가 아닙니다.")]
+
+
+def _handle_query_prometheus_range(
+    promql: str,
+    start_minutes_ago: int,
+    end_minutes_ago: int,
+    step_seconds: int,
+) -> list[TextContent]:
+    if not promql:
+        return [TextContent(type="text", text="promql 파라미터가 필요합니다.")]
+
+    now = time.time()
+    start = now - start_minutes_ago * 60
+    end   = now - end_minutes_ago * 60
+
+    try:
+        resp = requests.get(
+            f"{config.PROMETHEUS_URL}/api/v1/query_range",
+            params={"query": promql, "start": start, "end": end, "step": step_seconds},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+
+        if not result:
+            return [TextContent(type="text", text=f"`{promql}` → 해당 구간 데이터 없음")]
+
+        lines = [
+            f"**{promql}** ({start_minutes_ago}분 전 ~ {end_minutes_ago}분 전)\n"
+        ]
+        for series in result:
+            values = [float(v[1]) for v in series["value"] if v[1] != "NaN"] if "value" in series else \
+                     [float(v[1]) for v in series.get("values", []) if v[1] != "NaN"]
+            if not values:
+                continue
+            label_str = ", ".join(f'{k}="{v}"' for k, v in series.get("metric", {}).items()) or "(no labels)"
+            lines.append(
+                f"- {label_str}\n"
+                f"  최솟값: {min(values):.2f} / 최대값: {max(values):.2f} / 평균: {sum(values)/len(values):.2f}"
+            )
+
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Prometheus range 쿼리 실패: {e}")]
+
+
+# 테스트 리포트에서 조회할 메트릭 목록 (promql, 레이블, 임계값)
+_REPORT_METRICS = [
+    (
+        'sum(increase(http_server_requests_seconds_count{status=~"5.."}[1m]))',
+        "5xx 에러 (1분 합산)",
+        config.HTTP_5XX_THRESHOLD,
+        "건",
+    ),
+    (
+        "campaign_redis_queue_size",
+        "Redis Queue 적재량",
+        config.REDIS_QUEUE_CRITICAL,
+        "건",
+    ),
+    (
+        "sum(kafka_consumergroup_lag_sum)",
+        "Kafka consumer lag",
+        config.KAFKA_LAG_CRITICAL,
+        "",
+    ),
+    (
+        "campaign_consumer_latency_ms",
+        "Consumer 처리 지연",
+        config.CONSUMER_LATENCY_CRITICAL_MS,
+        "ms",
+    ),
+    (
+        "max(hikaricp_pending_threads)",
+        "HikariCP pending",
+        config.HIKARI_PENDING_THRESHOLD,
+        "개",
+    ),
+    (
+        "campaign_bridge_cycle_seconds",
+        "Bridge 드레인 사이클",
+        config.BRIDGE_CYCLE_WARNING_SECONDS,
+        "초",
+    ),
+]
+
+
+def _handle_get_test_report(start_minutes_ago: int, end_minutes_ago: int) -> list[TextContent]:
+    now   = time.time()
+    start = now - start_minutes_ago * 60
+    end   = now - end_minutes_ago * 60
+    step  = 30  # 30초 해상도
+
+    lines = [
+        f"## 부하 테스트 리포트",
+        f"조회 구간: {start_minutes_ago}분 전 ~ {end_minutes_ago}분 전\n",
+        f"{'메트릭':<30} {'최대값':>12} {'임계값':>12} {'초과':>6}",
+        "-" * 65,
+    ]
+
+    for promql, label, threshold, unit in _REPORT_METRICS:
+        try:
+            resp = requests.get(
+                f"{config.PROMETHEUS_URL}/api/v1/query_range",
+                params={"query": promql, "start": start, "end": end, "step": step},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            result = resp.json().get("data", {}).get("result", [])
+
+            if not result:
+                lines.append(f"{label:<30} {'데이터 없음':>12}")
+                continue
+
+            all_values = []
+            for series in result:
+                all_values += [float(v[1]) for v in series.get("values", []) if v[1] != "NaN"]
+
+            if not all_values:
+                lines.append(f"{label:<30} {'데이터 없음':>12}")
+                continue
+
+            max_val = max(all_values)
+            exceeded = "⚠️ YES" if max_val > threshold else "OK"
+            lines.append(
+                f"{label:<30} {f'{max_val:.1f}{unit}':>12} {f'{threshold}{unit}':>12} {exceeded:>6}"
+            )
+
+        except Exception as e:
+            lines.append(f"{label:<30} 조회 실패: {e}")
+
+    lines.append("\n*CloudWatch 메트릭(앱 CPU, RDS CPU)은 query_prometheus_range로 별도 확인*")
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+def _handle_trigger_consistency_check() -> list[TextContent]:
+    try:
+        check_consistency()
+        return [TextContent(type="text", text="정합성 검사 실행 완료 — Slack 결과 확인")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"정합성 검사 실패: {e}")]
+
+
+# ---------------------------------------------------------------------------
+# FastAPI 마운트용 SSE transport
+# ---------------------------------------------------------------------------
+
+sse = SseServerTransport("/mcp/messages")
+
+
+async def handle_sse(request):
+    async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+        await mcp_server.run(streams[0], streams[1], mcp_server.create_initialization_options())
+
+
+mcp_routes = [
+    Route("/mcp/sse", endpoint=handle_sse),
+    Route("/mcp/messages", endpoint=sse.handle_post_message, methods=["POST"]),
+]

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -200,7 +200,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
 def _handle_get_monitor_status() -> list[TextContent]:
     now = time.time()
-    alert_state = state._alert_state
+    alert_state = state.list_alerts()
 
     if not alert_state:
         return [TextContent(type="text", text="현재 활성화된 alert 없음 (모든 쿨다운 초기화 상태)")]
@@ -275,11 +275,10 @@ def _handle_reset_cooldown(key: str) -> list[TextContent]:
         return [TextContent(type="text", text="key 파라미터가 필요합니다.")]
 
     if key == "all":
-        cleared = list(state._alert_state.keys())
-        state._alert_state.clear()
+        cleared = state.reset_all()
         return [TextContent(type="text", text=f"전체 쿨다운 초기화 완료: {cleared}")]
 
-    if key in state._alert_state:
+    if key in state.list_alerts():
         state.reset_alert(key)
         return [TextContent(type="text", text=f"`{key}` 쿨다운 리셋 완료")]
 


### PR DESCRIPTION
# feat: Phase D+E 통합 — Spring Batch 안전망 + MCP 서버 운영 자동화
 
---
 
## 개요
 
Phase D (Spring Batch 안전망)와 Phase E (MCP 서버 AI 자율 운영)를 통합한다.
100만 트래픽 정합성 검증(11차 테스트, DB COUNT 1,000,000 완벽)을 기반으로
장애 대응 자동화와 AI 운영 모니터링을 추가한다.
 
---
 
## Phase D — Spring Batch 안전망
 
### DLQ 재처리 (DlqReplayJob)
 
- DLQ 메시지를 REPLAY / SKIP / FINAL_FAIL 3가지 정책으로 분류한다.
- `DlqReplayPolicyService`가 분류 판단을 담당하고, `DlqReplayService`가 실행한다.
- dry_run 모드 지원으로 실제 재처리 전 영향 범위를 사전 확인할 수 있다.
- Kafka 재발행 성공/실패 이력을 `dlq_replay_execution_item` 테이블에 기록한다.
### 정합성 복구 (ConsistencyRecoveryJob)
 
- Redis 재고 vs DB INSERT 건수를 주기적으로 비교한다.
- 불일치 감지 시 복구 이력을 `consistency_recovery` 테이블에 기록한다.
### PENDING 재처리 (PendingRecoveryJob)
 
- 5분 초과 PENDING 상태 레코드를 자동으로 재처리한다.
### 스케줄
 
- 일일 집계: 매일 새벽 2시
- PENDING 복구: 5분 주기
- 메타 정리: 매주 일요일 새벽 3시
---
 
## Phase E — MCP 서버 AI 자율 운영
 
### 자동 감지 (30초 폴링)
 
- **P1**: 5xx 에러, Redis Queue 임계값 초과, 정합성 불일치
- **P2**: 앱 CPU, Kafka Lag, Consumer 지연, HikariCP pending
- **P3**: RDS CPU, Bridge 사이클 시간
### MCP 도구 7개 (Claude에서 직접 호출 가능)
 
| 도구 | 용도 |
|---|---|
| `query_prometheus` | PromQL instant 쿼리 — 현재 메트릭 값 확인 |
| `query_prometheus_range` | 특정 구간 메트릭 조회 (최솟값/최댓값/평균) |
| `get_test_report` | 테스트 구간 핵심 메트릭 요약 |
| `run_check` | P1/P2/P3 감지기 수동 즉시 실행 |
| `get_monitor_status` | cooldown 상태 조회 |
| `reset_cooldown` | cooldown 초기화 |
| `trigger_consistency_check` | 정합성 검사 즉시 실행 |
 
### 설계 원칙
 
- 모든 도구는 read-only로 설계한다. 탐지와 설명만 담당하고, 실행은 사람이 판단한다.
- `state.py` `check_and_record()`로 alert 쿨다운을 스레드 안전하게 관리한다.
- `config.py`에 임계값을 모아 운영 중 튜닝이 용이하다.
---
 
## 인프라
 
`infra/ec2.tf`에 terraform-mcp IAM 역할에 CloudWatch 읽기 권한을 추가했다.
 
- 추가 Action: `cloudwatch:GetMetricStatistics`, `cloudwatch:ListMetrics`
---
 
## DB 마이그레이션
 
| 파일 | 내용 |
|---|---|
| `V5__dlq_replay_schema.sql` | `dlq_message`, `dlq_replay_execution`, `dlq_replay_execution_item` |
| `V6__consistency_recovery_schema.sql` | `consistency_recovery_history` |
 
---
 
## 기타
 
- `.gitignore`: Python `__pycache__/`, `*.py[cod]` 추가
- Spring Boot 4 + Jackson 3 호환 (`tools.jackson` 패키지 유지)