### PR TITLE
fix:  초기화 레이스를 유발하던 redirect만 제거

### DIFF
--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
     logger.info("스케줄러 종료")
 
 
-app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan)
+app = FastAPI(title="MCP Monitor Server", routes=mcp_routes, lifespan=lifespan, redirect_slashes=False)
 
 
 @app.get("/health")

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -432,7 +432,7 @@ def _handle_trigger_consistency_check() -> list[TextContent]:
 # FastAPI 마운트용 SSE transport
 # ---------------------------------------------------------------------------
 
-sse = SseServerTransport("/mcp/messages/")
+sse = SseServerTransport("/mcp/messages")
 
 
 async def handle_sse(request):
@@ -443,5 +443,5 @@ async def handle_sse(request):
 
 mcp_routes = [
     Route("/mcp/sse", endpoint=handle_sse, methods=["GET"]),
-    Mount("/mcp/messages/", app=sse.handle_post_message),
+    Mount("/mcp/messages", app=sse.handle_post_message),
 ]

--- a/mcp-server/tools.py
+++ b/mcp-server/tools.py
@@ -432,7 +432,7 @@ def _handle_trigger_consistency_check() -> list[TextContent]:
 # FastAPI 마운트용 SSE transport
 # ---------------------------------------------------------------------------
 
-sse = SseServerTransport("/mcp/messages")
+sse = SseServerTransport("/mcp/messages/")
 
 
 async def handle_sse(request):
@@ -443,5 +443,5 @@ async def handle_sse(request):
 
 mcp_routes = [
     Route("/mcp/sse", endpoint=handle_sse, methods=["GET"]),
-    Mount("/mcp/messages", app=sse.handle_post_message),
+    Mount("/mcp/messages/", app=sse.handle_post_message),
 ]


### PR DESCRIPTION
## 개요

> 이 PR이 무엇을 하는지 한 줄로 설명해주세요.

## 변경 사항

- tools.py                                                                                                                                                                      
                                                                                                                                                                                  
  sse = SseServerTransport("/mcp/messages")                                                                                                                                       
  ...
  Mount("/mcp/messages", app=sse.handle_post_message)                                                                                                                             
                                                                                                                                                                                  
  - main.py                                                                                                                                                                       
                                                                                                                                                                                  
  app = FastAPI(                                                                                                                                                                  
      title="MCP Monitor Server",                                                                                                                                                 
      routes=mcp_routes,                                                                                                                                                          
      lifespan=lifespan,                                                                                                                                                          
      redirect_slashes=False                                                                                                                                                      
  )                                                                                                                                                                               
                                                                                                                                                                                  
  의도                                                                                                                                                            
                                                                                                                                                                                  
  - 경로는 원래대로 /mcp/messages                                                                                                                                                 
  - Mount는 유지                                                                                                                                                                  
  - 대신 FastAPI가 /mcp/messages → /mcp/messages/로 307 리다이렉트하는 걸 꺼서                                                                                                    
  - 초기화 레이스를 유발하던 redirect만 제거    

## 변경 유형

- [ ] `feat` — 새 기능
- [x] `fix` — 버그 수정
- [ ] `refactor` — 기능 변경 없는 코드 개선
- [ ] `chore` — 빌드, 설정, 의존성 등 기타
- [ ] `docs` — 문서
- [ ] `test` — 테스트
- [ ] `infra` — Terraform / AWS 인프라

## 관련 이슈

closes #

## 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향을 주는 변경이라면 영향 범위를 파악함
- [ ] Phase에 맞는 변경인지 확인 (Phase 1 / 2 / 3)
