### PR TITLE
fix: Redis Lua로 동일 userId 중복 참여 원천 차단

### DIFF
--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package io.eventdriven.campaign.application.service;
 
+import io.eventdriven.campaign.api.exception.business.DuplicateParticipationException;
 import io.eventdriven.campaign.api.exception.business.QueueFullException;
 import io.eventdriven.campaign.api.exception.business.RateLimitExceededException;
 import io.eventdriven.campaign.api.exception.business.StockExhaustedException;
@@ -29,6 +30,9 @@ public class ParticipationService {
 
         if (remaining == RedisStockService.INACTIVE_CAMPAIGN) {
             throw new StockExhaustedException(campaignId);
+        }
+        if (remaining == RedisStockService.ALREADY_PARTICIPATED) {
+            throw new DuplicateParticipationException(campaignId, userId);
         }
         if (remaining == RedisStockService.QUEUE_FULL) {
             rateLimitService.release(campaignId, userId);

--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/service/RedisStockService.java
@@ -23,9 +23,11 @@ public class RedisStockService {
     private static final String STOCK_KEY_PREFIX = "stock:campaign:{";               // 해시태그 포함 — Redis Cluster 슬롯 통일
     private static final String TOTAL_KEY_PREFIX = "total:campaign:{";               // 해시태그 포함 — Redis Cluster 슬롯 통일
     private static final String QUEUE_KEY_PREFIX = "queue:campaign:{";               // 해시태그 포함 — Lua 원자화 필수 조건
+    private static final String PARTICIPATED_KEY_PREFIX = "participated:campaign:{"; // 해시태그 포함 — 중복 참여 방지
     private static final long MAX_QUEUE_SIZE = 1_500_000;
     public static final Long INACTIVE_CAMPAIGN = -999L;
     public static final Long QUEUE_FULL = -998L;
+    public static final Long ALREADY_PARTICIPATED = -997L;
 
 
     /**
@@ -79,7 +81,7 @@ public class RedisStockService {
     public long[] checkDecrEnqueue(Long campaignId, Long userId) {
         List<Long> result = (List<Long>) redisTemplate.execute(
             checkDecrEnqueueScript,
-            List.of(getActiveFlagKey(campaignId), getStockKey(campaignId), getTotalKey(campaignId), getQueueKey(campaignId)),
+            List.of(getActiveFlagKey(campaignId), getStockKey(campaignId), getTotalKey(campaignId), getQueueKey(campaignId), getParticipatedKey(campaignId, userId)),
             String.valueOf(MAX_QUEUE_SIZE),
             String.valueOf(campaignId),
             String.valueOf(userId)
@@ -122,6 +124,10 @@ public class RedisStockService {
 
     private String getQueueKey(Long campaignId) {
         return QUEUE_KEY_PREFIX + campaignId + "}";
+    }
+
+    private String getParticipatedKey(Long campaignId, Long userId) {
+        return PARTICIPATED_KEY_PREFIX + campaignId + "}:user:" + userId;
     }
 
     private String getTotalKey(Long campaignId) {

--- a/app/campaign-core/src/main/resources/scripts/check-decr-enqueue.lua
+++ b/app/campaign-core/src/main/resources/scripts/check-decr-enqueue.lua
@@ -2,12 +2,16 @@
 -- KEYS[2] = stock:campaign:{campaignId}    (재고)
 -- KEYS[3] = total:campaign:{campaignId}    (전체 재고 — sequence 계산용)
 -- KEYS[4] = queue:campaign:{campaignId}    (Redis Queue)
+-- KEYS[5] = participated:campaign:{campaignId}:user:{userId}  (중복 참여 방지)
 -- ARGV[1] = maxQueueSize
 -- ARGV[2] = campaignId
 -- ARGV[3] = userId
 -- 모든 KEYS는 {campaignId} 해시태그로 동일 슬롯 보장 (ElastiCache CME 필수 조건)
 if redis.call('EXISTS', KEYS[1]) == 0 then
     return {-999, 0}
+end
+if redis.call('EXISTS', KEYS[5]) == 1 then
+    return {-997, 0}
 end
 if tonumber(redis.call('LLEN', KEYS[4])) >= tonumber(ARGV[1]) then
     return {-998, 0}
@@ -23,4 +27,5 @@ local total = tonumber(redis.call('GET', KEYS[3])) or 0
 local sequence = total - remaining
 local message = '{"campaignId":' .. ARGV[2] .. ',"userId":' .. ARGV[3] .. ',"sequence":' .. sequence .. '}'
 redis.call('LPUSH', KEYS[4], message)
+redis.call('SET', KEYS[5], '1')
 return {remaining, total}


### PR DESCRIPTION
# fix: Redis Lua로 동일 userId 중복 참여 원천 차단
 
---
 
## 문제
 
`RateLimitService`는 10초 TTL로 연타를 막지만, TTL 만료 후 동일 userId가
같은 캠페인에 재요청하면 Redis stock이 추가 차감된다.
DB 단의 `UNIQUE(campaign_id, user_id)` 제약으로 INSERT는 1건만 성공하지만,
재고는 이미 2번 차감된 상태가 되어 다른 사용자가 받아야 할 선착순 기회가 소멸된다.
 
---
 
## 원인
 
`check-decr-enqueue.lua`가 중복 참여 여부를 체크하지 않고 DECR을 먼저 실행한다.
 
---
 
## 해결
 
Lua 원자 스크립트에 `participated:campaign:{campaignId}:user:{userId}` 영구 이력 키를 추가했다.
DECR 이전에 EXISTS 체크를 수행하여 이미 참여한 경우 `-997`을 반환한다 (재고 차감 없음).
LPUSH 성공 후 `SET '1'`으로 이력을 기록한다.
 
---
 
## 변경 파일
 
| 파일 | 변경 내용 |
|---|---|
| `check-decr-enqueue.lua` | `KEYS[5]` EXISTS 체크 (`-997` 반환), LPUSH 후 `SET '1'` |
| `RedisStockService.java` | `PARTICIPATED_KEY_PREFIX`, `ALREADY_PARTICIPATED(-997L)`, `getParticipatedKey()` 추가 |
| `ParticipationService.java` | `ALREADY_PARTICIPATED` 처리 → `DuplicateParticipationException` (409 Conflict) |
 
---
 
## 검증
 
- `./gradlew compileJava` BUILD SUCCESSFUL ✅
- 해시태그 `{campaignId}` 동일 슬롯 유지 → ElastiCache CME 제약 충족 ✅
- `RateLimitService` 로직 무변경 (연타 방지 10초 TTL 유지) ✅