### PR TITLE
fix: RDS 다운 시 Kafka offset commit 보류로 메시지 영구 소실 방지

### DIFF
--- a/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
+++ b/app/campaign-core/src/main/java/io/eventdriven/campaign/application/consumer/ParticipationEventConsumer.java
@@ -49,6 +49,7 @@ public class ParticipationEventConsumer {
 
         LocalDateTime batchStart = LocalDateTime.now();
         List<ParticipationEvent> successEvents = new ArrayList<>();
+        boolean hasTransientFailure = false;
 
         try {
             List<Object[]> batchArgs = new ArrayList<>(events.size());
@@ -77,8 +78,9 @@ public class ParticipationEventConsumer {
                             event.getCampaignId(), event.getUserId(), event.getSequence());
                     successEvents.add(event);
                 } catch (Exception e) {
-                    log.error("Insert failed. campaignId={}, userId={}, sequence={}",
+                    log.error("Insert failed (transient). campaignId={}, userId={}, sequence={}",
                             event.getCampaignId(), event.getUserId(), event.getSequence(), e);
+                    hasTransientFailure = true;
                     sendToDlqWithSlack(
                             String.valueOf(event.getUserId()),
                             serializeEvent(event),
@@ -96,12 +98,16 @@ public class ParticipationEventConsumer {
                 .register(meterRegistry)
                 .record(latencyMs, TimeUnit.MILLISECONDS);
 
-        log.info("Consumer batch processed. polled={}, parsed={}, success={}, latencyMs={}",
-                records.size(), events.size(), successEvents.size(), latencyMs);
+        log.info("Consumer batch processed. polled={}, parsed={}, success={}, transientFailure={}, latencyMs={}",
+                records.size(), events.size(), successEvents.size(), hasTransientFailure, latencyMs);
 
-
-        // ⑤ Kafka 오프셋 커밋
-        acknowledgment.acknowledge();
+        // ⑤ Kafka 오프셋 커밋 — transient failure(RDS 다운 등) 시 ack 보류 → Kafka 자동 재전달
+        if (!hasTransientFailure) {
+            acknowledgment.acknowledge();
+        } else {
+            log.warn("Skipping ack due to transient DB failure. Kafka will redeliver after recovery. count={}",
+                    events.size() - successEvents.size());
+        }
     }
 
     private List<ParticipationEvent> parseRecords(List<ConsumerRecord<String, String>> records) {


### PR DESCRIPTION
# fix: RDS 다운 시 Kafka offset commit 보류로 메시지 영구 소실 방지
 
---
 
## 배경
 
T06 장애 테스트(RDS 다운 → 재처리 → 정합성 복구) 준비 중
완전 다운 시 데이터가 복구 불가능하게 소실되는 구조적 결함을 발견했다.
 
---
 
## 문제 상세
 
### 기존 흐름 (RDS 다운 시)
 
```
Kafka → Consumer: 메시지 100건 수신
  → jdbcTemplate.batchUpdate() 실패 (RDS 연결 불가)
  → row-by-row 폴백도 전부 실패
  → sendToDlqWithSlack() 호출
      → dlqMessageService.saveDlqMessage() 실패 (RDS 다운이라 DB 저장 불가)
      → publishDlqEvent() → Kafka DLQ 토픽에는 발행 성공
      → Slack 알림 전송 성공
  → acknowledgment.acknowledge() 무조건 호출  ← 핵심 문제
  → Kafka offset commit 완료
  → RDS 복구 후에도 해당 메시지 재전달 없음
  → 100건 영구 소실, 복구 불가
```
 
Kafka DLQ 토픽에는 쌓이지만 `dlq_message_record` DB 저장도 실패하기 때문에
`DlqReplayJob`으로도 재처리 불가한 상태였다.
 
---
 
## 해결
 
INSERT 실패를 두 종류로 구분한다.
 
| 실패 유형 | 원인 | 처리 |
|---|---|---|
| `DataIntegrityViolationException` | 중복 키 (이미 처리됨) | 성공으로 간주, ack |
| 그 외 Exception | DB 연결 실패 등 일시적 장애 | `hasTransientFailure=true`, ack 보류 |
 
### 변경 후 흐름 (RDS 다운 시)
 
```
Kafka → Consumer: 메시지 100건 수신
  → INSERT 전부 실패
  → hasTransientFailure = true
  → Slack P1 알림 전송 (기존과 동일)
  → acknowledge() 호출 안 함  ← 핵심 변경
  → Kafka offset 유지 (commit 안 됨)
 
RDS 복구
  → Kafka가 미commit offset부터 메시지 자동 재전달
  → INSERT IGNORE로 멱등성 보장 (중복 처리 안전)
  → acknowledge() 정상 호출
  → DB COUNT 정합성 복구
```
 
Kafka 브로커의 메시지는 retention 기간(기본 7일) 동안 보존되므로
ack 안 하면 offset이 유지되어 복구 후 자동 재처리 대상이 된다.
 
---
 
## 테스트 계획
 
- [ ] RDS 중지 → VUS=500 부하 → Slack P1 알림 수신 확인
- [ ] Grafana Kafka lag 패널: lag 증가 및 유지 확인 (ack 보류 증거)
- [ ] RDS 재시작 → lag 해소 → DB COUNT 정합성 확인
- [ ] 정상 상황에서 `DataIntegrityViolationException`(중복)은 여전히 ack 정상 동작 확인
 