### PR TITLE
fix: Redis Queue 원자화로 선착순 캠페인 데이터 유실 근본 해결

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,12 @@ stress-test/           ← k6 부하 테스트 스크립트
 ```
 POST /api/campaigns/{id}/participation
   1. RateLimitService     SET NX EX 10
-  2. Redis Lua            SISMEMBER + DECR + GET total (check-decr-total.lua)
-     remaining < 0  → 보상 INCR + 400
-     remaining == 0 → DB CLOSED + active flag DEL
-  3. sequence = total - remaining (선착순 확정)
-  4. RedisQueueService    LPUSH queue:campaign:{id}  (MAX_QUEUE_SIZE=1M)
-  5. 202 반환 (DB 미접촉)
+  2. Redis Lua            큐 만원 체크 + DECR + LPUSH + GET total (check-decr-enqueue.lua) — 단일 원자 실행
+     queue full(-998) → 재고 차감 없이 429 반환
+     remaining < 0   → 400 반환
+     remaining == 0  → DB CLOSED + active flag DEL
+  3. sequence = total - remaining (Lua 내부에서 계산 후 message에 포함)
+  4. 202 반환 (DB 미접촉)
 
 ParticipationBridge (@Scheduled 100ms)
   → SMEMBERS active:campaigns → RPOP → Kafka publish (userId 파티션 키)
@@ -65,6 +65,7 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | 9차 | **ASG 2대**, 50만 | ~2,014/s | 앱 CPU 80% (인스턴스당) |
 | 10차 | **writeResultCache 제거 + 배치 INSERT**, 100만 | ~2,613/s | Queue 500K 상한 도달 → 데이터 유실 |
 | **11차** | **MAX_QUEUE_SIZE 1M**, 100만 | **~2,442/s** | **정합성 1,000,000 완벽 ✅** |
+| **12차** | **ASG 3대 사전 스케일아웃**, 재고 130만/요청 150만 | **~2,507/s** | Queue 1M 초과 → **141,062건 유실** 🔴 |
 
 ### 11차 테스트 상세 (100만, 최종 성공) ✅
 - 조건: TOTAL_REQUESTS=1,200,000, 재고=1,000,000, MAX_VUS=2,000
@@ -75,9 +76,23 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 - Kafka lag 거의 0 (rebalancing 순간 700 스파이크 → 즉시 해소) ✅
 - HikariCP pending 거의 0 ✅ / RDS CPU 최대 47% ✅
 
+### 12차 테스트 상세 (130만 재고, 구조적 결함 발견) 🔴
+- 조건: TOTAL_REQUESTS=1,500,000, 재고=1,300,000, MAX_VUS=2,000, ASG 3대
+- TPS ~2,507/s / avg 1.19s / p95 4.13s / 5xx: 0 ✅
+- DB COUNT = **1,158,938** (141,062건 유실) 🔴
+- Redis Queue 1M 상한 도달 → LPUSH 실패해도 202 반환 → 유실 (복구 불가)
+- 근본 원인: 재고 차감(DECR)과 큐 적재(LPUSH)가 비원자적 → partial failure
+- MCP 서버 실시간 GC 이상/Kafka lag 탐지 검증 ✅
+
 ### 10차 → 11차 개선 포인트
 - 10차: writeResultCache(CME pipeline) 제거 → Kafka lag 9K→거의 0, TPS 2,613/s 달성했으나 Queue 500K 상한으로 **데이터 425K 유실**
 - 11차: MAX_QUEUE_SIZE 1M으로 상향 → Queue 700K까지만 차서 유실 0건
+
+### 12차 발견 이슈 → fix/redis-queue-atomic-enqueue 브랜치 ✅ 구현 완료
+- check-decr-total.lua + push-queue.lua → check-decr-enqueue.lua 단일 원자 스크립트로 통합
+- 큐 만원 시 DECR 자체를 수행하지 않음 → partial failure 원천 차단
+- queue key 해시태그 추가 (`queue:campaign:{id}`) → ElastiCache CME 슬롯 제약 해결
+- Redis 왕복 2회 → 1회로 감소 (성능 개선 부수효과)
 
 ---
 
@@ -93,7 +108,8 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
 | #7 ASG 수평 확장 | ✅ 완료 (2026-04-27, ASG 2대 운영 중) |
 | Spring Batch PENDING 재처리 | 미작성 |
 | 모니터링 #22~#25 | ✅ 완료 (Grafana 13패널, 커스텀 메트릭 4종) |
-| Phase E MCP 서버 (#62~#66) | ✅ 코드 완료 — terraform-mcp 수동 배포 필요 |
+| Phase E MCP 서버 (#62~#66) | ✅ 배포 완료 — 12차 테스트 실시간 운영 검증 ✅ |
+| Redis Queue 원자화 (#XX) | ✅ 완료 (fix/redis-queue-atomic-enqueue, 빌드 검증 완료) |
 
 ---
 
@@ -110,11 +126,15 @@ Kafka Consumer (concurrency=10, 파티션 10개, RF=3, min.ISR=2)
        - terraform-mcp t3.large (k6 OOM 방지)
 [예정] Phase C — API 엔드포인트 v3 정리
 [예정] Phase D — Spring Batch 안전망
-[진행중] Phase E — MCP 서버 (AI 자율 운영)
-       - 코드 완료 (feat/mcp-server 브랜치)
-       - terraform apply -target=aws_iam_role_policy.terraform_mcp_cloudwatch_read 필요
-       - terraform-mcp EC2에서 수동 docker build & run으로 배포
-       - CI/CD 파이프라인 미구성 (mcp-server/** 트리거 없음, 수동 배포)
+[완료] Phase E — MCP 서버 (AI 자율 운영)
+       - terraform-mcp 배포 완료, Claude Desktop MCP 연결 (mcp-remote@latest)
+       - 12차 테스트 중 실시간 GC 이상/Kafka lag 탐지 검증 ✅
+       - CI/CD 파이프라인 미구성 (mcp-server/** 트리거 없음, 수동 배포 유지)
+[완료] fix/redis-queue-atomic-enqueue
+       - check-decr-enqueue.lua 단일 Lua 원자화 (DECR + LPUSH)
+       - 큐 만원 시 DECR 수행 안 함 → partial failure 원천 차단
+       - queue key 해시태그 통일 → ElastiCache CME 슬롯 제약 해결
+       - Redis 왕복 2회 → 1회 (성능 개선 부수효과)
 ```
 
 ---
@@ -281,6 +301,8 @@ MCP 도구 7개 (Claude에서 호출 가능):
 **Consumer 병목 개선**: "Kafka batch listener로 받아도 DB INSERT가 1건씩이면 소용없다는 걸 로그로 확인 후, JdbcTemplate.batchUpdate + rewriteBatchedStatements=true로 DB 왕복 N→1로 줄임. Consumer 지연 200ms → 7.5ms"
 
 **데이터 유실 발견 및 해결**: "10차 테스트에서 DB 정합성 검증 중 574,888건만 INSERT된 것 발견. Redis Queue 500K 상한 초과 시 LPUSH 실패해도 202 반환하는 구조적 문제. MAX_QUEUE_SIZE 1M으로 상향해 11차에서 정합성 완벽 달성"
+
+**구조적 결함 발견 및 해결 (12차)**: "재고 차감(DECR)과 큐 적재(LPUSH)가 비원자적이라 큐 만원 시 partial failure 발생. 재고는 차감됐는데 큐 적재 실패 → 사용자는 202 받았지만 DB에 없음 → PENDING/DLQ 기록도 없어 복구 불가. check-decr-enqueue.lua 단일 Lua로 통합해 원자화. 큐 만원 시 DECR 자체를 수행하지 않아 재고 보전 + Redis 왕복 2회 → 1회 감소"
 
 **모니터링**: "Prometheus + Grafana 커스텀 메트릭 4종(Bridge 드레인 속도/사이클, Consumer 지연, Redis Queue 적재량). Docker monitoring 네트워크로 컨테이너 이름 기반 DNS — IP 관리 불필요"
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/exception/business/QueueFullException.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/exception/business/QueueFullException.java
@@ -1,0 +1,11 @@
+package io.eventdriven.campaign.api.exception.business;
+
+import io.eventdriven.campaign.api.exception.common.BusinessException;
+import io.eventdriven.campaign.api.exception.common.ErrorCode;
+
+public class QueueFullException extends BusinessException {
+    public QueueFullException(Long campaignId) {
+        super(ErrorCode.QUEUE_FULL,
+                String.format("처리 큐 만원. campaignId=%d", campaignId));
+    }
+}

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/api/exception/common/ErrorCode.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/api/exception/common/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "PARTICIPATION_003", "중복 요청입니다. 잠시 후 다시 시도해주세요."),
     STOCK_EXHAUSTED(HttpStatus.BAD_REQUEST, "PARTICIPATION_004", "재고가 소진되었습니다."),
     PARTICIPATION_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "PARTICIPATION_005", "일시적으로 참여 처리에 실패했습니다."),
+    QUEUE_FULL(HttpStatus.TOO_MANY_REQUESTS, "PARTICIPATION_006", "처리 큐가 가득 찼습니다. 잠시 후 다시 시도해주세요."),
 
 
     // 배치 관련

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ParticipationBridge {
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
-    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";
     private static final String IMMEDIATE_SEND_FAILED = "IMMEDIATE_SEND_FAILED";
     private static final String ASYNC_SEND_FAILED = "ASYNC_SEND_FAILED";
 
@@ -80,7 +80,7 @@ public class ParticipationBridge {
     }
 
     private void drainCampaignQueue(Long campaignId) {
-        String queueKey = QUEUE_KEY_PREFIX + campaignId;
+        String queueKey = QUEUE_KEY_PREFIX + campaignId + "}";
         Long queueSize = redisTemplate.opsForList().size(queueKey);
         int dynamicBatchSize = resolveBatchSize(queueSize);
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/bridge/ParticipationBridge.java
@@ -27,6 +27,7 @@ public class ParticipationBridge {
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";
+    private static final String LEGACY_QUEUE_KEY_PREFIX = "queue:campaign:"; // 롤링 배포 전환 기간 fallback
     private static final String IMMEDIATE_SEND_FAILED = "IMMEDIATE_SEND_FAILED";
     private static final String ASYNC_SEND_FAILED = "ASYNC_SEND_FAILED";
 
@@ -94,6 +95,14 @@ public class ParticipationBridge {
                 break;
             }
             publishAsync(campaignId, message);
+        }
+
+        // 롤링 배포 전환 기간: 구 키(해시태그 없음)에 고립된 메시지 드레인
+        String legacyKey = LEGACY_QUEUE_KEY_PREFIX + campaignId;
+        String legacyMessage;
+        while ((legacyMessage = redisTemplate.opsForList().rightPop(legacyKey)) != null) {
+            log.info("Legacy queue key drained. campaignId={}", campaignId);
+            publishAsync(campaignId, legacyMessage);
         }
     }
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/scheduler/QueueMetricsScheduler.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/scheduler/QueueMetricsScheduler.java
@@ -34,7 +34,7 @@ public class QueueMetricsScheduler {
     private final MeterRegistry meterRegistry;
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";
-    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";
 
     // campaignId별 현재 Queue 크기 저장소
     // Gauge는 이 Map의 값을 주기적으로 읽어서 Prometheus에 노출
@@ -57,7 +57,7 @@ public class QueueMetricsScheduler {
         for (String campaignIdStr : campaignIds) {
             try {
                 Long campaignId = Long.parseLong(campaignIdStr);
-                String queueKey = QUEUE_KEY_PREFIX + campaignId;
+                String queueKey = QUEUE_KEY_PREFIX + campaignId + "}";
 
                 Long size = redisTemplate.opsForList().size(queueKey);
                 long queueSize = size != null ? size : 0L;

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package io.eventdriven.campaign.application.service;
 
+import io.eventdriven.campaign.api.exception.business.QueueFullException;
 import io.eventdriven.campaign.api.exception.business.RateLimitExceededException;
 import io.eventdriven.campaign.api.exception.business.StockExhaustedException;
 import io.eventdriven.campaign.domain.entity.CampaignStatus;
@@ -7,10 +8,6 @@ import io.eventdriven.campaign.domain.repository.CampaignRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import tools.jackson.databind.json.JsonMapper;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -18,22 +15,23 @@ import java.util.Map;
 public class ParticipationService {
     private final CampaignRepository campaignRepository;
     private final RateLimitService rateLimitService;
-    private final RedisQueueService redisQueueService;
     private final RedisStockService redisStockService;
-    private final JsonMapper jsonMapper;
 
     public void participate(Long campaignId, Long userId) {
         if (!rateLimitService.isAllowed(campaignId, userId)) {
             throw new RateLimitExceededException(campaignId, userId);
         }
 
-        // SISMEMBER + DECR + GET total 원자 실행 — 비활성/소진 요청은 DB 미접촉
-        long[] stockResult = redisStockService.checkDecrTotal(campaignId);
-        long remaining = stockResult[0];
-        long total     = stockResult[1];
+        // 재고 차감 + 큐 적재 단일 Lua 원자 실행 — partial failure 원천 차단
+        long[] result = redisStockService.checkDecrEnqueue(campaignId, userId);
+        long remaining = result[0];
+        long total     = result[1];
 
         if (remaining == RedisStockService.INACTIVE_CAMPAIGN) {
             throw new StockExhaustedException(campaignId);
+        }
+        if (remaining == RedisStockService.QUEUE_FULL) {
+            throw new QueueFullException(campaignId);
         }
         if (remaining < 0) {
             throw new StockExhaustedException(campaignId);
@@ -44,34 +42,8 @@ public class ParticipationService {
             log.info("캠페인 자동 종료. campaignId={}", campaignId);
         }
 
-        // sequence 확정 — Redis DECR 결과로 선착순 번호 원자적 결정
         long sequence = total - remaining;
-
-        // DB INSERT 없음 — Consumer가 sequence 기반으로 직접 INSERT SUCCESS 처리
-        long t0 = System.currentTimeMillis();
-        String message = buildMessage(campaignId, userId, sequence);
-        boolean pushed = redisQueueService.push(campaignId, message);
-        long redisPushMs = System.currentTimeMillis() - t0;
-
-        log.info("[TIMING] campaignId={} userId={} sequence={} REDIS_PUSH={}ms",
-                campaignId, userId, sequence, redisPushMs);
-
-        if (!pushed) {
-            log.warn("Redis Queue 적재 실패. campaignId={}, userId={}, sequence={}",
-                    campaignId, userId, sequence);
-        }
-    }
-
-    private String buildMessage(Long campaignId, Long userId, Long sequence) {
-        try {
-            Map<String, Object> msg = new HashMap<>();
-            msg.put("campaignId", campaignId);
-            msg.put("userId", userId);
-            msg.put("sequence", sequence);
-            return jsonMapper.writeValueAsString(msg);
-        } catch (Exception e) {
-            log.error("메시지 직렬화 실패. campaignId={}, userId={}, sequence={}", campaignId, userId, sequence, e);
-            throw new RuntimeException("메시지 직렬화 실패", e);
-        }
+        log.info("[ATOMIC] campaignId={} userId={} sequence={} remaining={}",
+                campaignId, userId, sequence, remaining);
     }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
@@ -31,6 +31,7 @@ public class ParticipationService {
             throw new StockExhaustedException(campaignId);
         }
         if (remaining == RedisStockService.QUEUE_FULL) {
+            rateLimitService.release(campaignId, userId);
             throw new QueueFullException(campaignId);
         }
         if (remaining < 0) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RateLimitService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RateLimitService.java
@@ -45,4 +45,11 @@ public class RateLimitService {
         // true 통과 / false는 차단
         return Boolean.TRUE.equals(result);   // null일 경우 false 반환
     }
+
+    // QUEUE_FULL 등 재시도 가능한 일시적 오류 시 rate limit 키 반환
+    // 사용자가 10초 대기 없이 즉시 재시도할 수 있도록 허용
+    public void release(Long campaignId, Long userId) {
+        String key = KEY_PREFIX + campaignId + ":user:" + userId;
+        redisTemplate.delete(key);
+    }
 }

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisQueueService.java
@@ -3,10 +3,7 @@ package io.eventdriven.campaign.application.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -14,51 +11,19 @@ import java.util.Collections;
 public class RedisQueueService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String QUEUE_KEY_PREFIX = "queue:campaign:";
-    private static final long MAX_QUEUE_SIZE = 1_000_000;
-    private final DefaultRedisScript<Long> pushQueueScript;
-
-
-
-
-
-    /**
-     *  historyId = PK
-     *  Consumer가 historyId로 조회:
-     *
-     *   SELECT * FROM participation_history WHERE id = 101868
-     *   -- PK 조회라 인덱스 타서 O(1)
-     *
-     SELECT * FROM participation_history
-     WHERE campaign_id = 1 AND user_id = 42
-     -- 인덱스 없으면 풀스캔
-
-     * @param campaignId
-     * @return
-     */
-    public boolean push(Long campaignId, String message) {
-        String key = QUEUE_KEY_PREFIX + campaignId;
-        Long result = redisTemplate.execute(
-                pushQueueScript,
-                Collections.singletonList(key),  // 루아는 키 값을 반드시 배열(리스트) 형태로 받음
-                String.valueOf(MAX_QUEUE_SIZE), //가변인자도 스프링이 자동으로 배열로 만들어 전달.
-                message
-        );
-        return Long.valueOf(1).equals(result);
-    }
-
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";
 
 
 
     public Long size(Long campaignId){
-        String key = QUEUE_KEY_PREFIX + campaignId;
+        String key = QUEUE_KEY_PREFIX + campaignId + "}";
         return redisTemplate.opsForList().size(key);
     }
 
 
 
     public String pop(Long campaignId) {
-        String key = QUEUE_KEY_PREFIX + campaignId;
+        String key = QUEUE_KEY_PREFIX + campaignId + "}";
         return redisTemplate.opsForList().rightPop(key);
     }
 

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
@@ -16,13 +16,16 @@ import java.util.List;
 public class RedisStockService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final DefaultRedisScript<List> checkDecrTotalScript;
+    private final DefaultRedisScript<List> checkDecrEnqueueScript;
 
     private static final String ACTIVE_CAMPAIGNS_KEY = "active:campaigns";          // Bridge SMEMBERS 순회용 전역 Set (Lua 밖에서만 사용)
     private static final String ACTIVE_FLAG_KEY_PREFIX = "active:campaign:{";        // Lua용 캠페인별 플래그 (해시태그로 stock/total과 동일 슬롯)
     private static final String STOCK_KEY_PREFIX = "stock:campaign:{";               // 해시태그 포함 — Redis Cluster 슬롯 통일
     private static final String TOTAL_KEY_PREFIX = "total:campaign:{";               // 해시태그 포함 — Redis Cluster 슬롯 통일
+    private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";               // 해시태그 포함 — Lua 원자화 필수 조건
+    private static final long MAX_QUEUE_SIZE = 1_000_000;
     public static final Long INACTIVE_CAMPAIGN = -999L;
+    public static final Long QUEUE_FULL = -998L;
 
 
     /**
@@ -66,18 +69,23 @@ public class RedisStockService {
     }
 
     /**
-     * EXISTS + DECR + DEL(remaining==0) + GET total 원자 실행 (Lua)
+     * EXISTS + 큐 만원 체크 + DECR + LPUSH + GET total 원자 실행 (Lua)
      * returns long[]{remaining, total}
      * remaining == INACTIVE_CAMPAIGN(-999): 비활성 캠페인
+     * remaining == QUEUE_FULL(-998): 큐 만원 (재고 차감 안 됨)
+     * remaining < 0: 재고 소진 (초과 요청, 재고 차감 됨)
      */
     @SuppressWarnings("unchecked")
-    public long[] checkDecrTotal(Long campaignId) {
+    public long[] checkDecrEnqueue(Long campaignId, Long userId) {
         List<Long> result = (List<Long>) redisTemplate.execute(
-            checkDecrTotalScript,
-            List.of(getActiveFlagKey(campaignId), getStockKey(campaignId), getTotalKey(campaignId))
+            checkDecrEnqueueScript,
+            List.of(getActiveFlagKey(campaignId), getStockKey(campaignId), getTotalKey(campaignId), getQueueKey(campaignId)),
+            String.valueOf(MAX_QUEUE_SIZE),
+            String.valueOf(campaignId),
+            String.valueOf(userId)
         );
         if (result == null || result.size() < 2) {
-            throw new IllegalStateException("checkDecrTotal 스크립트 오류. campaignId=" + campaignId);
+            throw new IllegalStateException("checkDecrEnqueue 스크립트 오류. campaignId=" + campaignId);
         }
         return new long[]{result.get(0), result.get(1)};
     }
@@ -110,6 +118,10 @@ public class RedisStockService {
         deleteStock(campaignId);
         deleteTotal(campaignId);
         deactivateCampaign(campaignId);
+    }
+
+    private String getQueueKey(Long campaignId) {
+        return QUEUE_KEY_PREFIX + campaignId + "}";
     }
 
     private String getTotalKey(Long campaignId) {

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/config/RedisConfig.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/config/RedisConfig.java
@@ -16,19 +16,11 @@ import java.util.List;
 public class RedisConfig {
 
 
-    @Bean
-    public DefaultRedisScript<Long> pushQueueScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setLocation(new ClassPathResource("scripts/push-queue.lua"));
-        script.setResultType(Long.class);
-        return script;
-    }
-
     @SuppressWarnings("rawtypes")
     @Bean
-    public DefaultRedisScript<List> checkDecrTotalScript() {
+    public DefaultRedisScript<List> checkDecrEnqueueScript() {
         DefaultRedisScript<List> script = new DefaultRedisScript<>();
-        script.setLocation(new ClassPathResource("scripts/check-decr-total.lua"));
+        script.setLocation(new ClassPathResource("scripts/check-decr-enqueue.lua"));
         script.setResultType(List.class);
         return script;
     }

--- a/app/campaign-core/src/main/resources/scripts/check-decr-enqueue.lua
+++ b/app/campaign-core/src/main/resources/scripts/check-decr-enqueue.lua
@@ -1,0 +1,26 @@
+-- KEYS[1] = active:campaign:{campaignId}   (캠페인별 active 플래그)
+-- KEYS[2] = stock:campaign:{campaignId}    (재고)
+-- KEYS[3] = total:campaign:{campaignId}    (전체 재고 — sequence 계산용)
+-- KEYS[4] = queue:campaign:{campaignId}    (Redis Queue)
+-- ARGV[1] = maxQueueSize
+-- ARGV[2] = campaignId
+-- ARGV[3] = userId
+-- 모든 KEYS는 {campaignId} 해시태그로 동일 슬롯 보장 (ElastiCache CME 필수 조건)
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return {-999, 0}
+end
+if tonumber(redis.call('LLEN', KEYS[4])) >= tonumber(ARGV[1]) then
+    return {-998, 0}
+end
+local remaining = redis.call('DECR', KEYS[2])
+if remaining < 0 then
+    return {remaining, 0}
+end
+if remaining == 0 then
+    redis.call('DEL', KEYS[1])
+end
+local total = tonumber(redis.call('GET', KEYS[3])) or 0
+local sequence = total - remaining
+local message = '{"campaignId":' .. ARGV[2] .. ',"userId":' .. ARGV[3] .. ',"sequence":' .. sequence .. '}'
+redis.call('LPUSH', KEYS[4], message)
+return {remaining, total}


### PR DESCRIPTION
# fix: Redis Queue 원자화로 선착순 캠페인 데이터 유실 근본 해결
 
---
 
## 배경
 
12차 부하 테스트(재고 1,300,000 / 요청 1,500,000)에서 DB COUNT = 1,158,938로
141,062건 유실이 발생했다. 원인은 재고 차감(DECR)과 큐 적재(LPUSH)가
분리된 Redis 호출로 이루어져 큐 만원 시 partial failure가 발생하는
구조적 결함이었다.
 
---
 
## 변경 내용
 
### 핵심: check-decr-enqueue.lua 단일 원자 스크립트
 
기존 `check-decr-total.lua` + `push-queue.lua` 두 스크립트를 하나로 통합했다.
DECR과 LPUSH가 단일 Lua 스크립트 안에서 실행되므로 Redis 단일 스레드 보장에 의해
두 연산은 항상 함께 성공하거나 함께 실패한다.
큐 만원 시 DECR 자체를 수행하지 않아 재고를 보전하고 429를 반환한다.
queue key에 해시태그를 추가하여 ElastiCache CME 슬롯 제약을 해결했다.
 
### 코드 리뷰 반영
 
- `QueueMetricsScheduler` queue key 해시태그 누락 수정 (모니터링 blind 방지)
- `ParticipationBridge` 롤링 배포 전환 기간 구 키 fallback 드레인 추가
- `QUEUE_FULL` 시 rate limit 키 즉시 반환하여 사용자 즉시 재시도 허용
---
 
## 기대 효과
 
| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 큐 만원 시 | DECR 성공 + LPUSH 실패 → 유실 | DECR 없이 429 → 재고 보전 |
| Redis 왕복 | 2회 | 1회 |
| CME 슬롯 | queue key 슬롯 불일치 가능 | 해시태그 통일 |
| 모니터링 | 키 포맷 불일치로 blind | 정상 수집 |
| 롤링 배포 | 구 키 메시지 고립 | fallback 드레인 |
| QUEUE_FULL 재시도 | 10초 차단 | 즉시 재시도 가능 |
 
---
 
## 관련 PR
 
- fix/redis-queue-atomic-enqueue → develop: #75